### PR TITLE
Upload table view cell wrong icons

### DIFF
--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -49,7 +49,7 @@ class UploadQueueViewController: UIViewController {
                 guard let self = self else { return }
                 self.progressForFileId[fileId] = progress
                 for cell in self.tableView.visibleCells {
-                    (cell as? UploadTableViewCell)?.updateProgress(fileId: fileId, progress: progress)
+                    (cell as? UploadTableViewCell)?.updateProgress(fileId: fileId, progress: progress, animated: progress > 0)
                 }
             }
         }

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -35,6 +35,7 @@ class UploadTableViewCell: InsetTableViewCell {
         cardContentView.iconView.isHidden = false
         cardContentView.editImage?.isHidden = true
         cardContentView.progressView.setInfomaniakStyle()
+        cardContentView.iconViewHeightConstraint.constant = 24
     }
 
     override func prepareForReuse() {

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -33,6 +33,7 @@ class UploadTableViewCell: InsetTableViewCell {
         cardContentView.iconView.isHidden = true
         cardContentView.progressView.isHidden = true
         cardContentView.iconView.isHidden = false
+        cardContentView.editImage?.isHidden = true
         cardContentView.progressView.setInfomaniakStyle()
     }
 
@@ -76,7 +77,7 @@ class UploadTableViewCell: InsetTableViewCell {
             }
         }
     }
-    
+
     private func addThumbnail(image: UIImage) {
         DispatchQueue.main.async {
             self.cardContentView.iconView.layer.cornerRadius = UIConstants.imageCornerRadius

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -93,7 +93,8 @@ class UploadTableViewCell: InsetTableViewCell {
         cardContentView.titleLabel.text = uploadFile.name
         setStatusFor(uploadFile: uploadFile)
 
-        if let progress = progress, let currentFileId = currentFileId {
+        if let progress = progress, let currentFileId = currentFileId,
+           uploadFile.error == nil || uploadFile.error == .taskRescheduled {
             updateProgress(fileId: currentFileId, progress: progress, animated: false)
         }
 

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -163,7 +163,7 @@ public class UploadQueue {
     public func cancel(_ file: UploadFile) {
         dispatchQueue.async { [fileId = file.id, parentId = file.parentDirectoryId, userId = file.userId, driveId = file.driveId, realm = realm!] in
             let operation = self.operationsInQueue[fileId]
-            if !(operation?.isExecuting ?? true) {
+            if operation?.isExecuting != true {
                 if let toDelete = realm.object(ofType: UploadFile.self, forPrimaryKey: fileId) {
                     let publishedToDelete = UploadFile(value: toDelete)
                     publishedToDelete.error = .taskCancelled

--- a/kDriveCore/Data/UploadQueue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/UploadQueue.swift
@@ -205,6 +205,7 @@ public class UploadQueue {
                 file.maxRetryCount = UploadFile.defaultMaxRetryCount
             }
             self.addToQueue(file: file, using: self.realm)
+            self.publishProgress(0, for: file.id)
         }
     }
 
@@ -217,7 +218,10 @@ public class UploadQueue {
                     file.maxRetryCount = UploadFile.defaultMaxRetryCount
                 }
             }
-            failedUploadFiles.forEach { self.addToQueue(file: $0, using: self.realm) }
+            failedUploadFiles.forEach {
+                self.addToQueue(file: $0, using: self.realm)
+                self.publishProgress(0, for: $0.id)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #603 

Fixes :
- bad icons displayed on UploadTableViewCell
- cancel button that doesn't work after an error
- wrong size of file icons
- 0% progression when restarting a download