### PR TITLE
Prevent resetting cell status archive download

### DIFF
--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -116,8 +116,10 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                 if downloadInProgress,
                    let currentArchiveId = currentArchiveId,
                    let operation = DownloadQueue.instance.archiveOperationsInQueue[currentArchiveId] {
+                    group.enter()
                     let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.cancelDownloadTitle, message: KDriveResourcesStrings.Localizable.cancelDownloadDescription, action: KDriveResourcesStrings.Localizable.buttonYes, destructive: true) {
                         operation.cancel()
+                        group.leave()
                     }
                     present(alert, animated: true)
                 } else {


### PR DESCRIPTION
When we are downloading an archive in multiple selection if we tap again to cancel the download but don't click cancel, the cell was resetted and lost the download progress.