### PR TITLE
Upload queue improvements: Realm creation, sorting, and network

### DIFF
--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -31,6 +31,8 @@ class UploadQueueViewController: UIViewController {
     private var uploadingFiles = [UploadFile]()
     private var progressForFileId = [String: CGFloat]()
 
+    private let realm = DriveFileManager.constants.uploadsRealm
+
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(cellView: UploadTableViewCell.self)
@@ -63,7 +65,7 @@ class UploadQueueViewController: UIViewController {
     }
 
     func reloadData(reloadTableView: Bool = true) {
-        let newUploadingFiles = Array(UploadQueue.instance.getUploadingFiles(withParent: currentDirectory.id).freeze())
+        let newUploadingFiles = Array(UploadQueue.instance.getUploadingFiles(withParent: currentDirectory.id, using: realm).freeze())
         newUploadingFiles.first?.isFirstInCollection = true
         newUploadingFiles.last?.isLastInCollection = true
 

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -83,14 +83,16 @@ class UploadTableViewCell: InsetTableViewCell {
         }
 
         cardContentView.cancelButtonPressedHandler = {
-            if let file = DriveFileManager.constants.uploadsRealm.object(ofType: UploadFile.self, forPrimaryKey: uploadFile.id) {
-                UploadQueue.instance.cancel(file)
+            let realm = DriveFileManager.constants.uploadsRealm
+            if let file = realm.object(ofType: UploadFile.self, forPrimaryKey: uploadFile.id) {
+                UploadQueue.instance.cancel(file, using: realm)
             }
         }
         cardContentView.retryButtonPressedHandler = {
             self.cardContentView.retryButton?.isHidden = true
-            if let file = DriveFileManager.constants.uploadsRealm.object(ofType: UploadFile.self, forPrimaryKey: uploadFile.id) {
-                UploadQueue.instance.retry(file)
+            let realm = DriveFileManager.constants.uploadsRealm
+            if let file = realm.object(ofType: UploadFile.self, forPrimaryKey: uploadFile.id) {
+                UploadQueue.instance.retry(file, using: realm)
             }
         }
     }

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -54,8 +54,7 @@ public class UploadQueue {
 
     /// Should suspend operation queue based on network status
     private var shouldSuspendQueue: Bool {
-        let status = ReachabilityListener.instance.currentStatus
-        return status == .offline || (status != .wifi && UserDefaults.isWifiOnlyMode())
+        return ReachabilityListener.instance.currentStatus == .offline
     }
 
     /// Should suspend operation queue based on explicit `suspendAllOperations()` call

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -125,7 +125,7 @@ public class UploadQueue {
     public func getUploadingFiles(withParent parentId: Int, using realm: Realm = DriveFileManager.constants.uploadsRealm) -> Results<UploadFile> {
         let driveId = AccountManager.instance.currentDriveFileManager.drive.id
         let userId = AccountManager.instance.currentAccount.user.id
-        return realm.objects(UploadFile.self).filter(NSPredicate(format: "uploadDate = nil AND parentDirectoryId = %d AND userId = %d AND driveId = %d", parentId, userId, driveId))
+        return realm.objects(UploadFile.self).filter(NSPredicate(format: "uploadDate = nil AND parentDirectoryId = %d AND userId = %d AND driveId = %d", parentId, userId, driveId)).sorted(byKeyPath: "taskCreationDate")
     }
 
     public func suspendAllOperations() {


### PR DESCRIPTION
- Upload queue view controller improvements:
    - Prevent creating a new Realm each time in upload queue view controller
    - Sort files
- Check network status for resuming or suspending upload queue