### PR TITLE
Object "drive_user": updated with "role"

### DIFF
--- a/kDrive/UI/View/Files/FileDetail/ShareLink/UsersAccessTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/ShareLink/UsersAccessTableViewCell.swift
@@ -58,7 +58,7 @@ class UsersAccessTableViewCell: InsetTableViewCell {
             rightsLabel.textColor = blocked ? KDriveResourcesAsset.secondaryTextColor.color : KDriveResourcesAsset.titleColor.color
             detailLabel.text = user.email
             notAcceptedView.isHidden = true
-            externalUserView.isHidden = user.type != .shared
+            externalUserView.isHidden = user.type != .shared || user.role == .external
             accessoryImageView.isHidden = blocked
         } else if let invitation = element as? ExternInvitationFileAccess {
             detailLabel.text = invitation.email

--- a/kDriveCore/Data/Models/DriveUser.swift
+++ b/kDriveCore/Data/Models/DriveUser.swift
@@ -28,6 +28,12 @@ public enum DriveUserType: String, Codable {
     case main
 }
 
+public enum DriveUserRole: String, Codable {
+    case admin
+    case user
+    case external
+}
+
 public enum UserPermission: String, Codable, CaseIterable {
     case read
     case write
@@ -68,6 +74,7 @@ public class DriveUser: Object, Codable, InfomaniakUser {
     @Persisted private var _avatarUrl: String?
     @Persisted public var displayName: String = ""
     public var type: DriveUserType?
+    public var role: DriveUserRole?
 
     public var avatar: String {
         return !_avatar.isBlank ? _avatar : (_avatarUrl ?? "")
@@ -80,6 +87,7 @@ public class DriveUser: Object, Codable, InfomaniakUser {
         case _avatarUrl = "avatar_url"
         case displayName = "display_name"
         case type
+        case role
     }
 
     public convenience init(user: InfomaniakCore.UserProfile) {

--- a/kDriveCore/Data/Models/FileAccess.swift
+++ b/kDriveCore/Data/Models/FileAccess.swift
@@ -84,6 +84,7 @@ public class UserFileAccess: FileAccessElement {
     public var email: String
     public var user: DriveUser?
     public var type: DriveUserType
+    public var role: DriveUserRole?
 
     public var shareable: Shareable? {
         return user


### PR DESCRIPTION
Object `drive_user` has been updated. Property `role` can have values `admin`/`user`/`external`, and property `type` (`shared`/`main`) is deprecated.
_(Preprod-next)_