### PR TITLE
Fix migration

### DIFF
--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -183,20 +183,8 @@ public class DriveFileManager {
                     }
                 }
                 if oldSchemaVersion < 5 {
-                    // Get file ids
-                    var fileIds = Set<Int>()
-                    migration.enumerateObjects(ofType: File.className()) { oldObject, _ in
-                        if let id = oldObject?["id"] as? Int {
-                            fileIds.insert(id)
-                        }
-                    }
-                    // Remove dangling rights
-                    migration.enumerateObjects(ofType: Rights.className()) { oldObject, newObject in
-                        guard let newObject = newObject, let fileId = oldObject?["fileId"] as? Int else { return }
-                        if !fileIds.contains(fileId) {
-                            migration.delete(newObject)
-                        }
-                    }
+                    // Remove rights
+                    migration.deleteData(forType: Rights.className())
                     // Delete file categories for migration
                     migration.deleteData(forType: FileCategory.className())
                 }

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -47,6 +47,7 @@ public enum Logging {
             ], key: "Realm")
         }
         #if DEBUG
+            copyDebugInformations()
             DDLogError("Realm files \(realmConfiguration.fileURL?.lastPathComponent ?? "") will be deleted to prevent migration error for next launch")
             _ = try? Realm.deleteFiles(for: realmConfiguration)
         #endif


### PR DESCRIPTION
In some cases migration wasn't working when migrating embedded objects.
Rights are removed as they will be recreated when dowloading files again.