### PR TITLE
Cancel task before creating background task

### DIFF
--- a/kDriveCore/Data/UploadQueue/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/UploadOperation.swift
@@ -336,7 +336,7 @@ public class UploadOperation: Operation {
     }
 
     private func end() {
-        DDLogInfo("[UploadOperation] Job \(file.id) ended error: \(file.error?.code ?? "")")
+        DDLogInfo("[UploadOperation] Job \(file.id) ended")
 
         if let path = file.pathURL,
            file.shouldRemoveAfterUpload && (file.error == nil || file.error == .taskCancelled) {


### PR DESCRIPTION
When rescheduling an upload due to the background task expiration, the uploaded file was renamed (file -> file (1)) because upload task wasn't canceled.