### PR TITLE
Fix disabled directories move multiple selection

### DIFF
--- a/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
@@ -112,17 +112,17 @@ class MultipleSelectionFileListViewModel {
         switch action {
         case .move:
             // Current directory is always disabled.
-            var disabledDirectories = [currentDirectory]
+            var disabledDirectoriesIds = [currentDirectory.id]
             // Selected items all have the same parent, add it to the disabled directories
-            if let firstSelectedParent = selectedItems.first?.parent,
-               firstSelectedParent != currentDirectory,
-               selectedItems.allSatisfy({ $0.parent == firstSelectedParent }) {
-                disabledDirectories.append(firstSelectedParent)
+            if let firstSelectedParentId = selectedItems.first?.parentId,
+               firstSelectedParentId != currentDirectory.id,
+               selectedItems.allSatisfy({ $0.parentId == firstSelectedParentId }) {
+                disabledDirectoriesIds.append(firstSelectedParentId)
             }
             let selectFolderNavigationController = SelectFolderViewController
                 .instantiateInNavigationController(driveFileManager: driveFileManager,
                                                    startDirectory: currentDirectory,
-                                                   disabledDirectoriesSelection: disabledDirectories) { selectedFolder in
+                                                   disabledDirectoriesIdsSelection: disabledDirectoriesIds) { selectedFolder in
                     Task { [weak self] in
                         await self?.moveSelectedItems(to: selectedFolder)
                     }
@@ -227,7 +227,7 @@ class MultipleSelectionFileListViewModel {
             do {
                 try await withThrowingTaskGroup(of: Void.self) { group in
                     // Move files only if needed
-                    for file in selectedItems where file.parent?.id != destinationDirectory.id {
+                    for file in selectedItems where file.parentId != destinationDirectory.id {
                         group.addTask { [self] in
                             _ = try await driveFileManager.move(file: file, to: destinationDirectory)
                         }

--- a/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
@@ -64,12 +64,15 @@ class SelectFolderViewController: FileListViewController {
         selectFolderButton.isEnabled = !disabledDirectoriesSelection.contains(viewModel.currentDirectory.id) && (viewModel.currentDirectory.capabilities.canMoveInto || viewModel.currentDirectory.capabilities.canCreateFile)
     }
 
-    static func instantiateInNavigationController(driveFileManager: DriveFileManager, startDirectory: File? = nil, fileToMove: Int? = nil, disabledDirectoriesSelection: [File] = [], delegate: SelectFolderDelegate? = nil, selectHandler: ((File) -> Void)? = nil) -> TitleSizeAdjustingNavigationController {
+    static func instantiateInNavigationController(driveFileManager: DriveFileManager,
+                                                  startDirectory: File? = nil, fileToMove: Int? = nil,
+                                                  disabledDirectoriesIdsSelection: [Int],
+                                                  delegate: SelectFolderDelegate? = nil,
+                                                  selectHandler: ((File) -> Void)? = nil) -> TitleSizeAdjustingNavigationController {
         var viewControllers = [SelectFolderViewController]()
-        let disabledDirectoriesSelection = disabledDirectoriesSelection.map(\.id)
         if startDirectory == nil || startDirectory?.isRoot == true {
             let selectFolderViewController = instantiate(viewModel: SelectFolderViewModel(driveFileManager: driveFileManager, currentDirectory: nil))
-            selectFolderViewController.disabledDirectoriesSelection = disabledDirectoriesSelection
+            selectFolderViewController.disabledDirectoriesSelection = disabledDirectoriesIdsSelection
             selectFolderViewController.fileToMove = fileToMove
             selectFolderViewController.delegate = delegate
             selectFolderViewController.selectHandler = selectHandler
@@ -79,7 +82,7 @@ class SelectFolderViewController: FileListViewController {
             var directory = startDirectory
             while directory != nil {
                 let selectFolderViewController = instantiate(viewModel: SelectFolderViewModel(driveFileManager: driveFileManager, currentDirectory: directory))
-                selectFolderViewController.disabledDirectoriesSelection = disabledDirectoriesSelection
+                selectFolderViewController.disabledDirectoriesSelection = disabledDirectoriesIdsSelection
                 selectFolderViewController.fileToMove = fileToMove
                 selectFolderViewController.delegate = delegate
                 selectFolderViewController.selectHandler = selectHandler
@@ -92,6 +95,15 @@ class SelectFolderViewController: FileListViewController {
         navigationController.setViewControllers(viewControllers.reversed(), animated: false)
         navigationController.navigationBar.prefersLargeTitles = true
         return navigationController
+    }
+
+    static func instantiateInNavigationController(driveFileManager: DriveFileManager,
+                                                  startDirectory: File? = nil, fileToMove: Int? = nil,
+                                                  disabledDirectoriesSelection: [File] = [],
+                                                  delegate: SelectFolderDelegate? = nil,
+                                                  selectHandler: ((File) -> Void)? = nil) -> TitleSizeAdjustingNavigationController {
+        let disabledDirectoriesIdsSelection = disabledDirectoriesSelection.map(\.id)
+        return instantiateInNavigationController(driveFileManager: driveFileManager, startDirectory: startDirectory, fileToMove: fileToMove, disabledDirectoriesIdsSelection: disabledDirectoriesIdsSelection, delegate: delegate, selectHandler: selectHandler)
     }
 
     // MARK: - Actions


### PR DESCRIPTION
Moving files is allowed to any destination directories from fake roots but only move the necessary files.
Close #581
