### PR TITLE
Fix invalid realm

### DIFF
--- a/kDriveCore/Data/Cache/BackgroundRealm.swift
+++ b/kDriveCore/Data/Cache/BackgroundRealm.swift
@@ -116,7 +116,9 @@ public class BackgroundRealm {
         try? realm.safeWrite {
             for write in buffer {
                 realm.add(write.file, update: .all)
-                write.parent?.children.insert(write.file)
+                if write.parent?.isInvalidated == false {
+                    write.parent?.children.insert(write.file)
+                }
             }
         }
         buffer.removeAll()

--- a/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
@@ -59,12 +59,17 @@ public class PhotoLibraryUploader {
     }
 
     private func updateLastSyncDate(_ date: Date, using realm: Realm = DriveFileManager.constants.uploadsRealm) {
-        realm.refresh()
         if let settings = realm.objects(PhotoSyncSettings.self).first {
             try? realm.safeWrite {
-                settings.lastSync = date
+                if !settings.isInvalidated {
+                    settings.lastSync = date
+                }
             }
-            self.settings = PhotoSyncSettings(value: settings)
+            if settings.isInvalidated {
+                self.settings = nil
+            } else {
+                self.settings = PhotoSyncSettings(value: settings)
+            }
         }
     }
 


### PR DESCRIPTION
Realm would crash the app because of an invalid object being accessed for the following reasons:
- Disable photosync while enumerating photos to sync
- Write upload buffer parent with deleted parent