### PR TITLE
Refactor SelectFloatingPanelTableViewController

### DIFF
--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -373,9 +373,9 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             (manageCategoriesViewController.topViewController as? ManageCategoriesViewController)?.fileListViewController = presentingParent as? FileListViewController
             present(manageCategoriesViewController, animated: true)
         case .favorite:
-            driveFileManager.setFavoriteFile(file: file, favorite: !file.isFavorite) { [wasFavorited = file.isFavorite] error in
+            FileActionsHelper.favorite(files: [file], driveFileManager: driveFileManager) { _, isFavored, error in
                 if error == nil {
-                    if !wasFavorited {
+                    if isFavored {
                         UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListAddFavorisConfirmationSnackbar(1))
                     }
                 } else {

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -436,16 +436,15 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             filePresenter.presentParent(of: file, driveFileManager: driveFileManager)
             dismiss(animated: true)
         case .offline:
-            if !file.isAvailableOffline {
+            FileActionsHelper.availableOffline(files: [file], at: indexPath, driveFileManager: driveFileManager) { _ in
                 // Update offline files before setting new file to synchronize them
                 (UIApplication.shared.delegate as? AppDelegate)?.updateAvailableOfflineFiles(status: ReachabilityListener.instance.currentStatus)
-            }
-            driveFileManager.setFileAvailableOffline(file: file, available: !file.isAvailableOffline) { error in
+            } completion: { [weak self] _, error in
                 if error != nil && error as? DriveError != .taskCancelled && error as? DriveError != .taskRescheduled {
                     UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.errorCache)
                 }
+                self?.collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])
             }
-            collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])
         case .download:
             if file.isMostRecentDownloaded {
                 save(file: file)

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -404,30 +404,9 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             presentingParent?.navigationController?.pushViewController(viewController, animated: true)
             dismiss(animated: true)
         case .folderColor:
-            if driveFileManager.drive.pack == .free {
-                let driveFloatingPanelController = FolderColorFloatingPanelViewController.instantiatePanel()
-                let floatingPanelViewController = driveFloatingPanelController.contentViewController as? FolderColorFloatingPanelViewController
-                floatingPanelViewController?.rightButton.isEnabled = driveFileManager.drive.accountAdmin
-                floatingPanelViewController?.actionHandler = { _ in
-                    driveFloatingPanelController.dismiss(animated: true) {
-                        StorePresenter.showStore(from: self, driveFileManager: self.driveFileManager)
-                    }
-                }
-                present(driveFloatingPanelController, animated: true)
-            } else {
-                let colorSelectionFloatingPanelViewController = ColorSelectionFloatingPanelViewController(files: [file], driveFileManager: driveFileManager)
-                let floatingPanelViewController = DriveFloatingPanelController()
-                floatingPanelViewController.isRemovalInteractionEnabled = true
-                floatingPanelViewController.set(contentViewController: colorSelectionFloatingPanelViewController)
-                floatingPanelViewController.track(scrollView: colorSelectionFloatingPanelViewController.collectionView)
-                colorSelectionFloatingPanelViewController.floatingPanelController = floatingPanelViewController
-                colorSelectionFloatingPanelViewController.completionHandler = { isSuccess in
-                    if isSuccess {
-                        UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListColorFolderConfirmationSnackbar(1))
-                    }
-                }
-                dismiss(animated: true) {
-                    self.presentingParent?.present(floatingPanelViewController, animated: true)
+            _ = FileActionsHelper.folderColor(files: [file], driveFileManager: driveFileManager, with: self, presentingParent: presentingParent) { isSuccess in
+                if isSuccess {
+                    UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListColorFolderConfirmationSnackbar(1))
                 }
             }
         case .seeFolder:

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -105,12 +105,6 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
     var file: File!
     var normalFolderHierarchy = true
     weak var presentingParent: UIViewController?
-    var matomoCategory: MatomoUtils.EventCategory {
-        if presentingParent is PhotoListViewController {
-            return .picturesFileAction
-        }
-        return .fileListFileAction
-    }
 
     var sharedWithMe: Bool {
         return driveFileManager?.drive.sharedWithMe ?? false
@@ -719,7 +713,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         case .actions:
             action = actions[indexPath.item]
         }
-        MatomoUtils.trackFileAction(action: action, file: file)
+        MatomoUtils.trackFileAction(action: action, file: file, fromPhotoList: presentingParent is PhotoListViewController)
         handleAction(action, at: indexPath)
     }
 }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -415,7 +415,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             filePresenter.presentParent(of: file, driveFileManager: driveFileManager)
             dismiss(animated: true)
         case .offline:
-            _ = FileActionsHelper.availableOffline(files: [file], at: indexPath, driveFileManager: driveFileManager) { _ in
+            _ = FileActionsHelper.offline(files: [file], at: indexPath, driveFileManager: driveFileManager) { _ in
                 // Update offline files before setting new file to synchronize them
                 (UIApplication.shared.delegate as? AppDelegate)?.updateAvailableOfflineFiles(status: ReachabilityListener.instance.currentStatus)
             } completion: { [weak self] _, error in
@@ -426,7 +426,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             }
         case .download:
             if file.isMostRecentDownloaded {
-                FileActionsHelper.save(file: file, with: self)
+                FileActionsHelper.save(file: file, from: self)
             } else if let operation = DownloadQueue.instance.operation(for: file) {
                 // Download is already scheduled, ask to cancel
                 let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.cancelDownloadTitle, message: KDriveResourcesStrings.Localizable.cancelDownloadDescription, action: KDriveResourcesStrings.Localizable.buttonYes, destructive: true) {
@@ -437,7 +437,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
                 downloadFile(action: action, indexPath: indexPath) { [weak self] in
                     if let file = self?.file {
                         guard let self = self else { return }
-                        FileActionsHelper.save(file: file, with: self)
+                        FileActionsHelper.save(file: file, from: self)
                     }
                 }
             }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -617,37 +617,6 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    internal func track(action: FloatingPanelAction) {
-        switch action {
-        // Quick Actions
-        case .sendCopy:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "sendFileCopy")
-        case .shareLink:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "copyShareLink")
-        case .informations:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "openFileInfos")
-        // Actions
-        case .duplicate:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "copy")
-        case .move:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "move")
-        case .download:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "download")
-        case .favorite:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "favorite", value: !file.isFavorite)
-        case .offline:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "offline", value: !file.isAvailableOffline)
-        case .rename:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "rename")
-        case .delete:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "putInTrash")
-        case .convertToDropbox:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "convertToDropBox")
-        default:
-            break
-        }
-    }
-
     private func setLoading(_ isLoading: Bool, action: FloatingPanelAction, at indexPath: IndexPath) {
         action.isLoading = isLoading
         DispatchQueue.main.async { [weak self] in
@@ -744,7 +713,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         case .actions:
             action = actions[indexPath.item]
         }
-        track(action: action)
+        MatomoUtils.trackFileAction(action: action, file: file)
         handleAction(action, at: indexPath)
     }
 }

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -342,6 +342,17 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
         }
     }
 
+    // MARK: - Collection view delegate
+
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let action: FloatingPanelAction
+        switch Self.sections[indexPath.section] {
+        case .actions:
+            action = actions[indexPath.item]
+        }
+        handleAction(action, at: indexPath)
+    }
+
     // MARK: - Collection view data source
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -21,7 +21,7 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-class SelectFloatingPanelTableViewController: UICollectionViewController {
+class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     var driveFileManager: DriveFileManager!
     var files: [File]!
     var changedFiles: [File]? = []

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -259,7 +259,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             action = actions[indexPath.item]
         }
         handleAction(action, at: indexPath)
-        MatomoUtils.trackBulkAction(action: action, files: files)
+        MatomoUtils.trackBulkAction(action: action, files: files, fromPhotoList: presentingParent is PhotoListViewController)
     }
 
     // MARK: - Collection view data source

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -102,18 +102,13 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                 }
             }
         case .favorite:
-            let isFavorite = filesAreFavorite
-            addAction = !isFavorite
-            for file in files where file.rights?.canFavorite ?? false {
-                group.enter()
-                driveFileManager.setFavoriteFile(file: file, favorite: !isFavorite) { error in
-                    if error != nil {
-                        success = false
-                    }
-                    if let file = self.driveFileManager.getCachedFile(id: file.id) {
-                        self.changedFiles?.append(file)
-                    }
-                    group.leave()
+            FileActionsHelper.favorite(files: files, driveFileManager: driveFileManager) { file, isFavored, error in
+                addAction = isFavored
+                if error != nil {
+                    success = false
+                }
+                if let file = self.driveFileManager.getCachedFile(id: file.id) {
+                    self.changedFiles?.append(file)
                 }
             }
         case .folderColor:

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -34,14 +34,6 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
         return driveFileManager?.drive.sharedWithMe ?? false
     }
 
-    enum Section: CaseIterable {
-        case actions
-    }
-
-    class var sections: [Section] {
-        return [.actions]
-    }
-
     var actions = FloatingPanelAction.listActions
 
     var filesAvailableOffline: Bool {
@@ -223,13 +215,10 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
 
     private static func createLayout() -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout { section, _ in
-            switch sections[section] {
-            case .actions:
-                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(53))
-                let item = NSCollectionLayoutItem(layoutSize: itemSize)
-                let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
-                return NSCollectionLayoutSection(group: group)
-            }
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(53))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
+            return NSCollectionLayoutSection(group: group)
         }
     }
 
@@ -253,11 +242,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     // MARK: - Collection view delegate
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let action: FloatingPanelAction
-        switch Self.sections[indexPath.section] {
-        case .actions:
-            action = actions[indexPath.item]
-        }
+        let action = actions[indexPath.item]
         handleAction(action, at: indexPath)
         MatomoUtils.trackBulkAction(action: action, files: files, fromPhotoList: presentingParent is PhotoListViewController)
     }
@@ -265,23 +250,17 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     // MARK: - Collection view data source
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return Self.sections.count
+        return 1
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        switch Self.sections[section] {
-        case .actions:
-            return actions.count
-        }
+        return actions.count
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        switch Self.sections[indexPath.section] {
-        case .actions:
-            let cell = collectionView.dequeueReusableCell(type: FloatingPanelActionCollectionViewCell.self, for: indexPath)
-            let action = actions[indexPath.item]
-            cell.configure(with: action, filesAreFavorite: filesAreFavorite, filesAvailableOffline: filesAvailableOffline, filesAreDirectory: files.allSatisfy(\.isDirectory), containsDirectory: files.contains(where: \.isDirectory), showProgress: downloadInProgress, archiveId: currentArchiveId)
-            return cell
-        }
+        let cell = collectionView.dequeueReusableCell(type: FloatingPanelActionCollectionViewCell.self, for: indexPath)
+        let action = actions[indexPath.item]
+        cell.configure(with: action, filesAreFavorite: filesAreFavorite, filesAvailableOffline: filesAvailableOffline, filesAreDirectory: files.allSatisfy(\.isDirectory), containsDirectory: files.contains(where: \.isDirectory), showProgress: downloadInProgress, archiveId: currentArchiveId)
+        return cell
     }
 }

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -86,24 +86,17 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
 
         switch action {
         case .offline:
-            let isAvailableOffline = filesAvailableOffline
-            addAction = !isAvailableOffline
-            if !isAvailableOffline {
+            FileActionsHelper.availableOffline(files: files, at: indexPath, driveFileManager: driveFileManager) { indexPath in
                 downloadInProgress = true
                 collectionView.reloadItems(at: [indexPath])
                 // Update offline files before setting new file to synchronize them
                 (UIApplication.shared.delegate as? AppDelegate)?.updateAvailableOfflineFiles(status: ReachabilityListener.instance.currentStatus)
-            }
-            for file in files where !file.isDirectory && file.isAvailableOffline == isAvailableOffline {
-                group.enter()
-                driveFileManager.setFileAvailableOffline(file: file, available: !isAvailableOffline) { error in
-                    if error != nil {
-                        success = false
-                    }
-                    if let file = self.driveFileManager.getCachedFile(id: file.id) {
-                        self.changedFiles?.append(file)
-                    }
-                    group.leave()
+            } completion: { file, error in
+                if error != nil {
+                    success = false
+                }
+                if let file = self.driveFileManager.getCachedFile(id: file.id) {
+                    self.changedFiles?.append(file)
                 }
             }
         case .favorite:
@@ -351,6 +344,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             action = actions[indexPath.item]
         }
         handleAction(action, at: indexPath)
+        // TODO: Add Matomo
     }
 
     // MARK: - Collection view data source

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -110,32 +110,9 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                 }
             }
         case .folderColor:
-            group.enter()
-            if driveFileManager.drive.pack == .free {
-                let driveFloatingPanelController = FolderColorFloatingPanelViewController.instantiatePanel()
-                let floatingPanelViewController = driveFloatingPanelController.contentViewController as? FolderColorFloatingPanelViewController
-                floatingPanelViewController?.rightButton.isEnabled = driveFileManager.drive.accountAdmin
-                floatingPanelViewController?.actionHandler = { _ in
-                    driveFloatingPanelController.dismiss(animated: true) {
-                        StorePresenter.showStore(from: self, driveFileManager: self.driveFileManager)
-                    }
-                }
-                present(driveFloatingPanelController, animated: true)
-            } else {
-                let colorSelectionFloatingPanelViewController = ColorSelectionFloatingPanelViewController(files: files, driveFileManager: driveFileManager)
-                let floatingPanelViewController = DriveFloatingPanelController()
-                floatingPanelViewController.isRemovalInteractionEnabled = true
-                floatingPanelViewController.set(contentViewController: colorSelectionFloatingPanelViewController)
-                floatingPanelViewController.track(scrollView: colorSelectionFloatingPanelViewController.collectionView)
-                colorSelectionFloatingPanelViewController.floatingPanelController = floatingPanelViewController
-                colorSelectionFloatingPanelViewController.completionHandler = { isSuccess in
-                    success = isSuccess
-                    group.leave()
-                }
-                dismiss(animated: true) {
-                    self.presentingParent?.present(floatingPanelViewController, animated: true)
-                }
-            }
+            group = FileActionsHelper.folderColor(files: files, driveFileManager: driveFileManager, with: self, presentingParent: presentingParent, completion: { isSuccess in
+                success = isSuccess
+            })
         case .download:
             if files.count > Constants.bulkActionThreshold || !files.allSatisfy({ !$0.isDirectory }) {
                 if downloadInProgress,

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -86,7 +86,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
 
         switch action {
         case .offline:
-            group = FileActionsHelper.availableOffline(files: files, at: indexPath, driveFileManager: driveFileManager) { indexPath in
+            group = FileActionsHelper.offline(files: files, at: indexPath, driveFileManager: driveFileManager) { indexPath in
                 downloadInProgress = true
                 collectionView.reloadItems(at: [indexPath])
                 // Update offline files before setting new file to synchronize them
@@ -138,7 +138,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             } else {
                 for file in files {
                     if file.isDownloaded {
-                        FileActionsHelper.save(file: file, with: self)
+                        FileActionsHelper.save(file: file, from: self)
                     } else {
                         downloadInProgress = true
                         collectionView.reloadItems(at: [indexPath])
@@ -146,7 +146,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                         DownloadQueue.instance.observeFileDownloaded(self, fileId: file.id) { [unowned self] _, error in
                             if error == nil {
                                 DispatchQueue.main.async {
-                                    FileActionsHelper.save(file: file, with: self)
+                                    FileActionsHelper.save(file: file, from: self)
                                 }
                             } else {
                                 success = false

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -219,27 +219,6 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    func track(action: FloatingPanelAction) {
-        let numberOfFiles = files.count
-        switch action {
-        // Quick Actions
-        case .duplicate:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "copy", numberOfItems: numberOfFiles)
-        case .download:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "download", numberOfItems: numberOfFiles)
-        case .favorite:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "add_favorite", numberOfItems: numberOfFiles)
-        case .offline:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "set_offline", numberOfItems: numberOfFiles)
-        case .delete:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "trash", numberOfItems: numberOfFiles)
-        case .folderColor:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "color_folder", numberOfItems: numberOfFiles)
-        default:
-            break
-        }
-    }
-
     // MARK: - Private methods
 
     private static func createLayout() -> UICollectionViewLayout {
@@ -280,7 +259,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             action = actions[indexPath.item]
         }
         handleAction(action, at: indexPath)
-        // TODO: Add Matomo
+        MatomoUtils.trackBulkAction(action: action, files: files)
     }
 
     // MARK: - Collection view data source

--- a/kDrive/UI/Controller/Files/MultipleSelectionViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionViewController.swift
@@ -233,7 +233,7 @@ class MultipleSelectionViewController: UIViewController {
 
     func showMenuForSelection() {
         let floatingPanelViewController = DriveFloatingPanelController()
-        let selectViewController = SelectFloatingPanelTableViewController()
+        let selectViewController = MultipleSelectionFloatingPanelViewController()
         selectViewController.presentingParent = self
         floatingPanelViewController.isRemovalInteractionEnabled = true
         selectViewController.files = Array(selectedItems)

--- a/kDrive/UI/Controller/Files/SelectFloatingPanelTableViewController.swift
+++ b/kDrive/UI/Controller/Files/SelectFloatingPanelTableViewController.swift
@@ -20,13 +20,17 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-class SelectFloatingPanelTableViewController: FileActionsFloatingPanelViewController {
+class SelectFloatingPanelTableViewController: UICollectionViewController {
     var files: [File]!
     var changedFiles: [File]? = []
     var downloadInProgress = false
     var reloadAction: (() -> Void)?
 
-    override class var sections: [Section] {
+    enum Section: CaseIterable {
+        case header, quickActions, actions
+    }
+
+    class var sections: [Section] {
         return [.actions]
     }
 

--- a/kDrive/UI/Controller/Files/SelectFloatingPanelTableViewController.swift
+++ b/kDrive/UI/Controller/Files/SelectFloatingPanelTableViewController.swift
@@ -21,10 +21,17 @@ import kDriveResources
 import UIKit
 
 class SelectFloatingPanelTableViewController: UICollectionViewController {
+    var driveFileManager: DriveFileManager!
     var files: [File]!
     var changedFiles: [File]? = []
     var downloadInProgress = false
     var reloadAction: (() -> Void)?
+
+    weak var presentingParent: UIViewController?
+
+    var sharedWithMe: Bool {
+        return driveFileManager?.drive.sharedWithMe ?? false
+    }
 
     enum Section: CaseIterable {
         case header, quickActions, actions
@@ -33,6 +40,8 @@ class SelectFloatingPanelTableViewController: UICollectionViewController {
     class var sections: [Section] {
         return [.actions]
     }
+
+    var actions = FloatingPanelAction.listActions
 
     var filesAvailableOffline: Bool {
         return files.allSatisfy(\.isAvailableOffline)
@@ -53,7 +62,7 @@ class SelectFloatingPanelTableViewController: UICollectionViewController {
         setupContent()
     }
 
-    override func setupContent() {
+    func setupContent() {
         if sharedWithMe {
             actions = FloatingPanelAction.multipleSelectionSharedWithMeActions
         } else if files.count > Constants.bulkActionThreshold {
@@ -63,7 +72,7 @@ class SelectFloatingPanelTableViewController: UICollectionViewController {
         }
     }
 
-    override func handleAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
+    func handleAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
         let action = actions[indexPath.row]
         var success = true
         var addAction = true
@@ -239,7 +248,7 @@ class SelectFloatingPanelTableViewController: UICollectionViewController {
         }
     }
 
-    override func track(action: FloatingPanelAction) {
+    func track(action: FloatingPanelAction) {
         let numberOfFiles = files.count
         switch action {
         // Quick Actions

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -26,6 +26,8 @@ public class FileActionsHelper {
 
     private var interactionController: UIDocumentInteractionController!
 
+    // MARK: - Single file
+
     public func openWith(file: File, from rect: CGRect, in view: UIView, delegate: UIDocumentInteractionControllerDelegate) {
         guard let rootFolderURL = DriveFileManager.constants.openInPlaceDirectoryURL else {
             DDLogError("Open in place directory not found")
@@ -106,6 +108,8 @@ public class FileActionsHelper {
         }
     }
 
+    // MARK: - Single file and multiselection
+
     public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: @escaping (File, Bool, Error?) -> Void) -> DispatchGroup {
         let isFavorite = files.allSatisfy(\.isFavorite)
         let group = DispatchGroup()
@@ -114,8 +118,8 @@ public class FileActionsHelper {
             let isFavored = !isFavorite
             driveFileManager.setFavoriteFile(file: file, favorite: isFavored) { error in
                 completion(file, isFavored, error)
+                group.leave()
             }
-            group.leave()
         }
         return group
     }

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -142,6 +142,8 @@ public class FileActionsHelper {
         return group
     }
 
+    #if !ISEXTENSION
+
     public static func folderColor(files: [File], driveFileManager: DriveFileManager, with viewController: UIViewController,
                                    presentingParent: UIViewController?, completion: @escaping (Bool) -> Void) -> DispatchGroup {
         let group = DispatchGroup()
@@ -173,4 +175,6 @@ public class FileActionsHelper {
         }
         return group
     }
+
+    #endif
 }

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -67,7 +67,7 @@ public class FileActionsHelper {
         }
     }
 
-    public static func save(file: File, with viewController: UIViewController) {
+    public static func save(file: File, from viewController: UIViewController) {
         switch file.convertedType {
         case .image:
             if let image = UIImage(contentsOfFile: file.localUrl.path) {
@@ -110,12 +110,13 @@ public class FileActionsHelper {
 
     // MARK: - Single file and multiselection
 
-    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: @escaping (File, Bool, Error?) -> Void) -> DispatchGroup {
-        let isFavorite = files.allSatisfy(\.isFavorite)
+    public static func favorite(files: [File], driveFileManager: DriveFileManager,
+                                completion: @escaping (File, Bool, Error?) -> Void) -> DispatchGroup {
         let group = DispatchGroup()
-        for file in files where file.rights?.canFavorite != false {
+        let areFilesFavorites = files.allSatisfy(\.isFavorite)
+        let isFavored = !areFilesFavorites
+        for file in files where file.rights?.canFavorite == true {
             group.enter()
-            let isFavored = !isFavorite
             driveFileManager.setFavoriteFile(file: file, favorite: isFavored) { error in
                 completion(file, isFavored, error)
                 group.leave()
@@ -124,7 +125,8 @@ public class FileActionsHelper {
         return group
     }
 
-    public static func availableOffline(files: [File], at indexPath: IndexPath, driveFileManager: DriveFileManager, filesNotAvailable: (IndexPath) -> Void, completion: @escaping (File, Error?) -> Void) -> DispatchGroup {
+    public static func offline(files: [File], at indexPath: IndexPath, driveFileManager: DriveFileManager,
+                               filesNotAvailable: (IndexPath) -> Void, completion: @escaping (File, Error?) -> Void) -> DispatchGroup {
         let isAvailableOffline = files.allSatisfy(\.isAvailableOffline)
         if !isAvailableOffline {
             filesNotAvailable(indexPath)
@@ -140,7 +142,8 @@ public class FileActionsHelper {
         return group
     }
 
-    public static func folderColor(files: [File], driveFileManager: DriveFileManager, with viewController: UIViewController, presentingParent: UIViewController?, completion: @escaping (Bool) -> Void) -> DispatchGroup {
+    public static func folderColor(files: [File], driveFileManager: DriveFileManager, with viewController: UIViewController,
+                                   presentingParent: UIViewController?, completion: @escaping (Bool) -> Void) -> DispatchGroup {
         let group = DispatchGroup()
         group.enter()
         if driveFileManager.drive.pack == .free {

--- a/kDrive/Utils/MatomoUtils.swift
+++ b/kDrive/Utils/MatomoUtils.swift
@@ -143,53 +143,55 @@ class MatomoUtils {
 
     #if !ISEXTENSION
 
-    static func trackFileAction(action: FloatingPanelAction, file: File) {
+    static func trackFileAction(action: FloatingPanelAction, file: File, fromPhotoList: Bool) {
+        let category: EventCategory = fromPhotoList ? .picturesFileAction : .fileListFileAction
         switch action {
         // Quick Actions
         case .sendCopy:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "sendFileCopy")
+            track(eventWithCategory: category, name: "sendFileCopy")
         case .shareLink:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "copyShareLink")
+            track(eventWithCategory: category, name: "copyShareLink")
         case .informations:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "openFileInfos")
+            track(eventWithCategory: category, name: "openFileInfos")
         // Actions
         case .duplicate:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "copy")
+            track(eventWithCategory: category, name: "copy")
         case .move:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "move")
+            track(eventWithCategory: category, name: "move")
         case .download:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "download")
+            track(eventWithCategory: category, name: "download")
         case .favorite:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "favorite", value: !file.isFavorite)
+            track(eventWithCategory: category, name: "favorite", value: !file.isFavorite)
         case .offline:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "offline", value: !file.isAvailableOffline)
+            track(eventWithCategory: category, name: "offline", value: !file.isAvailableOffline)
         case .rename:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "rename")
+            track(eventWithCategory: category, name: "rename")
         case .delete:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "putInTrash")
+            track(eventWithCategory: category, name: "putInTrash")
         case .convertToDropbox:
-            MatomoUtils.track(eventWithCategory: .fileAction, name: "convertToDropBox")
+            track(eventWithCategory: category, name: "convertToDropBox")
         default:
             break
         }
     }
 
-    static func trackBulkAction(action: FloatingPanelAction, files: [File]) {
+    static func trackBulkAction(action: FloatingPanelAction, files: [File], fromPhotoList: Bool) {
         let numberOfFiles = files.count
+        let category: EventCategory = fromPhotoList ? .picturesFileAction : .fileListFileAction
         switch action {
         // Quick Actions
         case .duplicate:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "copy", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "copy", numberOfItems: numberOfFiles)
         case .download:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "download", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "download", numberOfItems: numberOfFiles)
         case .favorite:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "add_favorite", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "add_favorite", numberOfItems: numberOfFiles)
         case .offline:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "set_offline", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "set_offline", numberOfItems: numberOfFiles)
         case .delete:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "trash", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "trash", numberOfItems: numberOfFiles)
         case .folderColor:
-            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "color_folder", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "color_folder", numberOfItems: numberOfFiles)
         default:
             break
         }

--- a/kDrive/Utils/MatomoUtils.swift
+++ b/kDrive/Utils/MatomoUtils.swift
@@ -138,4 +138,62 @@ class MatomoUtils {
     static func trackMediaPlayer(leaveAt percentage: Double?) {
         track(eventWithCategory: .mediaPlayer, name: "duration", value: Float(percentage ?? 0))
     }
+
+    // MARK: - File action
+
+    #if !ISEXTENSION
+
+    static func trackFileAction(action: FloatingPanelAction, file: File) {
+        switch action {
+        // Quick Actions
+        case .sendCopy:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "sendFileCopy")
+        case .shareLink:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "copyShareLink")
+        case .informations:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "openFileInfos")
+        // Actions
+        case .duplicate:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "copy")
+        case .move:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "move")
+        case .download:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "download")
+        case .favorite:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "favorite", value: !file.isFavorite)
+        case .offline:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "offline", value: !file.isAvailableOffline)
+        case .rename:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "rename")
+        case .delete:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "putInTrash")
+        case .convertToDropbox:
+            MatomoUtils.track(eventWithCategory: .fileAction, name: "convertToDropBox")
+        default:
+            break
+        }
+    }
+
+    static func trackBulkAction(action: FloatingPanelAction, files: [File]) {
+        let numberOfFiles = files.count
+        switch action {
+        // Quick Actions
+        case .duplicate:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "copy", numberOfItems: numberOfFiles)
+        case .download:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "download", numberOfItems: numberOfFiles)
+        case .favorite:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "add_favorite", numberOfItems: numberOfFiles)
+        case .offline:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "set_offline", numberOfItems: numberOfFiles)
+        case .delete:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "trash", numberOfItems: numberOfFiles)
+        case .folderColor:
+            MatomoUtils.trackBulkEvent(eventWithCategory: .fileAction, name: "color_folder", numberOfItems: numberOfFiles)
+        default:
+            break
+        }
+    }
+
+    #endif
 }

--- a/kDriveCore/Utils/FileActionsHelper.swift
+++ b/kDriveCore/Utils/FileActionsHelper.swift
@@ -76,4 +76,19 @@ public class FileActionsHelper {
             group.leave()
         }
     }
+
+    public static func availableOffline(files: [File], at indexPath: IndexPath, driveFileManager: DriveFileManager, filesNotAvailable: (IndexPath) -> Void, completion: @escaping (File, Error?) -> Void) {
+        let isAvailableOffline = files.allSatisfy(\.isAvailableOffline)
+        if !isAvailableOffline {
+            filesNotAvailable(indexPath)
+        }
+        let group = DispatchGroup()
+        for file in files where !file.isDirectory && file.isAvailableOffline == isAvailableOffline {
+            group.enter()
+            driveFileManager.setFileAvailableOffline(file: file, available: !isAvailableOffline) { error in
+                completion(file, error)
+                group.leave()
+            }
+        }
+    }
 }

--- a/kDriveCore/Utils/FileActionsHelper.swift
+++ b/kDriveCore/Utils/FileActionsHelper.swift
@@ -63,4 +63,17 @@ public class FileActionsHelper {
             UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.errorGeneric)
         }
     }
+
+    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: @escaping (File, Bool, Error?) -> Void) {
+        let isFavorite = files.allSatisfy(\.isFavorite)
+        let group = DispatchGroup()
+        for file in files where file.rights?.canFavorite != false {
+            group.enter()
+            let isFavored = !isFavorite
+            driveFileManager.setFavoriteFile(file: file, favorite: isFavored) { error in
+                completion(file, isFavored, error)
+            }
+            group.leave()
+        }
+    }
 }


### PR DESCRIPTION
- Rename `SelectFloatingPanelTableViewController` to `MultipleSelectionFloatingPanelViewController`
- Refactor file actions used in both `MultipleSelectionFloatingPanelViewController` and `FileActionsFloatingPanelViewController` in `FileActionsHelper`