### PR TITLE
Improve snackbar with UIWindow

### DIFF
--- a/kDrive/UI/Controller/Files/FileDetailViewController.swift
+++ b/kDrive/UI/Controller/Files/FileDetailViewController.swift
@@ -319,7 +319,7 @@ class FileDetailViewController: UIViewController {
                     self.comments.insert(comment, at: 0)
                     self.tableView.reloadSections(IndexSet(integersIn: 1...1), with: .automatic)
                 } else {
-                    UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorAddComment, view: self.view)
+                    UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorAddComment)
                 }
             }
 
@@ -566,7 +566,7 @@ extension FileDetailViewController: UITableViewDelegate, UITableViewDataSource {
                             self.tableView.reloadSections(IndexSet([1]), with: .automatic)
                         }
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDelete, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDelete)
                     }
                     completionHandler(success)
                 }
@@ -593,7 +593,7 @@ extension FileDetailViewController: UITableViewDelegate, UITableViewDataSource {
                         self.comments[indexPath.row].body = comment
                         self.tableView.reloadRows(at: [indexPath], with: .automatic)
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorModification, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorModification)
                     }
                     completionHandler(success)
                 }

--- a/kDrive/UI/Controller/Files/FileQuickActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileQuickActionsFloatingPanelViewController.swift
@@ -389,7 +389,7 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                         if success {
                             self.refreshFileAndRows(oldFile: self.file, rows: [indexPath, IndexPath(row: 0, section: 0)])
                         } else {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorRename, view: self.view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorRename)
                         }
                     }
                 }
@@ -446,7 +446,7 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                             })
                         }
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDelete, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDelete)
                     }
                 }
             }
@@ -466,7 +466,7 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                             saveLocalFile(file: file)
                             refreshFileAndRows(oldFile: file, rows: [indexPath])
                         } else {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDownload, view: view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDownload)
                         }
                     }
                 }
@@ -499,10 +499,10 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                     _ = group.wait(timeout: .now() + 5)
                     DispatchQueue.main.async {
                         if success {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.fileListDuplicationConfirmationSnackbar(1), view: self.view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.fileListDuplicationConfirmationSnackbar(1))
                             self.refreshFileAndRows(oldFile: self.file, rows: [indexPath, IndexPath(row: 0, section: 0)])
                         } else {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDuplicate, view: self.view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorDuplicate)
                         }
                     }
                 }
@@ -520,13 +520,13 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
             selectFolderViewController?.selectHandler = { selectedFolder in
                 self.driveFileManager.moveFile(file: self.file, newParent: selectedFolder) { response, _, error in
                     if error != nil {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorMove, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorMove)
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.fileListMoveFileConfirmationSnackbar(1, selectedFolder.name), view: self.view, action: .init(title: KDriveStrings.Localizable.buttonCancel) {
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.fileListMoveFileConfirmationSnackbar(1, selectedFolder.name), action: .init(title: KDriveStrings.Localizable.buttonCancel) {
                             if let cancelId = response?.id {
                                 self.driveFileManager.cancelAction(file: self.file, cancelId: cancelId) { error in
                                     if error == nil {
-                                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.allFileMoveCancelled, view: self.view)
+                                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.allFileMoveCancelled)
                                     }
                                 }
                             }
@@ -551,11 +551,11 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                 _ = group.wait(timeout: .now() + 5)
                 DispatchQueue.main.async {
                     if success {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarLeaveShareConfirmation, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarLeaveShareConfirmation)
                         self.presentingParent?.navigationController?.popViewController(animated: true)
                         self.dismiss(animated: true)
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorLeaveShare, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorLeaveShare)
                     }
                 }
             }
@@ -666,9 +666,9 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
                 PhotoLibrarySaver.instance.save(image: image) { success, _ in
                     DispatchQueue.main.async {
                         if success {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarImageSavedConfirmation, view: self.view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarImageSavedConfirmation)
                         } else {
-                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorSave, view: self.view)
+                            UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorSave)
                         }
                     }
                 }
@@ -677,9 +677,9 @@ class FileQuickActionsFloatingPanelViewController: UITableViewController {
             PhotoLibrarySaver.instance.save(videoUrl: file.localUrl) { success, _ in
                 DispatchQueue.main.async {
                     if success {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarVideoSavedConfirmation, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.snackbarVideoSavedConfirmation)
                     } else {
-                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorSave, view: self.view)
+                        UIConstants.showSnackBar(message: KDriveStrings.Localizable.errorSave)
                     }
                 }
             }

--- a/kDrive/UI/Controller/Menu/Trash/TrashViewController.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashViewController.swift
@@ -104,7 +104,7 @@ class TrashViewController: FileListViewController {
             _ = group.wait(timeout: .now() + 5)
             DispatchQueue.main.async {
                 let message = success ? KDriveStrings.Localizable.snackbarEmptyTrashConfirmation : KDriveStrings.Localizable.errorDelete
-                UIConstants.showSnackBar(message: message, view: self.view)
+                UIConstants.showSnackBar(message: message)
             }
         }
         present(alert, animated: true)
@@ -162,7 +162,7 @@ class TrashViewController: FileListViewController {
                 } else {
                     message = KDriveStrings.Localizable.errorDelete
                 }
-                UIConstants.showSnackBar(message: message, view: self.view)
+                UIConstants.showSnackBar(message: message)
                 if self.selectionMode {
                     self.selectionMode = false
                 }
@@ -284,7 +284,7 @@ extension TrashViewController: SelectFolderDelegate {
                 folder.signalChanges(userId: driveFileManager.drive.userId)
                 if error == nil {
                     removeFileFromList(id: file.id)
-                    UIConstants.showSnackBar(message: KDriveStrings.Localizable.trashedFileRestoreFileInSuccess(file.name, folder.name), view: self.view)
+                    UIConstants.showSnackBar(message: KDriveStrings.Localizable.trashedFileRestoreFileInSuccess(file.name, folder.name))
                 } else {
                     UIConstants.showSnackBar(message: error?.localizedDescription ?? KDriveStrings.Localizable.errorRestore)
                 }

--- a/kDrive/Utils/UIConstants.swift
+++ b/kDrive/Utils/UIConstants.swift
@@ -33,8 +33,8 @@ class UIConstants {
     static let largeTitleHeight: CGFloat = 96
     static let insufficientStorageMinimumPercentage: Double = 90.0
 
-    static func showSnackBar(message: String, view: UIView? = nil, action: IKSnackBar.Action? = nil) {
-        let snackbar = IKSnackBar.make(message: message, duration: .lengthLong, view: view)
+    static func showSnackBar(message: String, action: IKSnackBar.Action? = nil) {
+        let snackbar = IKSnackBar.make(message: message, duration: .lengthLong)
         if let action = action {
             snackbar?.setAction(action).show()
         } else {

--- a/kDriveCore/Utils/IKSnackBar.swift
+++ b/kDriveCore/Utils/IKSnackBar.swift
@@ -173,8 +173,7 @@ public class IKSnackBar: SnackBar {
         return setAction(with: action.title, action: action.action)
     }
 
-    override public func removeFromSuperview() {
-        super.removeFromSuperview()
+    deinit {
         IKWindowProvider.shared.displayRollbackWindowIfNeeded()
     }
 }

--- a/kDriveCore/Utils/IKSnackBar.swift
+++ b/kDriveCore/Utils/IKSnackBar.swift
@@ -95,7 +95,7 @@ public class IKWindowProvider {
         return snackBar
     }
 
-    func displayPendingEntryOrRollbackWindow() {
+    func displayRollbackWindowIfNeeded() {
         if snackBar == nil {
             displayRollbackWindow()
         }
@@ -175,6 +175,6 @@ public class IKSnackBar: SnackBar {
 
     override public func removeFromSuperview() {
         super.removeFromSuperview()
-        IKWindowProvider.shared.displayPendingEntryOrRollbackWindow()
+        IKWindowProvider.shared.displayRollbackWindowIfNeeded()
     }
 }

--- a/kDriveCore/Utils/IKSnackBar.swift
+++ b/kDriveCore/Utils/IKSnackBar.swift
@@ -19,6 +19,22 @@
 import SnackBar
 import UIKit
 
+class IKWrapperView: UIView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        if view != self {
+            return view
+        }
+        return nil
+    }
+}
+
+class IKRootViewController: UIViewController {
+    override func loadView() {
+        view = IKWrapperView()
+    }
+}
+
 class IKWindow: UIWindow {
     init(with rootVC: UIViewController) {
         if #available(iOS 13.0, *) {
@@ -41,9 +57,8 @@ class IKWindow: UIWindow {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        if let rootViewController = IKWindowProvider.shared.rootViewController,
-           let view = rootViewController.view.subviews.first {
-            return view.hitTest(point, with: event)
+        if let rootViewController = IKWindowProvider.shared.rootViewController {
+            return rootViewController.view.hitTest(point, with: event)
         }
 
         return nil
@@ -68,7 +83,7 @@ public class IKWindowProvider {
     func setupWindowAndRootVC() -> UIViewController {
         let entryViewController: UIViewController
         if entryWindow == nil {
-            entryViewController = UIViewController()
+            entryViewController = IKRootViewController()
             entryWindow = IKWindow(with: entryViewController)
             entryWindow.isHidden = false
             mainRollbackWindow = UIApplication.shared.keyWindow

--- a/kDriveCore/Utils/IKSnackBar.swift
+++ b/kDriveCore/Utils/IKSnackBar.swift
@@ -16,8 +16,62 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import UIKit
 import SnackBar
+import UIKit
+
+class IKWindow: UIWindow {
+    init(with rootVC: UIViewController) {
+        if #available(iOS 13.0, *) {
+            if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+                super.init(windowScene: scene)
+            } else {
+                super.init(frame: UIScreen.main.bounds)
+            }
+        } else {
+            super.init(frame: UIScreen.main.bounds)
+        }
+        backgroundColor = .clear
+        rootViewController = rootVC
+        accessibilityViewIsModal = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if let rootViewController = IKWindowProvider.shared.rootViewController,
+           let view = rootViewController.view.subviews.first {
+            return view.hitTest(point, with: event)
+        }
+
+        return nil
+    }
+}
+
+public class IKWindowProvider {
+    public static let shared = IKWindowProvider()
+
+    var entryWindow: IKWindow!
+    var rootViewController: UIViewController? {
+        return entryWindow?.rootViewController
+    }
+
+    private init() {}
+
+    func setupWindowAndRootVC() -> UIViewController {
+        let entryViewController: UIViewController
+        if entryWindow == nil {
+            entryViewController = UIViewController()
+            entryWindow = IKWindow(with: entryViewController)
+            entryWindow.isHidden = false
+        } else {
+            entryViewController = rootViewController!
+        }
+        return entryViewController
+    }
+}
 
 public class IKSnackBar: SnackBar {
     public struct Action {
@@ -32,14 +86,15 @@ public class IKSnackBar: SnackBar {
 
     required init(contextView: UIView, message: String, duration: Duration) {
         super.init(contextView: contextView, message: message, duration: duration)
-        self.addShadow(elevation: 6)
+        addShadow(elevation: 6)
     }
 
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override var style: SnackBarStyle {
+    override public var style: SnackBarStyle {
         let textStyle = TextStyle.subtitle2
         let buttonStyle = TextStyle.action
         var style = SnackBarStyle()
@@ -65,10 +120,10 @@ public class IKSnackBar: SnackBar {
 
     private static func getVisibleViewController(from viewController: UIViewController) -> UIViewController {
         if let navigationController = viewController as? UINavigationController,
-            let visibleController = navigationController.visibleViewController {
+           let visibleController = navigationController.visibleViewController {
             return getVisibleViewController(from: visibleController)
         } else if let tabBarController = viewController as? UITabBarController,
-            let selectedTabController = tabBarController.selectedViewController {
+                  let selectedTabController = tabBarController.selectedViewController {
             return getVisibleViewController(from: selectedTabController)
         } else {
             if let presentedViewController = viewController.presentedViewController {
@@ -83,12 +138,17 @@ public class IKSnackBar: SnackBar {
         if let view = view {
             return Self.make(in: view, message: message, duration: duration)
         } else {
-            guard let vc = getTopViewController() else { return nil }
+            let vc = IKWindowProvider.shared.setupWindowAndRootVC()
             return Self.make(in: vc.view, message: message, duration: duration)
         }
     }
 
     public func setAction(_ action: Action) -> SnackBarPresentable {
         return setAction(with: action.title, action: action.action)
+    }
+
+    public override func removeFromSuperview() {
+        super.removeFromSuperview()
+        // Remove window
     }
 }


### PR DESCRIPTION
Use a different `UIWindow` to present snackbars. It simplifies the workflow and prevents snackbars to be hidden when navigating the app.