### PR TITLE
Small fixes

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -61,6 +61,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
 
         registerBackgroundTasks()
 
+        // In some cases the application can show the old Nextcloud import notification badge
+        UIApplication.shared.applicationIconBadgeNumber = 0
         NotificationsHelper.askForPermissions()
         NotificationsHelper.registerCategories()
         UNUserNotificationCenter.current().delegate = self

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -540,7 +540,8 @@ public class File: Object, Codable {
                 if let image = try? result.get().image {
                     completion(image, true)
                 } else {
-                    completion(self.icon, false)
+                    // The file can become invalidated while retrieving the icon online
+                    completion(self.isInvalidated ? ConvertedType.unknown.icon : self.icon, false)
                 }
             }
         } else {


### PR DESCRIPTION
- Fix: In some cases users could have a badge of pending upload count (from the old nextcloud app)
- Fix: If a file is removed from realm before thumbnail fetch, realm crashes