### PR TITLE
[T989] Hide "see folder" action if not available

### DIFF
--- a/kDrive/UI/Controller/Files/FileQuickActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileQuickActionsFloatingPanelViewController.swift
@@ -190,7 +190,7 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
             case .manageDropbox:
                 return file.visibility == .isCollaborativeFolder
             case .seeFolder:
-                return !normalFolderHierarchy
+                return !normalFolderHierarchy && (file.parent != nil || file.parentId != 0)
             case .offline:
                 return !sharedWithMe
             case .move:


### PR DESCRIPTION
Hide "see folder" action if no parent's file is available