### PR TITLE
Prepare for API v2

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/ProxymanApp/atlantis",
         "state": {
           "branch": null,
-          "revision": "0f79efcbad23ecb45525ca6e0b8f0721514535f9",
-          "version": "1.14.0"
+          "revision": "5e848072d45e3969bd1d69fab3b6c2151f826c41",
+          "version": "1.15.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack.git",
         "state": {
           "branch": null,
-          "revision": "e518eb6e362df327574ba5e04269cd6d29f40aec",
-          "version": "3.7.2"
+          "revision": "80ada1f753b0d53d9b57c465936a7c4169375002",
+          "version": "3.7.4"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "797005ad8a1f0614063933e2fa010a5d13cb09d0",
-          "version": "7.6.0"
+          "revision": "b3bb0c5551fb3f80ca939829639ab5b093edd14f",
+          "version": "7.7.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/airbnb/HorizonCalendar.git",
         "state": {
           "branch": null,
-          "revision": "27bc5a1ee79681e30dc06101ad81cb7172be425b",
-          "version": "1.11.0"
+          "revision": "1e98736e42fe4e5bea39ce8b89838641f2261c32",
+          "version": "1.13.3"
         }
       },
       {
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "79a0b70547f7c40ea54c67487f935fa2f2eaaadc",
-          "version": "3.2.3"
+          "revision": "4a6058cbbdfe4f74aeae92c8bd51ad3b0de2a1ee",
+          "version": "3.3.0"
         }
       },
       {
@@ -240,8 +240,8 @@
         "repositoryURL": "https://github.com/adam-fowler/mqtt-nio",
         "state": {
           "branch": null,
-          "revision": "55da431a0f59e008c889e79495a4cd9fe194d25c",
-          "version": "2.5.1"
+          "revision": "3f0efa5908cedcc6c23ac37184b3d9f01d529a1a",
+          "version": "2.5.2"
         }
       },
       {
@@ -267,8 +267,8 @@
         "repositoryURL": "https://github.com/realm/realm-cocoa",
         "state": {
           "branch": null,
-          "revision": "bdbbd57f411a0f4e72b359113dbc6d23fdf96680",
-          "version": "10.20.0"
+          "revision": "f297dfb2dd256018ed76cde0cdf9ea93ee0158c4",
+          "version": "10.21.0"
         }
       },
       {
@@ -285,8 +285,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "a68422852a7695a6ebb427a7d9ec5c1deae12fa4",
-          "version": "7.6.1"
+          "revision": "5dcd5c245545a03a27988dcdb1a53f78fbee12a1",
+          "version": "7.8.0"
         }
       },
       {
@@ -321,8 +321,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "37e7a33de45bac894c0b08b56a2f755ebe4884e6",
-          "version": "2.35.0"
+          "revision": "213eb6887e526e0dfac526a2eae559a1893ebbac",
+          "version": "2.36.0"
         }
       },
       {
@@ -330,8 +330,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0324d60429870284810ba5bdb039640761bf10c9",
-          "version": "2.17.0"
+          "revision": "2b329e37e9dd34fb382655181a680261d58cbbf1",
+          "version": "2.17.1"
         }
       },
       {

--- a/.package.resolved
+++ b/.package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "d120af1e8638c7da36c8481fd61a66c0c08dc4fc",
-          "version": "5.4.4"
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e79121864",
+          "version": "5.5.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/ProxymanApp/atlantis",
         "state": {
           "branch": null,
-          "revision": "507b49a18b7a19324d98a454dd3c0ababc101950",
-          "version": "1.13.0"
+          "revision": "0f79efcbad23ecb45525ca6e0b8f0721514535f9",
+          "version": "1.14.0"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher",
         "state": {
           "branch": null,
-          "revision": "318e319998bf555c3e914d5c3adb6da05af86a32",
-          "version": "7.1.1"
+          "revision": "0c02c46cfdc0656ce74fd0963a75e5000a0b7f23",
+          "version": "7.1.2"
         }
       },
       {
@@ -285,8 +285,8 @@
         "repositoryURL": "https://github.com/getsentry/sentry-cocoa",
         "state": {
           "branch": null,
-          "revision": "3dd1867f423c9f0dd241d0669d2563f091f805e9",
-          "version": "7.5.4"
+          "revision": "a68422852a7695a6ebb427a7d9ec5c1deae12fa4",
+          "version": "7.6.1"
         }
       },
       {

--- a/kDrive/UI/Controller/Files/ColorSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/ColorSelectionFloatingPanelViewController.swift
@@ -91,7 +91,7 @@ class ColorSelectionFloatingPanelViewController: UICollectionViewController {
         width = view.frame.width
         setUpHeight()
     }
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         width = size.width
@@ -177,11 +177,12 @@ class ColorSelectionFloatingPanelViewController: UICollectionViewController {
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let color = folderColors[indexPath.row]
-        driveFileManager.updateFolderColor(file: file, color: color.hex) { error in
-            if let error = error {
-                UIConstants.showSnackBar(message: error.localizedDescription)
-            } else {
+        Task {
+            do {
+                try await driveFileManager.updateColor(directory: file, color: color.hex)
                 self.dismiss(animated: true)
+            } catch {
+                UIConstants.showSnackBar(message: error.localizedDescription)
             }
         }
     }

--- a/kDrive/UI/Controller/Files/Search/DateRangePickerViewController.swift
+++ b/kDrive/UI/Controller/Files/Search/DateRangePickerViewController.swift
@@ -235,16 +235,16 @@ class DateRangePickerViewController: UIViewController {
             visibleDateRange: visibleDateRange,
             monthsLayout: .vertical(options: VerticalMonthsLayoutOptions(alwaysShowCompleteBoundaryMonths: false))
         )
-        .withInterMonthSpacing(24)
-        .withVerticalDayMargin(8)
-        .withHorizontalDayMargin(8)
-        .withDayItemModelProvider { [unowned self] day in
+        .interMonthSpacing(24)
+        .verticalDayMargin(8)
+        .horizontalDayMargin(8)
+        .dayItemProvider { [unowned self] day in
             self.configureDay(day)
         }
-        .withMonthHeaderItemModelProvider { [unowned self] month in
+        .monthHeaderItemProvider { [unowned self] month in
             self.configureMonthHeader(month)
         }
-        .withDayRangeItemModelProvider(for: dateRanges) { [unowned self] dayRangeLayoutContext in
+        .dayRangeItemProvider(for: dateRanges) { [unowned self] dayRangeLayoutContext in
             self.configureDayRange(dayRangeLayoutContext)
         }
     }

--- a/kDriveCore/Data/Api/ApiRoutes.swift
+++ b/kDriveCore/Data/Api/ApiRoutes.swift
@@ -20,7 +20,6 @@ import Foundation
 
 public enum ApiRoutes {
     static let driveApiUrl = "https://drive.infomaniak.com/drive/"
-    static let driveApiUrlV2 = "https://drive.infomaniak.com/2/drive/"
     static let officeApiUrl = "https://drive.infomaniak.com/app/office/"
     static let with = "with=parent,children,rights,collaborative_folder,favorite,mobile,share_link,categories"
     static let shopUrl = "https://shop.infomaniak.com/order/"
@@ -280,9 +279,5 @@ public enum ApiRoutes {
 
     public static func downloadFileAsPdf(file: File) -> String {
         return "\(fileURL(file: file))download?as=pdf"
-    }
-
-    public static func updateFolderColor(file: File) -> String {
-        return "\(driveApiUrlV2)\(file.driveId)/files/\(file.id)/color"
     }
 }

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -25,7 +25,7 @@ import Sentry
 import UIKit
 
 extension ApiFetcher {
-    convenience init(token: ApiToken, delegate: RefreshTokenDelegate) {
+    public convenience init(token: ApiToken, delegate: RefreshTokenDelegate) {
         self.init()
         setToken(token, authenticator: SyncedAuthenticator(refreshTokenDelegate: delegate))
     }

--- a/kDriveCore/Data/Api/Endpoint.swift
+++ b/kDriveCore/Data/Api/Endpoint.swift
@@ -1,0 +1,400 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2021 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+// MARK: - Type definition
+
+enum ApiEnvironment {
+    case prod, preprod
+
+    var host: String {
+        switch self {
+        case .prod:
+            return "api.infomaniak.com"
+        case .preprod:
+            return "api.preprod.dev.infomaniak.ch"
+        }
+    }
+}
+
+struct Endpoint {
+    let path: String
+    let queryItems: [URLQueryItem]?
+    let apiEnvironment: ApiEnvironment = .preprod
+
+    var url: URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = apiEnvironment.host
+        components.path = "/2/drive\(path)"
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            fatalError("Invalid endpoint URL: \(self)")
+        }
+        return url
+    }
+
+    func appending(path: String, queryItems: [URLQueryItem]? = nil) -> Endpoint {
+        return Endpoint(path: self.path + path, queryItems: queryItems)
+    }
+}
+
+// MARK: - Proxies
+
+protocol AbstractDrive {
+    var id: Int { get set }
+}
+
+class ProxyDrive: AbstractDrive {
+    var id: Int
+
+    init(id: Int) {
+        self.id = id
+    }
+}
+
+extension Drive: AbstractDrive {}
+
+protocol AbstractFile {
+    var driveId: Int { get set }
+    var id: Int { get set }
+}
+
+class ProxyFile: AbstractFile {
+    var driveId: Int
+    var id: Int
+
+    init(driveId: Int, id: Int) {
+        self.driveId = driveId
+        self.id = id
+    }
+}
+
+extension File: AbstractFile {}
+
+// MARK: - Endpoints
+
+extension Endpoint {
+    // MARK: Action
+
+    static func undoAction(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/cancel")
+    }
+
+    // MARK: Activities
+
+    static func fileActivities(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/activities")
+    }
+
+    static func notifications(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/notifications")
+    }
+
+    static func fileActivities(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/activities")
+    }
+
+    static func trashedFileActivities(file: AbstractFile) -> Endpoint {
+        return .trashedInfo(file: file).appending(path: "/activities")
+    }
+
+    // MARK: Archive
+
+    static func buildArchive(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/archives")
+    }
+
+    static func getArchive(drive: AbstractDrive, uuid: String) -> Endpoint {
+        return .buildArchive(drive: drive).appending(path: "/\(uuid)")
+    }
+
+    // MARK: Comment
+
+    static func comments(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/comments")
+    }
+
+    static func comment(file: AbstractFile, comment: Comment) -> Endpoint {
+        return .comments(file: file).appending(path: "/\(comment.id)")
+    }
+
+    static func likeComment(file: AbstractFile, comment: Comment) -> Endpoint {
+        return .comment(file: file, comment: comment).appending(path: "/like")
+    }
+
+    static func unlikeComment(file: AbstractFile, comment: Comment) -> Endpoint {
+        return .comment(file: file, comment: comment).appending(path: "/unlike")
+    }
+
+    // MARK: Drive (complete me)
+
+    static func driveInfo(drive: AbstractDrive) -> Endpoint {
+        return Endpoint(path: "/\(drive.id)", queryItems: nil)
+    }
+
+    static func driveUsers(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/account/user")
+    }
+
+    static func driveSettings(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/settings")
+    }
+
+    // MARK: Dropbox
+
+    static func dropboxes(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/dropboxes")
+    }
+
+    static func dropbox(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/dropbox")
+    }
+
+    static func dropboxInvite(file: AbstractFile) -> Endpoint {
+        return .dropbox(file: file).appending(path: "/invite")
+    }
+
+    // MARK: Favorite
+
+    static func favorites(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/favorites")
+    }
+
+    static func favorite(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/favorite")
+    }
+
+    // MARK: File access
+
+    static func invitation(drive: AbstractDrive, id: Int) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/invitations/\(id)")
+    }
+
+    static func access(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/access")
+    }
+
+    static func checkAccess(file: AbstractFile) -> Endpoint {
+        return .access(file: file).appending(path: "/check")
+    }
+
+    static func invitationsAccess(file: AbstractFile) -> Endpoint {
+        return .access(file: file).appending(path: "/invitations")
+    }
+
+    static func teamsAccess(file: AbstractFile) -> Endpoint {
+        return .access(file: file).appending(path: "/teams")
+    }
+
+    static func teamAccess(file: AbstractFile, id: Int) -> Endpoint {
+        return .teamsAccess(file: file).appending(path: "/\(id)")
+    }
+
+    static func usersAccess(file: AbstractFile) -> Endpoint {
+        return .access(file: file).appending(path: "/users")
+    }
+
+    static func userAccess(file: AbstractFile, id: Int) -> Endpoint {
+        return .usersAccess(file: file).appending(path: "/\(id)")
+    }
+
+    static func forceAccess(file: AbstractFile) -> Endpoint {
+        return .access(file: file).appending(path: "/force")
+    }
+
+    // MARK: File permission
+
+    static func acl(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/acl")
+    }
+
+    static func permissions(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/permission")
+    }
+
+    static func userPermission(file: AbstractFile) -> Endpoint {
+        return .permissions(file: file).appending(path: "/user")
+    }
+
+    static func teajPermission(file: AbstractFile) -> Endpoint {
+        return .permissions(file: file).appending(path: "/team")
+    }
+
+    static func inheritPermission(file: AbstractFile) -> Endpoint {
+        return .permissions(file: file).appending(path: "/inherit")
+    }
+
+    static func permission(file: AbstractFile, id: Int) -> Endpoint {
+        return .permissions(file: file).appending(path: "/\(id)")
+    }
+
+    // MARK: File version
+
+    static func versions(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/versions")
+    }
+
+    static func version(file: AbstractFile, id: Int) -> Endpoint {
+        return .versions(file: file).appending(path: "/\(id)")
+    }
+
+    static func downloadVersion(file: AbstractFile, id: Int) -> Endpoint {
+        return .version(file: file, id: id).appending(path: "/download")
+    }
+
+    static func restoreVersion(file: AbstractFile, id: Int) -> Endpoint {
+        return .version(file: file, id: id).appending(path: "/restore")
+    }
+
+    // MARK: File/directory
+
+    static func fileInfo(_ file: AbstractFile) -> Endpoint {
+        return .driveInfo(drive: ProxyDrive(id: file.driveId)).appending(path: "/files/\(file.id)")
+    }
+
+    static func files(of directory: AbstractFile) -> Endpoint {
+        return .fileInfo(directory).appending(path: "/files")
+    }
+
+    static func createDirectory(in file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/directory")
+    }
+
+    static func createFile(in file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/file")
+    }
+
+    static func thumbnail(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/thumbnail")
+    }
+
+    static func preview(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/preview")
+    }
+
+    static func download(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/download")
+    }
+
+    static func convert(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/convert")
+    }
+
+    static func move(file: AbstractFile, destinationId: Int) -> Endpoint {
+        return .fileInfo(file).appending(path: "/move/\(destinationId)")
+    }
+
+    static func duplicate(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/copy")
+    }
+
+    static func copy(file: AbstractFile, destinationId: Int) -> Endpoint {
+        return .duplicate(file: file).appending(path: "/\(destinationId)")
+    }
+
+    static func rename(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/rename")
+    }
+
+    static func count(of directory: AbstractFile) -> Endpoint {
+        return .fileInfo(directory).appending(path: "/count")
+    }
+
+    static func size(file: AbstractFile, depth: String) -> Endpoint {
+        return .fileInfo(file).appending(path: "/size", queryItems: [
+            URLQueryItem(name: "depth", value: depth)
+        ])
+    }
+
+    static func unlock(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/lock")
+    }
+
+    static func directoryColor(file: AbstractFile) -> Endpoint {
+        return .fileInfo(file).appending(path: "/color")
+    }
+
+    // MARK: Preferences
+
+    static var userPreferences: Endpoint {
+        return Endpoint(path: "/preferences", queryItems: nil)
+    }
+
+    static func preferences(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/preference")
+    }
+
+    // MARK: Root directory
+
+    static func lockedFiles(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/files/lock")
+    }
+
+    // MARK: Search
+
+    // MARK: Share link
+
+    // MARK: Trash
+
+    static func trash(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/trash")
+    }
+
+    static func trashCount(drive: AbstractDrive) -> Endpoint {
+        return .trash(drive: drive).appending(path: "/count")
+    }
+
+    static func trashedInfo(file: AbstractFile) -> Endpoint {
+        return .trash(drive: ProxyDrive(id: file.driveId)).appending(path: "/\(file.id)")
+    }
+
+    static func trashedFiles(of directory: AbstractFile) -> Endpoint {
+        return .trashedInfo(file: directory).appending(path: "/files")
+    }
+
+    static func restore(file: AbstractFile) -> Endpoint {
+        return .trashedInfo(file: file).appending(path: "/restore")
+    }
+
+    static func trashThumbnail(file: AbstractFile) -> Endpoint {
+        return .trashedInfo(file: file).appending(path: "/thumbnail")
+    }
+
+    static func trashCount(of directory: AbstractFile) -> Endpoint {
+        return .trashedInfo(file: directory).appending(path: "/count")
+    }
+
+    // MARK: Upload
+
+    // MARK: User invitation
+
+    static func userInvitations(drive: AbstractDrive) -> Endpoint {
+        return .driveInfo(drive: drive).appending(path: "/user/invitation")
+    }
+
+    static func userInvitation(drive: AbstractDrive, id: Int) -> Endpoint {
+        return .userInvitations(drive: drive).appending(path: "/\(id)")
+    }
+
+    static func sendUserInvitation(drive: AbstractDrive, id: Int) -> Endpoint {
+        return .userInvitation(drive: drive, id: id).appending(path: "/send")
+    }
+}

--- a/kDriveCore/Data/Api/Endpoint.swift
+++ b/kDriveCore/Data/Api/Endpoint.swift
@@ -121,7 +121,7 @@ extension File: AbstractFile {}
 
 extension Endpoint {
     private static var base: Endpoint {
-        return Endpoint(path: "/2/drive", apiEnvironment: .preprod)
+        return Endpoint(path: "/2/drive", apiEnvironment: .prod)
     }
 
     // MARK: Action

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -1410,15 +1410,12 @@ public class DriveFileManager {
         }
     }
 
-    public func updateFolderColor(file: File, color: String, completion: @escaping (Error?) -> Void) {
-        apiFetcher.updateFolderColor(file: file, color: color) { [fileId = file.id] _, error in
-            if let error = error {
-                completion(error)
-            } else {
-                self.updateFileProperty(fileId: fileId) { file in
-                    file.color = color
-                }
-                completion(nil)
+    public func updateColor(directory: File, color: String) async throws {
+        let fileId = directory.id
+        let result = try await apiFetcher.updateColor(directory: directory, color: color)
+        if result {
+            updateFileProperty(fileId: fileId) { file in
+                file.color = color
             }
         }
     }

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -105,7 +105,7 @@ public struct DriveError: Error, Equatable {
         if let error = DriveError.allErrors.first(where: { $0.type == .serverError && $0.code == apiErrorCode }) {
             self = error
         } else {
-            self = .errorWithUserInfo(.serverError, info: [.status: ErrorUserInfo(intValue: httpStatus)])
+            self = .serverError(statusCode: httpStatus)
         }
     }
 
@@ -133,6 +133,10 @@ public struct DriveError: Error, Equatable {
         var error = error
         error.userInfo = info
         return error
+    }
+
+    static func serverError(statusCode: Int) -> DriveError {
+        return errorWithUserInfo(.serverError, info: [.status: ErrorUserInfo(intValue: statusCode)])
     }
 
     public static func == (lhs: DriveError, rhs: DriveError) -> Bool {

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -160,6 +160,7 @@ public enum SortType: String {
     case ext
     case olderDelete
     case newerDelete
+    case type
 
     public struct SortTypeValue {
         public let apiValue: String
@@ -192,6 +193,8 @@ public enum SortType: String {
             return SortTypeValue(apiValue: "deleted_at", order: "asc", translation: KDriveResourcesStrings.Localizable.sortOlder, realmKeyPath: \.deletedAt)
         case .newerDelete:
             return SortTypeValue(apiValue: "deleted_at", order: "desc", translation: KDriveResourcesStrings.Localizable.sortRecent, realmKeyPath: \.deletedAt)
+        case .type:
+            return SortTypeValue(apiValue: "type", order: "desc", translation: "", realmKeyPath: \.type)
         }
     }
 }

--- a/kDriveCore/Data/Models/UploadFile.swift
+++ b/kDriveCore/Data/Models/UploadFile.swift
@@ -135,6 +135,22 @@ public class UploadFile: Object {
         }
     }
 
+    public var queryItems: [URLQueryItem] {
+        var queryItems = [
+            URLQueryItem(name: "conflict", value: conflictOption.rawValue),
+            URLQueryItem(name: "file_name", value: name),
+            URLQueryItem(name: "relative_path", value: relativePath),
+            URLQueryItem(name: "total_size", value: "\(size)")
+        ]
+        if let creationDate = creationDate {
+            queryItems.append(URLQueryItem(name: "file_created_at", value: "\(Int(creationDate.timeIntervalSince1970))"))
+        }
+        if let modificationDate = modificationDate {
+            queryItems.append(URLQueryItem(name: "last_modified_at", value: "\(Int(modificationDate.timeIntervalSince1970))"))
+        }
+        return queryItems
+    }
+
     public init(id: String = UUID().uuidString, parentDirectoryId: Int, userId: Int, driveId: Int, url: URL, name: String? = nil, conflictOption: ConflictOption = .rename, shouldRemoveAfterUpload: Bool = true, priority: Operation.QueuePriority = .normal) {
         self.parentDirectoryId = parentDirectoryId
         self.userId = userId

--- a/kDriveTests/DriveApiTests.swift
+++ b/kDriveTests/DriveApiTests.swift
@@ -55,6 +55,14 @@ final class DriveApiTests: XCTestCase {
         }
     }
 
+    func setUpTest(testName: String) async -> File {
+        await withCheckedContinuation { continuation in
+            setUpTest(testName: testName) { file in
+                continuation.resume(returning: file)
+            }
+        }
+    }
+
     func tearDownTest(directory: File) {
         currentApiFetcher.deleteFile(file: directory) { response, _ in
             XCTAssertNotNil(response, "Failed to delete directory")
@@ -1534,21 +1542,14 @@ final class DriveApiTests: XCTestCase {
         tearDownTest(directory: folder)
     }
 
-    func testFolderColor() {
-        let expectation = XCTestExpectation(description: "Change folder color")
-
-        var folder = File()
-
-        setUpTest(testName: "FolderColor") { file in
-            folder = file
-
-            self.currentApiFetcher.updateFolderColor(file: folder, color: "#E91E63") { _, error in
-                XCTAssertNil(error, "There should be no error on changing folder color")
-                expectation.fulfill()
-            }
+    func testDirectoryColor() async {
+        let directory = await setUpTest(testName: "DirectoryColor")
+        do {
+            let result = try await currentApiFetcher.updateColor(directory: directory, color: "#E91E63")
+            XCTAssertEqual(result, true, "API should return true")
+        } catch {
+            XCTFail("There should be no error on changing directory color")
         }
-
-        wait(for: [expectation], timeout: DriveApiTests.defaultTimeout)
-        tearDownTest(directory: folder)
+        tearDownTest(directory: directory)
     }
 }


### PR DESCRIPTION
Preparing foundations for API v2:

- New `Endpoint` struct to improve API endpoints management
- Update dependencies (Alamofire 5.5 includes support for Swift Concurrency)
- New request helper methods in API fetcher to use `Endpoint` and async/await
- Rewrite folder color API methods using this new mechanism