### PR TITLE
Refactor SelectFloatingPanelTableViewController

### DIFF
--- a/kDrive/UI/Controller/Create File/PlusButtonFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Create File/PlusButtonFloatingPanelViewController.swift
@@ -191,7 +191,7 @@ class PlusButtonFloatingPanelViewController: UITableViewController, FloatingPane
                 guard sourceType != .camera || AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
                     let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.cameraAccessDeniedTitle, message: KDriveResourcesStrings.Localizable.cameraAccessDeniedDescription, action: KDriveResourcesStrings.Localizable.buttonGoToSettings) {
                         if let settingsUrl = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(settingsUrl) {
-                            UIApplication.shared.open(settingsUrl)
+                            await UIApplication.shared.open(settingsUrl)
                         }
                     }
                     mainTabViewController.present(alert, animated: true)

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -439,6 +439,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
             case .multipleSelection:
                 floatingPanelViewController = AdaptiveDriveFloatingPanelController()
                 let selectViewController = MultipleSelectionFloatingPanelViewController()
+                selectViewController.presentingParent = self
 
                 if viewModel.multipleSelectionViewModel?.isSelectAllModeEnabled == true {
                     selectViewController.allItemsSelected = true

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -438,7 +438,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
                 (floatingPanelViewController as? AdaptiveDriveFloatingPanelController)?.trackAndObserve(scrollView: trashFloatingPanelTableViewController.tableView)
             case .multipleSelection:
                 floatingPanelViewController = AdaptiveDriveFloatingPanelController()
-                let selectViewController = SelectFloatingPanelTableViewController()
+                let selectViewController = MultipleSelectionFloatingPanelViewController()
 
                 if viewModel.multipleSelectionViewModel?.isSelectAllModeEnabled == true {
                     selectViewController.allItemsSelected = true

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -376,7 +376,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             Task {
                 do {
                     let isFavored = try await FileActionsHelper.favorite(files: [file], driveFileManager: driveFileManager)
-                    if !isFavored {
+                    if isFavored {
                         UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListAddFavorisConfirmationSnackbar(1))
                     }
                 } catch {

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -405,7 +405,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             presentingParent?.navigationController?.pushViewController(viewController, animated: true)
             dismiss(animated: true)
         case .folderColor:
-            FileActionsHelper.folderColor(files: [file], driveFileManager: driveFileManager, from: self, presentingParent: presentingParent) { <#Bool#> in
+            FileActionsHelper.folderColor(files: [file], driveFileManager: driveFileManager, from: self, presentingParent: presentingParent) { isSuccess in
                 if isSuccess {
                     UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListColorFolderConfirmationSnackbar(1))
                 }
@@ -415,11 +415,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             FilePresenter(viewController: viewController).presentParent(of: file, driveFileManager: driveFileManager)
             dismiss(animated: true)
         case .offline:
-            if !file.isAvailableOffline {
-                // Update offline files before setting new file to synchronize them
-                (UIApplication.shared.delegate as? AppDelegate)?.updateAvailableOfflineFiles(status: ReachabilityListener.instance.currentStatus)
-            }
-            driveFileManager.setFileAvailableOffline(file: file, available: !file.isAvailableOffline) { error in
+            FileActionsHelper.offline(files: [file], driveFileManager: driveFileManager, filesNotAvailable: nil) { _, error in
                 if error != nil && error as? DriveError != .taskCancelled && error as? DriveError != .taskRescheduled {
                     UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.errorCache)
                 }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -405,30 +405,9 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             presentingParent?.navigationController?.pushViewController(viewController, animated: true)
             dismiss(animated: true)
         case .folderColor:
-            if driveFileManager.drive.pack == .free {
-                let driveFloatingPanelController = FolderColorFloatingPanelViewController.instantiatePanel()
-                let floatingPanelViewController = driveFloatingPanelController.contentViewController as? FolderColorFloatingPanelViewController
-                floatingPanelViewController?.rightButton.isEnabled = driveFileManager.drive.accountAdmin
-                floatingPanelViewController?.actionHandler = { _ in
-                    driveFloatingPanelController.dismiss(animated: true) {
-                        StorePresenter.showStore(from: self, driveFileManager: self.driveFileManager)
-                    }
-                }
-                present(driveFloatingPanelController, animated: true)
-            } else {
-                let colorSelectionFloatingPanelViewController = ColorSelectionFloatingPanelViewController(files: [file], driveFileManager: driveFileManager)
-                let floatingPanelViewController = DriveFloatingPanelController()
-                floatingPanelViewController.isRemovalInteractionEnabled = true
-                floatingPanelViewController.set(contentViewController: colorSelectionFloatingPanelViewController)
-                floatingPanelViewController.track(scrollView: colorSelectionFloatingPanelViewController.collectionView)
-                colorSelectionFloatingPanelViewController.floatingPanelController = floatingPanelViewController
-                colorSelectionFloatingPanelViewController.completionHandler = { isSuccess in
-                    if isSuccess {
-                        UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListColorFolderConfirmationSnackbar(1))
-                    }
-                }
-                dismiss(animated: true) {
-                    self.presentingParent?.present(floatingPanelViewController, animated: true)
+            FileActionsHelper.folderColor(files: [file], driveFileManager: driveFileManager, from: self, presentingParent: presentingParent) { <#Bool#> in
+                if isSuccess {
+                    UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.fileListColorFolderConfirmationSnackbar(1))
                 }
             }
         case .seeFolder:

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -448,7 +448,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])
         case .download:
             if file.isMostRecentDownloaded {
-                save(file: file)
+                FileActionsHelper.save(file: file, from: self)
             } else if let operation = DownloadQueue.instance.operation(for: file) {
                 // Download is already scheduled, ask to cancel
                 let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.cancelDownloadTitle, message: KDriveResourcesStrings.Localizable.cancelDownloadDescription, action: KDriveResourcesStrings.Localizable.buttonYes, destructive: true) {
@@ -457,8 +457,9 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
                 present(alert, animated: true)
             } else {
                 downloadFile(action: action, indexPath: indexPath) { [weak self] in
-                    if let file = self?.file {
-                        self?.save(file: file)
+                    guard let self = self else { return }
+                    if let file = self.file {
+                        FileActionsHelper.save(file: file, from: self)
                     }
                 }
             }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -548,37 +548,6 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    internal func track(action: FloatingPanelAction) {
-        switch action {
-        // Quick Actions
-        case .sendCopy:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "sendFileCopy")
-        case .shareLink:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "copyShareLink")
-        case .informations:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "openFileInfos")
-        // Actions
-        case .duplicate:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "copy")
-        case .move:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "move")
-        case .download:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "download")
-        case .favorite:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "favorite", value: !file.isFavorite)
-        case .offline:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "offline", value: !file.isAvailableOffline)
-        case .rename:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "rename")
-        case .delete:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "putInTrash")
-        case .convertToDropbox:
-            MatomoUtils.track(eventWithCategory: matomoCategory, name: "convertToDropBox")
-        default:
-            break
-        }
-    }
-
     private func setLoading(_ isLoading: Bool, action: FloatingPanelAction, at indexPath: IndexPath) {
         action.isLoading = isLoading
         DispatchQueue.main.async { [weak self] in
@@ -675,7 +644,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         case .actions:
             action = actions[indexPath.item]
         }
-        track(action: action)
+        MatomoUtils.trackFileAction(action: action, file: file, fromPhotoList: presentingParent is PhotoListViewController)
         handleAction(action, at: indexPath)
     }
 }

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -99,10 +99,8 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             group.enter()
             Task {
                 let isFavored = try await FileActionsHelper.favorite(files: files, driveFileManager: driveFileManager) { file in
-                    await MainActor.run {
-                        if let file = self.driveFileManager.getCachedFile(id: file.id) {
-                            self.changedFiles?.append(file)
-                        }
+                    if let file = self.driveFileManager.getCachedFile(id: file.id) {
+                        self.changedFiles?.append(file)
                     }
                 }
                 addAction = isFavored
@@ -212,27 +210,6 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    func track(action: FloatingPanelAction) {
-        let numberOfFiles = files.count
-        switch action {
-        // Quick Actions
-        case .duplicate:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "copy", numberOfItems: numberOfFiles)
-        case .download:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "download", numberOfItems: numberOfFiles)
-        case .favorite:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "add_favorite", numberOfItems: numberOfFiles)
-        case .offline:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "set_offline", numberOfItems: numberOfFiles)
-        case .delete:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "trash", numberOfItems: numberOfFiles)
-        case .folderColor:
-            MatomoUtils.trackBulkEvent(eventWithCategory: matomoCategory, name: "color_folder", numberOfItems: numberOfFiles)
-        default:
-            break
-        }
-    }
-
     // MARK: - Private methods
 
     @MainActor
@@ -317,7 +294,6 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let action = actions[indexPath.item]
         handleAction(action, at: indexPath)
-        // TODO: Add matomo
-        track(action: action)
+        MatomoUtils.trackBuklAction(action: action, files: files, fromPhotoList: presentingParent is PhotoListViewController)
     }
 }

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -116,7 +116,6 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                         operation.cancel()
                     }
                     present(alert, animated: true)
-                    return
                 } else {
                     downloadedArchiveUrl = nil
                     downloadInProgress = true

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -98,11 +98,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
         case .favorite:
             group.enter()
             Task {
-                let isFavored = try await FileActionsHelper.favorite(files: files, driveFileManager: driveFileManager) { file in
-                    if let file = self.driveFileManager.getCachedFile(id: file.id) {
-                        self.changedFiles?.append(file)
-                    }
-                }
+                let isFavored = try await FileActionsHelper.favorite(files: files, driveFileManager: driveFileManager, completion: favorite)
                 addAction = isFavored
                 group.leave()
             }
@@ -271,6 +267,14 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
             return NSCollectionLayoutSection(group: group)
+        }
+    }
+
+    private func favorite(file: File) async {
+        if let file = self.driveFileManager.getCachedFile(id: file.id) {
+            await MainActor.run {
+                self.changedFiles?.append(file)
+            }
         }
     }
 

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -84,6 +84,18 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
 
         switch action {
         case .offline:
+            FileActionsHelper.offline(files: files, driveFileManager: driveFileManager) {
+                self.downloadInProgress = true
+                self.collectionView.reloadItems(at: [indexPath])
+            } completion: { file, error in
+                if error != nil {
+                    self.success = false
+                }
+                if let file = self.driveFileManager.getCachedFile(id: file.id) {
+                    self.changedFiles?.append(file)
+                }
+            }
+
             let isAvailableOffline = filesAvailableOffline
             addAction = !isAvailableOffline
             if !isAvailableOffline {

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -84,7 +84,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
 
         switch action {
         case .offline:
-            addAction = FileActionsHelper.offline(files: files, driveFileManager: driveFileManager) {
+            addAction = FileActionsHelper.offline(files: files, driveFileManager: driveFileManager, group: group) {
                 self.downloadInProgress = true
                 self.collectionView.reloadItems(at: [indexPath])
             } completion: { file, error in
@@ -109,10 +109,9 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                 group.leave()
             }
         case .folderColor:
-            group.enter()
-            FileActionsHelper.folderColor(files: files, driveFileManager: driveFileManager, from: self, presentingParent: presentingParent) { isSuccess in
+            FileActionsHelper.folderColor(files: files, driveFileManager: driveFileManager, from: self,
+                                          presentingParent: presentingParent, group: group) { isSuccess in
                 self.success = isSuccess
-                group.leave()
             }
         case .download:
             if files.count > Constants.bulkActionThreshold || allItemsSelected || files.contains(where: \.isDirectory) {

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -60,6 +60,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        collectionView.register(cellView: FloatingPanelActionCollectionViewCell.self)
         collectionView.alwaysBounceVertical = false
         setupContent()
     }
@@ -383,6 +384,14 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
     }
 
     // MARK: - Collection view data source
+
+    override func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return actions.count
+    }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(type: FloatingPanelActionCollectionViewCell.self, for: indexPath)

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -119,30 +119,9 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
             }
         case .folderColor:
             group.enter()
-            if driveFileManager.drive.pack == .free {
-                let driveFloatingPanelController = FolderColorFloatingPanelViewController.instantiatePanel()
-                let floatingPanelViewController = driveFloatingPanelController.contentViewController as? FolderColorFloatingPanelViewController
-                floatingPanelViewController?.rightButton.isEnabled = driveFileManager.drive.accountAdmin
-                floatingPanelViewController?.actionHandler = { _ in
-                    driveFloatingPanelController.dismiss(animated: true) {
-                        StorePresenter.showStore(from: self, driveFileManager: self.driveFileManager)
-                    }
-                }
-                present(driveFloatingPanelController, animated: true)
-            } else {
-                let colorSelectionFloatingPanelViewController = ColorSelectionFloatingPanelViewController(files: files, driveFileManager: driveFileManager)
-                let floatingPanelViewController = DriveFloatingPanelController()
-                floatingPanelViewController.isRemovalInteractionEnabled = true
-                floatingPanelViewController.set(contentViewController: colorSelectionFloatingPanelViewController)
-                floatingPanelViewController.track(scrollView: colorSelectionFloatingPanelViewController.collectionView)
-                colorSelectionFloatingPanelViewController.floatingPanelController = floatingPanelViewController
-                colorSelectionFloatingPanelViewController.completionHandler = { isSuccess in
-                    self.success = isSuccess
-                    group.leave()
-                }
-                dismiss(animated: true) {
-                    self.presentingParent?.present(floatingPanelViewController, animated: true)
-                }
+            FileActionsHelper.folderColor(files: files, driveFileManager: driveFileManager, from: self, presentingParent: presentingParent) { isSuccess in
+                self.success = isSuccess
+                group.leave()
             }
         case .download:
             if files.count > Constants.bulkActionThreshold || allItemsSelected || files.contains(where: \.isDirectory) {

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -19,7 +19,7 @@
 import CocoaLumberjackSwift
 import kDriveResources
 import UIKit
-import kDriveCore
+import kDrive
 
 @MainActor
 public class FileActionsHelper {
@@ -146,5 +146,32 @@ public class FileActionsHelper {
         }
 
         return isFavored
+    }
+
+    public static func folderColor(files: [File], driveFileManager: DriveFileManager, from viewController: UIViewController, presentingParent: UIViewController?, completion: (Bool) -> Void) {
+        if driveFileManager.drive.pack == .free {
+            let driveFloatingPanelController = FolderColorFloatingPanelViewController.instantiatePanel()
+            let floatingPanelViewController = driveFloatingPanelController.contentViewController as? FolderColorFloatingPanelViewController
+            floatingPanelViewController?.rightButton.isEnabled = driveFileManager.drive.accountAdmin
+            floatingPanelViewController?.actionHandler = { _ in
+                driveFloatingPanelController.dismiss(animated: true) {
+                    StorePresenter.showStore(from: self, driveFileManager: self.driveFileManager)
+                }
+            }
+            viewController.present(driveFloatingPanelController, animated: true)
+        } else {
+            let colorSelectionFloatingPanelViewController = ColorSelectionFloatingPanelViewController(files: files, driveFileManager: driveFileManager)
+            let floatingPanelViewController = DriveFloatingPanelController()
+            floatingPanelViewController.isRemovalInteractionEnabled = true
+            floatingPanelViewController.set(contentViewController: colorSelectionFloatingPanelViewController)
+            floatingPanelViewController.track(scrollView: colorSelectionFloatingPanelViewController.collectionView)
+            colorSelectionFloatingPanelViewController.floatingPanelController = floatingPanelViewController
+            colorSelectionFloatingPanelViewController.completionHandler = { isSuccess in
+                completion(isSuccess)
+            }
+            viewController.dismiss(animated: true) {
+                presentingParent?.present(floatingPanelViewController, animated: true)
+            }
+        }
     }
 }

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -151,20 +151,22 @@ public class FileActionsHelper {
 
     #if !ISEXTENSION
 
-    public static func offline(files: [File], driveFileManager: DriveFileManager, filesNotAvailable: (() -> Void)?, completion: @escaping (File, Error?) -> Void) {
-        let isAvailableOffline = files.allSatisfy(\.isAvailableOffline)
-
-        if !isAvailableOffline {
+    public static func offline(files: [File], driveFileManager: DriveFileManager, filesNotAvailable: (() -> Void)?, completion: @escaping (File, Error?) -> Void) -> Bool {
+        let areAvailableOffline = files.allSatisfy(\.isAvailableOffline)
+        let makeFilesAvailableOffline = !areAvailableOffline
+        if makeFilesAvailableOffline {
             filesNotAvailable?()
             // Update offline files before setting new file to synchronize them
             (UIApplication.shared.delegate as? AppDelegate)?.updateAvailableOfflineFiles(status: ReachabilityListener.instance.currentStatus)
         }
 
-        for file in files where !file.isDirectory && file.isAvailableOffline == isAvailableOffline {
-            driveFileManager.setFileAvailableOffline(file: file, available: !isAvailableOffline) { error in
+        for file in files where !file.isDirectory && file.isAvailableOffline == areAvailableOffline {
+            driveFileManager.setFileAvailableOffline(file: file, available: makeFilesAvailableOffline) { error in
                 completion(file, error)
             }
         }
+
+        return makeFilesAvailableOffline
     }
 
     public static func folderColor(files: [File], driveFileManager: DriveFileManager, from viewController: UIViewController, presentingParent: UIViewController?, completion: @escaping (Bool) -> Void) {

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -133,16 +133,14 @@ public class FileActionsHelper {
 
     // MARK: - Single file or multiselection
 
-    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: ((File) -> Void)? = nil) async throws -> Bool {
+    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: ((File) -> async Void)? = nil) async throws -> Bool {
         let areFilesFavorites = files.allSatisfy(\.isFavorite)
         let areFavored = !areFilesFavorites
         try await withThrowingTaskGroup(of: Void.self) { group in
             for file in files where file.capabilities.canUseFavorite {
                 group.addTask { [frozenFile = file.freezeIfNeeded()] in
                     try await driveFileManager.setFavorite(file: frozenFile, favorite: areFavored)
-                    await MainActor.run {
-                        completion?(file)
-                    }
+                    await completion?(file)
                 }
             }
             try await group.waitForAll()

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -133,7 +133,7 @@ public class FileActionsHelper {
 
     // MARK: - Single file or multiselection
 
-    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: ((File) -> async Void)? = nil) async throws -> Bool {
+    public static func favorite(files: [File], driveFileManager: DriveFileManager, completion: ((File) async -> Void)? = nil) async throws -> Bool {
         let areFilesFavorites = files.allSatisfy(\.isFavorite)
         let areFavored = !areFilesFavorites
         try await withThrowingTaskGroup(of: Void.self) { group in

--- a/kDrive/Utils/MatomoUtils.swift
+++ b/kDrive/Utils/MatomoUtils.swift
@@ -144,31 +144,32 @@ class MatomoUtils {
     #if !ISEXTENSION
 
     static func trackFileAction(action: FloatingPanelAction, file: File, fromPhotoList: Bool) {
+        let category: EventCategory = fromPhotoList ? .picturesFileAction : .fileListFileAction
         switch action {
         // Quick Actions
         case .sendCopy:
-            track(eventWithCategory: .fileAction, name: "sendFileCopy")
+            track(eventWithCategory: category, name: "sendFileCopy")
         case .shareLink:
-            track(eventWithCategory: .fileAction, name: "copyShareLink")
+            track(eventWithCategory: category, name: "copyShareLink")
         case .informations:
-            track(eventWithCategory: .fileAction, name: "openFileInfos")
+            track(eventWithCategory: category, name: "openFileInfos")
         // Actions
         case .duplicate:
-            track(eventWithCategory: .fileAction, name: "copy")
+            track(eventWithCategory: category, name: "copy")
         case .move:
-            track(eventWithCategory: .fileAction, name: "move")
+            track(eventWithCategory: category, name: "move")
         case .download:
-            track(eventWithCategory: .fileAction, name: "download")
+            track(eventWithCategory: category, name: "download")
         case .favorite:
-            track(eventWithCategory: .fileAction, name: "favorite", value: !file.isFavorite)
+            track(eventWithCategory: category, name: "favorite", value: !file.isFavorite)
         case .offline:
-            track(eventWithCategory: .fileAction, name: "offline", value: !file.isAvailableOffline)
+            track(eventWithCategory: category, name: "offline", value: !file.isAvailableOffline)
         case .rename:
-            track(eventWithCategory: .fileAction, name: "rename")
+            track(eventWithCategory: category, name: "rename")
         case .delete:
-            track(eventWithCategory: .fileAction, name: "putInTrash")
+            track(eventWithCategory: category, name: "putInTrash")
         case .convertToDropbox:
-            track(eventWithCategory: .fileAction, name: "convertToDropBox")
+            track(eventWithCategory: category, name: "convertToDropBox")
         default:
             break
         }
@@ -176,20 +177,21 @@ class MatomoUtils {
 
     static func trackBuklAction(action: FloatingPanelAction, files: [File], fromPhotoList: Bool) {
         let numberOfFiles = files.count
+        let category: EventCategory = fromPhotoList ? .picturesFileAction : .fileListFileAction
         switch action {
         // Quick Actions
         case .duplicate:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "copy", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "copy", numberOfItems: numberOfFiles)
         case .download:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "download", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "download", numberOfItems: numberOfFiles)
         case .favorite:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "add_favorite", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "add_favorite", numberOfItems: numberOfFiles)
         case .offline:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "set_offline", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "set_offline", numberOfItems: numberOfFiles)
         case .delete:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "trash", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "trash", numberOfItems: numberOfFiles)
         case .folderColor:
-            trackBulkEvent(eventWithCategory: .fileAction, name: "color_folder", numberOfItems: numberOfFiles)
+            trackBulkEvent(eventWithCategory: category, name: "color_folder", numberOfItems: numberOfFiles)
         default:
             break
         }

--- a/kDrive/Utils/MatomoUtils.swift
+++ b/kDrive/Utils/MatomoUtils.swift
@@ -138,4 +138,62 @@ class MatomoUtils {
     static func trackMediaPlayer(leaveAt percentage: Double?) {
         track(eventWithCategory: .mediaPlayer, name: "duration", value: Float(percentage ?? 0))
     }
+
+    // MARK: - File action
+
+    #if !ISEXTENSION
+
+    static func trackFileAction(action: FloatingPanelAction, file: File, fromPhotoList: Bool) {
+        switch action {
+        // Quick Actions
+        case .sendCopy:
+            track(eventWithCategory: .fileAction, name: "sendFileCopy")
+        case .shareLink:
+            track(eventWithCategory: .fileAction, name: "copyShareLink")
+        case .informations:
+            track(eventWithCategory: .fileAction, name: "openFileInfos")
+        // Actions
+        case .duplicate:
+            track(eventWithCategory: .fileAction, name: "copy")
+        case .move:
+            track(eventWithCategory: .fileAction, name: "move")
+        case .download:
+            track(eventWithCategory: .fileAction, name: "download")
+        case .favorite:
+            track(eventWithCategory: .fileAction, name: "favorite", value: !file.isFavorite)
+        case .offline:
+            track(eventWithCategory: .fileAction, name: "offline", value: !file.isAvailableOffline)
+        case .rename:
+            track(eventWithCategory: .fileAction, name: "rename")
+        case .delete:
+            track(eventWithCategory: .fileAction, name: "putInTrash")
+        case .convertToDropbox:
+            track(eventWithCategory: .fileAction, name: "convertToDropBox")
+        default:
+            break
+        }
+    }
+
+    static func trackBuklAction(action: FloatingPanelAction, files: [File], fromPhotoList: Bool) {
+        let numberOfFiles = files.count
+        switch action {
+        // Quick Actions
+        case .duplicate:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "copy", numberOfItems: numberOfFiles)
+        case .download:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "download", numberOfItems: numberOfFiles)
+        case .favorite:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "add_favorite", numberOfItems: numberOfFiles)
+        case .offline:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "set_offline", numberOfItems: numberOfFiles)
+        case .delete:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "trash", numberOfItems: numberOfFiles)
+        case .folderColor:
+            trackBulkEvent(eventWithCategory: .fileAction, name: "color_folder", numberOfItems: numberOfFiles)
+        default:
+            break
+        }
+    }
+
+    #endif
 }


### PR DESCRIPTION
- Rename `SelectFloatingPanelTableViewController` to `MultipleSelectionFloatingPanelViewController`
- Refactor file actions used in both `MultipleSelectionFloatingPanelViewController` and `FileActionsFloatingPanelViewController` in `FileActionsHelper`