### PR TITLE
Fix photo sync predicates

### DIFF
--- a/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
@@ -141,9 +141,9 @@ public class PhotoLibraryUploader {
             if settings.syncPicturesEnabled && settings.syncScreenshotsEnabled {
                 typesPredicates.append(NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue))
             } else if settings.syncPicturesEnabled {
-                typesPredicates.append(NSPredicate(format: "mediaType == %d AND (mediaSubtypes & %d) == 0", PHAssetMediaType.image.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue))
+                typesPredicates.append(NSPredicate(format: "(mediaType == %d) AND !((mediaSubtype & %d) == %d)", PHAssetMediaType.image.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue))
             } else if settings.syncScreenshotsEnabled {
-                typesPredicates.append(NSPredicate(format: "mediaType == %d AND (mediaSubtypes & %d) != 0", PHAssetMediaType.image.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue))
+                typesPredicates.append(NSPredicate(format: "(mediaType == %d) AND ((mediaSubtype & %d) == %d)", PHAssetMediaType.image.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue, PHAssetMediaSubtype.photoScreenshot.rawValue))
             }
             if settings.syncVideosEnabled {
                 typesPredicates.append(NSPredicate(format: "mediaType == %d", PHAssetMediaType.video.rawValue))


### PR DESCRIPTION
There was an issue with predicate when disabling either pictures or screenshot in photo sync