### PR TITLE
Fix share extension

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -452,10 +452,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate, U
     }
 
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+        DDLogInfo("[Background Session] background session relaunched \(identifier)")
         if identifier == DownloadQueue.backgroundIdentifier {
             BackgroundDownloadSessionManager.instance.backgroundCompletionHandler = completionHandler
-        } else if identifier == UploadQueue.backgroundIdentifier {
-            BackgroundUploadSessionManager.instance.backgroundCompletionHandler = completionHandler
+        } else if identifier.hasSuffix(UploadQueue.backgroundBaseIdentifier) {
+            BackgroundUploadSessionManager.instance.handleEventsForBackgroundURLSession(identifier: identifier, completionHandler: completionHandler)
         } else {
             completionHandler()
         }

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -16,12 +16,11 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import UIKit
 import InfomaniakCore
 import kDriveCore
+import UIKit
 
 class UploadTableViewCell: InsetTableViewCell {
-
     // This view is reused if FileListCollectionView header
     @IBOutlet weak var cardContentView: UploadCardView!
     private var currentFileId: String!
@@ -47,10 +46,11 @@ class UploadTableViewCell: InsetTableViewCell {
     }
 
     private func setStatusFor(uploadFile: UploadFile) {
-        cardContentView.retryButton?.isHidden = uploadFile.error == nil
-        if let error = uploadFile.error {
+        if let error = uploadFile.error, error != .taskRescheduled {
+            cardContentView.retryButton?.isHidden = false
             cardContentView.detailsLabel.text = KDriveStrings.Localizable.errorUpload + " (\(error.localizedDescription))"
         } else {
+            cardContentView.retryButton?.isHidden = true
             var status = KDriveStrings.Localizable.uploadInProgressPending
             if ReachabilityListener.instance.currentStatus == .offline {
                 status = KDriveStrings.Localizable.uploadNetworkErrorDescription

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -32,7 +32,7 @@ public class DriveFileManager {
         public let cacheDirectoryURL: URL
         public let openInPlaceDirectoryURL: URL?
         public let rootID = 1
-        public let currentUploadDbVersion: UInt64 = 6
+        public let currentUploadDbVersion: UInt64 = 7
         public lazy var migrationBlock = { [weak self] (migration: Migration, oldSchemaVersion: UInt64) in
             guard let strongSelf = self else { return }
             if oldSchemaVersion < strongSelf.currentUploadDbVersion {
@@ -42,7 +42,7 @@ public class DriveFileManager {
                         newObject!["maxRetryCount"] = 3
                     }
                 }
-                // Migration to version 4 & 5 is not needed
+                // Migration to version 4 -> 7 is not needed
             }
         }
 

--- a/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
+++ b/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
@@ -58,7 +58,7 @@ public final class BackgroundDownloadSessionManager: NSObject, BackgroundSession
             let realm = DriveFileManager.constants.uploadsRealm
             for task in uploadTasks {
                 if let sessionUrl = task.originalRequest?.url?.absoluteString,
-                   let fileId = realm.objects(DownloadTask.self).filter(NSPredicate(format: "AND sessionUrl = %@", sessionUrl)).first?.fileId {
+                   let fileId = realm.objects(DownloadTask.self).filter(NSPredicate(format: "sessionUrl = %@", sessionUrl)).first?.fileId {
                     self.progressObservers[self.backgroundSession.identifierFor(task: task)] = task.progress.observe(\.fractionCompleted, options: .new) { [fileId = fileId] _, value in
                         guard let newValue = value.newValue else {
                             return

--- a/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
+++ b/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
@@ -18,13 +18,16 @@
 
 import Foundation
 
-public protocol FileDownloadSession {
+public protocol FileDownloadSession: BackgroundSession {
     func downloadTask(with request: URLRequest, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> URLSessionDownloadTask
 }
 
-extension URLSession: FileDownloadSession { }
+extension URLSession: FileDownloadSession {}
 
 public final class BackgroundDownloadSessionManager: NSObject, BackgroundSessionManager, URLSessionDownloadDelegate, FileDownloadSession {
+    public var identifier: String {
+        return backgroundSession.identifier
+    }
 
     public typealias Task = URLSessionDownloadTask
     public typealias CompletionHandler = (URL?, URLResponse?, Error?) -> Void
@@ -37,11 +40,11 @@ public final class BackgroundDownloadSessionManager: NSObject, BackgroundSession
     static let maxBackgroundTasks = 10
 
     var backgroundSession: URLSession!
-    var tasksCompletionHandler: [Int: CompletionHandler] = [:]
-    var progressObservers: [Int: NSKeyValueObservation] = [:]
+    var tasksCompletionHandler: [String: CompletionHandler] = [:]
+    var progressObservers: [String: NSKeyValueObservation] = [:]
     var operations = [Operation]()
 
-    private override init() {
+    override private init() {
         super.init()
         let backgroundUrlSessionConfiguration = URLSessionConfiguration.background(withIdentifier: DownloadQueue.backgroundIdentifier)
         backgroundUrlSessionConfiguration.sessionSendsLaunchEvents = true
@@ -55,8 +58,8 @@ public final class BackgroundDownloadSessionManager: NSObject, BackgroundSession
             let realm = DriveFileManager.constants.uploadsRealm
             for task in uploadTasks {
                 if let sessionUrl = task.originalRequest?.url?.absoluteString,
-                    let fileId = realm.objects(DownloadTask.self).filter(NSPredicate(format: "AND sessionUrl = %@", sessionUrl)).first?.fileId {
-                    self.progressObservers[task.taskIdentifier] = task.progress.observe(\.fractionCompleted, options: .new) { [fileId = fileId] _, value in
+                   let fileId = realm.objects(DownloadTask.self).filter(NSPredicate(format: "AND sessionUrl = %@", sessionUrl)).first?.fileId {
+                    self.progressObservers[self.backgroundSession.identifierFor(task: task)] = task.progress.observe(\.fractionCompleted, options: .new) { [fileId = fileId] _, value in
                         guard let newValue = value.newValue else {
                             return
                         }
@@ -69,39 +72,42 @@ public final class BackgroundDownloadSessionManager: NSObject, BackgroundSession
 
     public func downloadTask(with request: URLRequest, completionHandler: @escaping CompletionHandler) -> Task {
         let task = backgroundSession.downloadTask(with: request)
-        tasksCompletionHandler[task.taskIdentifier] = completionHandler
+        tasksCompletionHandler[backgroundSession.identifierFor(task: task)] = completionHandler
         return task
     }
 
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let taskIdentifier = session.identifierFor(task: task)
         // Unsuccessful completion
         if let task = task as? URLSessionDownloadTask {
-            getCompletionHandler(for: task)?(nil, task.response, error)
+            getCompletionHandler(for: task, session: session)?(nil, task.response, error)
         }
-        progressObservers[task.taskIdentifier]?.invalidate()
-        progressObservers[task.taskIdentifier] = nil
-        tasksCompletionHandler[task.taskIdentifier] = nil
+        progressObservers[taskIdentifier]?.invalidate()
+        progressObservers[taskIdentifier] = nil
+        tasksCompletionHandler[taskIdentifier] = nil
     }
 
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         // Successful completion
-        getCompletionHandler(for: downloadTask)?(location, downloadTask.response, nil)
-        progressObservers[downloadTask.taskIdentifier]?.invalidate()
-        progressObservers[downloadTask.taskIdentifier] = nil
-        tasksCompletionHandler[downloadTask.taskIdentifier] = nil
+        let taskIdentifier = session.identifierFor(task: downloadTask)
+        getCompletionHandler(for: downloadTask, session: session)?(location, downloadTask.response, nil)
+        progressObservers[taskIdentifier]?.invalidate()
+        progressObservers[taskIdentifier] = nil
+        tasksCompletionHandler[taskIdentifier] = nil
     }
 
-    func getCompletionHandler(for task: Task) -> CompletionHandler? {
-        if let completionHandler = tasksCompletionHandler[task.taskIdentifier] {
+    func getCompletionHandler(for task: Task, session: URLSession) -> CompletionHandler? {
+        let taskIdentifier = session.identifierFor(task: task)
+        if let completionHandler = tasksCompletionHandler[taskIdentifier] {
             return completionHandler
         } else if let sessionUrl = task.originalRequest?.url?.absoluteString,
-            let downloadTask = DriveFileManager.constants.uploadsRealm.objects(DownloadTask.self)
-            .filter(NSPredicate(format: "sessionUrl = %@", sessionUrl)).first,
-            let drive = AccountManager.instance.getDrive(for: downloadTask.userId, driveId: downloadTask.driveId),
-            let driveFileManager = AccountManager.instance.getDriveFileManager(for: drive),
-            let file = driveFileManager.getCachedFile(id: downloadTask.fileId) {
+                  let downloadTask = DriveFileManager.constants.uploadsRealm.objects(DownloadTask.self)
+                  .filter(NSPredicate(format: "sessionUrl = %@", sessionUrl)).first,
+                  let drive = AccountManager.instance.getDrive(for: downloadTask.userId, driveId: downloadTask.driveId),
+                  let driveFileManager = AccountManager.instance.getDriveFileManager(for: drive),
+                  let file = driveFileManager.getCachedFile(id: downloadTask.fileId) {
             let operation = DownloadOperation(file: file, driveFileManager: driveFileManager, task: task, urlSession: self)
-            tasksCompletionHandler[task.taskIdentifier] = operation.downloadCompletion
+            tasksCompletionHandler[taskIdentifier] = operation.downloadCompletion
             operations.append(operation)
             return operation.downloadCompletion
         } else {

--- a/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
+++ b/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
@@ -103,8 +103,7 @@ public final class BackgroundDownloadSessionManager: NSObject, BackgroundSession
         } else if let sessionUrl = task.originalRequest?.url?.absoluteString,
                   let downloadTask = DriveFileManager.constants.uploadsRealm.objects(DownloadTask.self)
                   .filter(NSPredicate(format: "sessionUrl = %@", sessionUrl)).first,
-                  let drive = AccountManager.instance.getDrive(for: downloadTask.userId, driveId: downloadTask.driveId),
-                  let driveFileManager = AccountManager.instance.getDriveFileManager(for: drive),
+                  let driveFileManager = AccountManager.instance.getDriveFileManager(for: downloadTask.driveId, userId: downloadTask.userId),
                   let file = driveFileManager.getCachedFile(id: downloadTask.fileId) {
             let operation = DownloadOperation(file: file, driveFileManager: driveFileManager, task: task, urlSession: self)
             tasksCompletionHandler[taskIdentifier] = operation.downloadCompletion

--- a/kDriveCore/Data/Models/UploadFile.swift
+++ b/kDriveCore/Data/Models/UploadFile.swift
@@ -33,6 +33,7 @@ public class UploadFile: Object {
     @objc public dynamic var id: String = ""
     @objc public dynamic var name: String = ""
     @objc dynamic var relativePath: String = ""
+    @objc dynamic var sessionId: String?
     @objc dynamic var sessionUrl: String = ""
     @objc private dynamic var url: String?
     @objc private dynamic var rawType: String = "file"

--- a/kDriveCore/Data/UploadQueue/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/UploadOperation.swift
@@ -180,6 +180,13 @@ public class UploadOperation: Operation {
                 UploadQueue.instance.publishProgress(newValue, for: fileId)
             }
             task?.resume()
+
+            // Save UploadFile state (we are mainly interested in saving sessionUrl)
+            BackgroundRealm.uploads.execute { uploadsRealm in
+                try? uploadsRealm.safeWrite {
+                    uploadsRealm.add(UploadFile(value: file), update: .modified)
+                }
+            }
         } else {
             DDLogInfo("[UploadOperation] No file path found for job \(file.id)")
             file.error = .fileNotFound

--- a/kDriveCore/Data/UploadQueue/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/UploadOperation.swift
@@ -156,7 +156,7 @@ public class UploadOperation: Operation {
         DDLogInfo("[UploadOperation] Executing job \(file.id)")
         file.maxRetryCount -= 1
         guard let token = uploadToken else {
-            DDLogInfo("[UploadOperation] Failed to fetch upload token for job \(file.id)")
+            DDLogError("[UploadOperation] Failed to fetch upload token for job \(file.id)")
             file.error = .refreshToken
             end()
             return
@@ -190,7 +190,7 @@ public class UploadOperation: Operation {
                 }
             }
         } else {
-            DDLogInfo("[UploadOperation] No file path found for job \(file.id)")
+            DDLogError("[UploadOperation] No file path found for job \(file.id)")
             file.error = .fileNotFound
             end()
         }
@@ -222,7 +222,7 @@ public class UploadOperation: Operation {
                 DDLogInfo("[UploadOperation] Got photo asset, writing URL")
                 file.pathURL = url
             } else {
-                DDLogWarn("[UploadOperation] Failed to get photo asset")
+                DDLogError("[UploadOperation] Failed to get photo asset")
             }
         }
     }

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -288,7 +288,7 @@ public class UploadQueue {
     private func sendFileUploadedNotificationIfNeeded(with result: UploadCompletionResult) {
         fileUploadedCount += (result.uploadFile.error == nil ? 1 : 0)
         if let error = result.uploadFile.error,
-           error != .networkError || error != .taskCancelled || error != .taskRescheduled {
+           error != .networkError && error != .taskCancelled && error != .taskRescheduled {
             NotificationsHelper.sendUploadError(filename: result.uploadFile.name, parentId: result.uploadFile.parentDirectoryId, error: error)
             if operationQueue.operationCount == 0 {
                 fileUploadedCount = 0

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -242,8 +242,10 @@ public class UploadQueue {
         operation.completionBlock = { [parentId = file.parentDirectoryId, fileId = file.id, userId = file.userId, driveId = file.driveId] in
             self.dispatchQueue.async {
                 self.operationsInQueue.removeValue(forKey: fileId)
-                self.publishFileUploaded(result: operation.result)
-                self.publishUploadCount(withParent: parentId, userId: userId, driveId: driveId, using: self.realm)
+                if operation.result.uploadFile.error != .taskRescheduled {
+                    self.publishFileUploaded(result: operation.result)
+                    self.publishUploadCount(withParent: parentId, userId: userId, driveId: driveId, using: self.realm)
+                }
             }
         }
         operationQueue.addOperation(operation)

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -23,7 +23,10 @@ import RealmSwift
 
 public class UploadQueue {
     public static let instance = UploadQueue()
-    public static let backgroundIdentifier = "com.infomaniak.background.upload"
+    public static let backgroundBaseIdentifier = ".backgroundsession.upload"
+    public static var backgroundIdentifier: String {
+        return (Bundle.main.bundleIdentifier ?? "com.infomaniak.drive") + backgroundBaseIdentifier
+    }
 
     public var pausedNotificationSent = false
 

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -24,13 +24,21 @@ import Sentry
 
 public enum Logging {
     public static func initLogging() {
+        UserDefaults.standard.set(true, forKey: "_UIConstraintBasedLayoutLogUnsatisfiable")
         initLogger()
         initNetworkLogging()
         initSentry()
         copyDebugInformations()
     }
 
+    class LogFormatter: NSObject, DDLogFormatter {
+        func format(message logMessage: DDLogMessage) -> String? {
+            return "[Infomaniak] [\(logMessage.fileName):\(logMessage.line)]: \(logMessage.message)"
+        }
+    }
+
     private static func initLogger() {
+        DDOSLogger.sharedInstance.logFormatter = LogFormatter()
         DDLog.add(DDOSLogger.sharedInstance)
         let logFileManager = DDLogFileManagerDefault(logsDirectory: DriveFileManager.constants.cacheDirectoryURL.appendingPathComponent("logs", isDirectory: true).path)
         let fileLogger = DDFileLogger(logFileManager: logFileManager)

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -33,7 +33,7 @@ public enum Logging {
 
     class LogFormatter: NSObject, DDLogFormatter {
         func format(message logMessage: DDLogMessage) -> String? {
-            return "[Infomaniak] [\(logMessage.fileName):\(logMessage.line)]: \(logMessage.message)"
+            return "[Infomaniak] \(logMessage.message)"
         }
     }
 


### PR DESCRIPTION
The upload queue had to be modified a lot resolve multiple issues we had regarding background upload with extensions.
Each extension now has its own background session identifier. While working on those improvements I noticed some issues with our current handling of background session when rescheduling an upload that I also fixed.

As this is a large rewrite of the current upload implementation we still have a lot of stability testing to do:
- [x] Test rescheduling from main app -> Uploading a file needs to last more than 30 sec while the app is in background
- [x] Test with small amount of files in share extension
- [x] Test with large amount of files in share extension
- [x] Test in file provider -> No modification as been done regarding the FP we need to check if everything is still working fine
