### PR TITLE
Fix disabled files in File Provider

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -187,7 +187,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate, U
                     try FileManager.default.removeItem(atPath: importPath.path)
                 }
                 try FileManager.default.moveItem(at: url, to: importPath)
-                let saveNavigationViewController = SaveFileViewController.instantiateInNavigationController(driveFileManager: currentDriveFileManager, file: .init(name: filename, path: importPath, uti: importPath.typeIdentifier ?? .data))
+                let saveNavigationViewController = SaveFileViewController.instantiateInNavigationController(driveFileManager: currentDriveFileManager, file: .init(name: filename, path: importPath, uti: importPath.uti ?? .data))
                 window?.rootViewController?.present(saveNavigationViewController, animated: true)
                 return true
             } catch {
@@ -260,7 +260,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate, U
                     self.window?.rootViewController?.present(floatingPanelViewController, animated: true)
                 }
             }
-             if UserDefaults.shared.numberOfConnections == 10 {
+            if UserDefaults.shared.numberOfConnections == 10 {
                 if #available(iOS 14.0, *) {
                     if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
                         SKStoreReviewController.requestReview(in: scene)
@@ -500,8 +500,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate, U
                     navController.popToRootViewController(animated: false)
                     // Present folder (if it's not root)
                     if let parentId = parentId, parentId > DriveFileManager.constants.rootID,
-                       let driveFileManager = accountManager.currentDriveFileManager,
-                       let directory = driveFileManager.getCachedFile(id: parentId) {
+                        let driveFileManager = accountManager.currentDriveFileManager,
+                        let directory = driveFileManager.getCachedFile(id: parentId) {
                         let filesList = FileListViewController.instantiate(driveFileManager: driveFileManager)
                         filesList.currentDirectory = directory
                         navController.pushViewController(filesList, animated: false)

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -277,8 +277,12 @@ public class File: Object, Codable {
         return URL(string: ApiRoutes.showOffice(file: self))
     }
 
-    public var typeIdentifier: UTI {
-        localUrl.typeIdentifier ?? convertedType.uti
+    public var typeIdentifier: String {
+        localUrl.typeIdentifier ?? convertedType.uti.identifier
+    }
+
+    public var uti: UTI {
+        localUrl.uti ?? convertedType.uti
     }
 
     public func applyLastModifiedDateToLocalFile() {

--- a/kDriveCore/Data/Models/UploadFile.swift
+++ b/kDriveCore/Data/Models/UploadFile.swift
@@ -164,7 +164,7 @@ public class UploadFile: Object {
                 }
             }
         } else {
-            let uti = pathURL?.typeIdentifier ?? .data
+            let uti = pathURL?.uti ?? .data
             placeholder(ConvertedType.fromUTI(uti).icon)
         }
     }

--- a/kDriveCore/Utils/URL+Extension.swift
+++ b/kDriveCore/Utils/URL+Extension.swift
@@ -23,7 +23,12 @@ extension URL {
         if hasDirectoryPath {
             return UTI.folder.identifier
         }
-        return try? resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier
+        if FileManager.default.fileExists(atPath: path) {
+            return try? resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier
+        } else {
+            // If the file is not downloaded, we get the type identifier using its extension
+            return UTI(filenameExtension: pathExtension, conformingTo: .item)?.identifier
+        }
     }
 
     public var uti: UTI? {

--- a/kDriveCore/Utils/URL+Extension.swift
+++ b/kDriveCore/Utils/URL+Extension.swift
@@ -19,19 +19,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Foundation
 
 extension URL {
-    public var typeIdentifier: UTI? {
+    public var typeIdentifier: String? {
         if hasDirectoryPath {
-            return .folder
+            return UTI.folder.identifier
         }
-        if let uti = try? resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier {
-            return UTI(uti)
+        return try? resourceValues(forKeys: [.typeIdentifierKey]).typeIdentifier
+    }
+
+    public var uti: UTI? {
+        if let typeIdentifier = typeIdentifier {
+            return UTI(typeIdentifier)
         }
-        /*if #available(iOS 14.0, *) {
-            let identifier = UTType(filenameExtension: pathExtension, conformingTo: .item)?.identifier
-            return identifier
-        } else {*/
-        return UTI(filenameExtension: pathExtension, conformingTo: .item)
-        // }
+        return nil
     }
 
     public var creationDate: Date? {

--- a/kDriveFileProvider/FileProviderItem.swift
+++ b/kDriveFileProvider/FileProviderItem.swift
@@ -76,7 +76,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
     init(file: File, domain: NSFileProviderDomain?) {
         self.itemIdentifier = NSFileProviderItemIdentifier(file.id)
         self.filename = file.name
-        self.typeIdentifier = file.typeIdentifier.identifier
+        self.typeIdentifier = file.typeIdentifier
         if let rights = file.rights {
             let rights = rights.realm == nil ? rights : rights.freeze()
             self.capabilities = FileProviderItem.rightsToCapabilities(rights)
@@ -120,7 +120,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
         let resourceValues = try? importedFileUrl.resourceValues(forKeys: [.fileSizeKey, .creationDateKey, .contentModificationDateKey, .totalFileSizeKey])
         self.itemIdentifier = identifier
         self.filename = importedFileUrl.lastPathComponent
-        self.typeIdentifier = (importedFileUrl.typeIdentifier ?? .item).identifier
+        self.typeIdentifier = importedFileUrl.typeIdentifier ?? UTI.item.identifier
         self.capabilities = .allowsAll
         self.parentItemIdentifier = parentIdentifier
         if let totalSize = resourceValues?.totalFileSize {

--- a/kDriveFileProvider/FileProviderItem.swift
+++ b/kDriveFileProvider/FileProviderItem.swift
@@ -99,7 +99,7 @@ class FileProviderItem: NSObject, NSFileProviderItem {
             self.isDownloaded = false
         } else {
             self.isDownloading = false
-            self.isDownloaded = FileManager.default.fileExists(atPath: storageUrl.path)
+            self.isDownloaded = file.isDownloaded
         }
         if file.visibility == .isShared {
             self.isShared = true


### PR DESCRIPTION
Using the `UTI` struct could result in an incorrect type identifier for the File Provider Item. Fixes #81.