### PR TITLE
Increase argument count limit swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,3 +32,4 @@ opt_in_rules:
 excluded:
  - .tuist-bin/*
  - Derived/Sources/*
+function_parameter_count: 7


### PR DESCRIPTION
Increase argument count limit for swiftlint to stay consistant with sonarcloud