### PR TITLE
Fix freeze file activities

### DIFF
--- a/kDrive/UI/Controller/MainTabViewController.swift
+++ b/kDrive/UI/Controller/MainTabViewController.swift
@@ -227,8 +227,10 @@ extension MainTabViewController: SwitchAccountDelegate, SwitchDriveDelegate {
     func didSwitchDriveFileManager(newDriveFileManager: DriveFileManager) {
         driveFileManager = newDriveFileManager
         //Tell Files app that the drive changed
-        NSFileProviderManager.default.signalEnumerator(for: .workingSet) { (_) in }
-        NSFileProviderManager.default.signalEnumerator(for: .rootContainer) { (_) in }
+        DriveInfosManager.instance.getFileProviderManager(for: driveFileManager.drive) { manager in
+            manager.signalEnumerator(for: .workingSet) { (_) in }
+            manager.signalEnumerator(for: .rootContainer) { (_) in }
+        }
         for viewController in viewControllers ?? [] {
             if viewController.isViewLoaded {
                 ((viewController as? UINavigationController)?.viewControllers.first as? SwitchDriveDelegate)?.didSwitchDriveFileManager(newDriveFileManager: driveFileManager)

--- a/kDrive/UI/Controller/Menu/Trash/TrashCollectionViewController.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashCollectionViewController.swift
@@ -245,7 +245,7 @@ class TrashCollectionViewController: FileListCollectionViewController {
             for file in files {
                 group.enter()
                 self.driveFileManager.apiFetcher.deleteFileDefinitely(file: file) { (response, error) in
-                    file.signalChanges()
+                    file.signalChanges(userId: self.driveFileManager.drive.userId)
                     if let error = error {
                         success = false
                         DDLogError("Error while deleting file: \(error)")
@@ -324,7 +324,7 @@ extension TrashCollectionViewController: TrashOptionsDelegate {
                 group.enter()
                 driveFileManager.apiFetcher.restoreTrashedFile(file: file) { [self] (response, error) in
                     // TODO: Find parent to signal changes
-                    file.signalChanges()
+                    file.signalChanges(userId: self.driveFileManager.drive.userId)
                     if error == nil {
                         getNewChildren(deletedChild: file)
                         UIConstants.showSnackBar(message: KDriveStrings.Localizable.trashedFileRestoreFileToOriginalPlaceSuccess(file.name))
@@ -351,7 +351,7 @@ extension TrashCollectionViewController: SelectFolderDelegate {
         for file in currentTrashedFiles ?? [] {
             group.enter()
             driveFileManager.apiFetcher.restoreTrashedFile(file: file, in: folder.id) { [self] (response, error) in
-                folder.signalChanges()
+                folder.signalChanges(userId: self.driveFileManager.drive.userId)
                 if error == nil {
                     getNewChildren(deletedChild: file)
                     UIConstants.showSnackBar(message: KDriveStrings.Localizable.trashedFileRestoreFileInSuccess(file.name, folder.name), view: self.view)

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -719,10 +719,10 @@ public class DriveFileManager {
 
                         realm.add(renamedFile, update: .modified)
                         if !file.children.contains(renamedFile) {
-                            file.children.append(renamedFile.freeze())
+                            file.children.append(renamedFile)
                         }
                         renamedFile.applyLastModifiedDateToLocalFile()
-                        updatedFiles.append(File(value: renamedFile))
+                        updatedFiles.append(renamedFile)
                         pagedActions[fileId] = .fileUpdate
                     }
                 case .fileFavoriteCreate:
@@ -734,7 +734,7 @@ public class DriveFileManager {
                 case .fileFavoriteRemove:
                     if let file = realm.object(ofType: File.self, forPrimaryKey: fileId) {
                         file.isFavorite = false
-                        updatedFiles.append(file.freeze())
+                        updatedFiles.append(file)
                         pagedActions[fileId] = .fileUpdate
                     }
                 case .fileMoveIn, .fileRestore, .fileCreate:
@@ -758,7 +758,7 @@ public class DriveFileManager {
                     if let newFile = activity.file {
                         keepCacheAttributesForFile(newFile: newFile, keepStandard: true, keepExtras: true, keepRights: false, using: realm)
                         realm.add(newFile, update: .modified)
-                        updatedFiles.append(File(value: newFile))
+                        updatedFiles.append(newFile)
                         pagedActions[fileId] = .fileUpdate
                     }
                 default:
@@ -768,7 +768,7 @@ public class DriveFileManager {
         }
         file.responseAt = timestamp
         try? realm.commitWrite()
-        return (inserted: insertedFiles.map { $0.freeze() }, updated: updatedFiles, deleted: deletedFiles)
+        return (inserted: insertedFiles.map { $0.freeze() }, updated: updatedFiles.map({ $0.freeze() }), deleted: deletedFiles)
     }
 
     public func getWorkingSet() -> [File] {

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -808,7 +808,7 @@ public class DriveFileManager {
         let fileId = file.id
         apiFetcher.deleteFile(file: file) { (response, error) in
             if error == nil {
-                file.signalChanges()
+                file.signalChanges(userId: self.drive.userId)
                 self.backgroundQueue.async { [self] in
                     let localRealm = getRealm()
                     removeFileInDatabase(fileId: fileId, cascade: false, withTransaction: true, using: localRealm)
@@ -841,10 +841,10 @@ public class DriveFileManager {
                         newParent.children.append(file)
                     }
                     if let oldParent = oldParent {
-                        oldParent.signalChanges()
+                        oldParent.signalChanges(userId: self.drive.userId)
                         self.notifyObserversWith(file: oldParent)
                     }
-                    newParent.signalChanges()
+                    newParent.signalChanges(userId: self.drive.userId)
                     self.notifyObserversWith(file: newParent)
                     completion(response?.data, file, error)
                 } else {
@@ -865,7 +865,7 @@ public class DriveFileManager {
                 do {
                     updatedFile.isAvailableOffline = file.isAvailableOffline
                     let updatedFile = try self.updateFileInDatabase(updatedFile: updatedFile, oldFile: file, using: realm)
-                    updatedFile.signalChanges()
+                    updatedFile.signalChanges(userId: drive.userId)
                     self.notifyObserversWith(file: updatedFile)
                     completion(updatedFile, nil)
                 } catch {
@@ -889,9 +889,9 @@ public class DriveFileManager {
                         parent?.children.append(duplicateFile)
                     }
 
-                    duplicateFile.signalChanges()
+                    duplicateFile.signalChanges(userId: self.drive.userId)
                     if let parent = file.parent {
-                        parent.signalChanges()
+                        parent.signalChanges(userId: self.drive.userId)
                         self.notifyObserversWith(file: parent)
                     }
                     completion(duplicateFile, nil)
@@ -917,7 +917,7 @@ public class DriveFileManager {
                         parent?.children.append(createdDirectory)
                     }
                     if let parent = createdDirectory.parent {
-                        parent.signalChanges()
+                        parent.signalChanges(userId: self.drive.userId)
                         self.notifyObserversWith(file: parent)
                     }
                     completion(createdDirectory, error)
@@ -936,7 +936,7 @@ public class DriveFileManager {
                 do {
                     let createdDirectory = try self.updateFileInDatabase(updatedFile: createdDirectory)
                     if let parent = createdDirectory.parent {
-                        parent.signalChanges()
+                        parent.signalChanges(userId: self.drive.userId)
                         self.notifyObserversWith(file: parent)
                     }
                     completion(createdDirectory, error)
@@ -972,7 +972,7 @@ public class DriveFileManager {
                                 parent?.children.append(createdDirectory)
                             }
                             if let parent = createdDirectory.parent {
-                                parent.signalChanges()
+                                parent.signalChanges(userId: self.drive.userId)
                                 self.notifyObserversWith(file: parent)
                             }
                             completion(createdDirectory, dropbox, error)
@@ -999,10 +999,10 @@ public class DriveFileManager {
                 try? realm.write {
                     parent?.children.append(createdFile)
                 }
-                createdFile.signalChanges()
+                createdFile.signalChanges(userId: self.drive.userId)
 
                 if let parent = createdFile.parent {
-                    parent.signalChanges()
+                    parent.signalChanges(userId: self.drive.userId)
                     self.notifyObserversWith(file: parent)
                 }
 

--- a/kDriveCore/Data/DownloadQueue/DownloadOperation.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadOperation.swift
@@ -127,7 +127,9 @@ public class DownloadOperation: Operation {
                         DownloadQueue.instance.publishProgress(newValue, for: fileId)
                     })
                     if let itemIdentifier = itemIdentifier {
-                        NSFileProviderManager.default.register(task!, forItemWithIdentifier: itemIdentifier) { _ in }
+                        DriveInfosManager.instance.getFileProviderManager(for: driveFileManager.drive) { manager in
+                            manager.register(task!, forItemWithIdentifier: itemIdentifier) { _ in }
+                        }
                     }
                     task?.resume()
                 } else {

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -368,8 +368,7 @@ public class File: Object, Codable {
     }
 
     /// Signal changes on this file to the File Provider Extension
-    public func signalChanges() {
-        NSFileProviderManager.default.signalEnumerator(for: .workingSet) { _ in }
+    public func signalChanges(userId: Int) {
         let identifier: NSFileProviderItemIdentifier
         if isDirectory {
             identifier = id == DriveFileManager.constants.rootID ? .rootContainer : NSFileProviderItemIdentifier("\(id)")
@@ -378,7 +377,10 @@ public class File: Object, Codable {
         } else {
             identifier = .rootContainer
         }
-        NSFileProviderManager.default.signalEnumerator(for: identifier) { _ in }
+        DriveInfosManager.instance.getFileProviderManager(driveId: driveId, userId: userId) { manager in
+            manager.signalEnumerator(for: .workingSet) { _ in }
+            manager.signalEnumerator(for: identifier) { _ in }
+        }
     }
 
     required public init(from decoder: Decoder) throws {

--- a/kDriveFileProvider/FileProviderExtension+Actions.swift
+++ b/kDriveFileProvider/FileProviderExtension+Actions.swift
@@ -56,8 +56,8 @@ extension FileProviderExtension {
             if let file = response?.data {
                 self.driveFileManager.apiFetcher.deleteFileDefinitely(file: file) { (response, error) in
                     FileProviderExtensionState.shared.workingSet.removeValue(forKey: itemIdentifier)
-                    NSFileProviderManager.default.signalEnumerator(for: .workingSet) { _ in }
-                    NSFileProviderManager.default.signalEnumerator(for: itemIdentifier) { _ in }
+                    self.manager.signalEnumerator(for: .workingSet) { _ in }
+                    self.manager.signalEnumerator(for: itemIdentifier) { _ in }
                     completionHandler(error)
                 }
             } else {
@@ -103,7 +103,7 @@ extension FileProviderExtension {
 
         backgroundUploadItem(importedItem)
 
-        NSFileProviderManager.default.signalEnumerator(for: parentItemIdentifier) { _ in }
+        manager.signalEnumerator(for: parentItemIdentifier) { _ in }
         completionHandler(importedItem, nil)
     }
 
@@ -111,7 +111,7 @@ extension FileProviderExtension {
         // Doc says we should do network request after renaming local file but we could end up with model desync
         if let item = FileProviderExtensionState.shared.importedDocuments[itemIdentifier] {
             item.filename = itemName
-            NSFileProviderManager.default.signalEnumerator(for: item.parentItemIdentifier) { _ in }
+            manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }
             completionHandler(item, nil)
             return
         }
@@ -144,7 +144,7 @@ extension FileProviderExtension {
     override func reparentItem(withIdentifier itemIdentifier: NSFileProviderItemIdentifier, toParentItemWithIdentifier parentItemIdentifier: NSFileProviderItemIdentifier, newName: String?, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
         if let item = FileProviderExtensionState.shared.importedDocuments[itemIdentifier] {
             item.parentItemIdentifier = parentItemIdentifier
-            NSFileProviderManager.default.signalEnumerator(for: item.parentItemIdentifier) { _ in }
+            manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }
             completionHandler(item, nil)
             return
         }
@@ -230,8 +230,8 @@ extension FileProviderExtension {
                         item.parentItemIdentifier = parentItemIdentifier
                         item.isTrashed = false
                         FileProviderExtensionState.shared.workingSet.removeValue(forKey: itemIdentifier)
-                        NSFileProviderManager.default.signalEnumerator(for: .workingSet) { _ in }
-                        NSFileProviderManager.default.signalEnumerator(for: parentItemIdentifier) { _ in }
+                        self.manager.signalEnumerator(for: .workingSet) { _ in }
+                        self.manager.signalEnumerator(for: parentItemIdentifier) { _ in }
                         if let error = error {
                             completionHandler(nil, error)
                         } else {
@@ -244,8 +244,8 @@ extension FileProviderExtension {
                         let item = FileProviderItem(file: file, domain: self.domain)
                         item.isTrashed = false
                         FileProviderExtensionState.shared.workingSet.removeValue(forKey: itemIdentifier)
-                        NSFileProviderManager.default.signalEnumerator(for: .workingSet) { _ in }
-                        NSFileProviderManager.default.signalEnumerator(for: item.parentItemIdentifier) { _ in }
+                        self.manager.signalEnumerator(for: .workingSet) { _ in }
+                        self.manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }
                         if let error = error {
                             completionHandler(nil, error)
                         } else {

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -140,7 +140,8 @@ class FileProviderExtension: NSFileProviderExtension {
     }
 
     override func startProvidingItem(at url: URL, completionHandler: @escaping (Error?) -> Void) {
-        guard let fileId = FileProviderItem.identifier(for: url, domain: domain)?.toFileId() else {
+        guard let fileId = FileProviderItem.identifier(for: url, domain: domain)?.toFileId(),
+            let file = driveFileManager.getCachedFile(id: fileId) else {
             if FileManager.default.fileExists(atPath: url.path) {
                 completionHandler(nil)
             } else {
@@ -149,26 +150,24 @@ class FileProviderExtension: NSFileProviderExtension {
             return
         }
 
-        if let file = driveFileManager.getCachedFile(id: fileId) {
-            let item = FileProviderItem(file: file, domain: domain)
+        let item = FileProviderItem(file: file, domain: domain)
 
-            if !FileManager.default.fileExists(atPath: item.storageUrl.path) {
-                //File is not in the file provider we have to download/copy it
-                downloadRemoteFile(file: file, for: item, completion: completionHandler)
-            } else if fileStorageIsCurrent(item: item, file: file) {
-                //File is in the file provider and is the same, nothing to do...
-                manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }
-                completionHandler(nil)
-            } else {
-                //File from file provider has changes not synced with cloud, we have to upload the local file
-                if !FileManager.default.contentsEqual(atPath: item.storageUrl.path, andPath: file.localUrl.path) {
-                    //This is not optimal because we wait for the item to be uploaded before downloading the remote
-                    backgroundUploadItem(item) {
-                        self.downloadRemoteFile(file: file, for: item, completion: completionHandler)
-                    }
-                } else {
-                    downloadRemoteFile(file: file, for: item, completion: completionHandler)
+        if !FileManager.default.fileExists(atPath: item.storageUrl.path) {
+            // File is not in the file provider we have to download/copy it
+            downloadRemoteFile(file: file, for: item, completion: completionHandler)
+        } else if fileStorageIsCurrent(item: item, file: file) {
+            // File is in the file provider and is the same, nothing to do...
+            manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }
+            completionHandler(nil)
+        } else {
+            // File from file provider has changes not synced with cloud, we have to upload the local file
+            if !FileManager.default.contentsEqual(atPath: item.storageUrl.path, andPath: file.localUrl.path) {
+                // This is not optimal because we wait for the item to be uploaded before downloading the remote
+                backgroundUploadItem(item) {
+                    self.downloadRemoteFile(file: file, for: item, completion: completionHandler)
                 }
+            } else {
+                downloadRemoteFile(file: file, for: item, completion: completionHandler)
             }
         }
     }
@@ -185,6 +184,11 @@ class FileProviderExtension: NSFileProviderExtension {
 
     private func downloadRemoteFile(file: File, for item: FileProviderItem, completion: @escaping (Error?) -> ()) {
         if file.isLocalVersionOlderThanRemote() {
+            // Prevent observing file multiple times
+            guard DownloadQueue.instance.operationsInQueue[file.id] == nil else {
+                completion(nil)
+                return
+            }
             DownloadQueue.instance.observeFileDownloaded(self, fileId: file.id) { (fileId, error) in
                 if error != nil {
                     self.manager.signalEnumerator(for: item.parentItemIdentifier) { _ in }

--- a/kDriveFileProvider/FileProviderItem.swift
+++ b/kDriveFileProvider/FileProviderItem.swift
@@ -78,7 +78,8 @@ class FileProviderItem: NSObject, NSFileProviderItem {
         self.itemIdentifier = NSFileProviderItemIdentifier(file.id)
         self.filename = file.name
         self.typeIdentifier = file.typeIdentifier.identifier
-        if let rights = file.rights?.freeze() {
+        if let rights = file.rights {
+            let rights = rights.realm == nil ? rights : rights.freeze()
             self.capabilities = FileProviderItem.rightsToCapabilities(rights)
         } else {
             self.capabilities = [.allowsContentEnumerating, .allowsReading]

--- a/kDriveFileProvider/FileProviderItem.swift
+++ b/kDriveFileProvider/FileProviderItem.swift
@@ -190,7 +190,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     class func identifier(for itemURL: URL, domain: NSFileProviderDomain?) -> NSFileProviderItemIdentifier? {
         let rootStorageURL: URL
         if let domain = domain {
-            rootStorageURL = NSFileProviderManager.default.documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true)
+            rootStorageURL = NSFileProviderManager(for: domain)!.documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true)
         } else {
             rootStorageURL = NSFileProviderManager.default.documentStorageURL
         }
@@ -204,7 +204,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     class func createStorageUrl(identifier: NSFileProviderItemIdentifier, filename: String, domain: NSFileProviderDomain?) -> URL {
         let rootStorageURL: URL
         if let domain = domain {
-            rootStorageURL = NSFileProviderManager.default.documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true)
+            rootStorageURL = NSFileProviderManager(for: domain)!.documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true)
         } else {
             rootStorageURL = NSFileProviderManager.default.documentStorageURL
         }


### PR DESCRIPTION
Fixes for #72 

- [x] Realm accessed from wrong thread
- [x] startProvidingItem called twice