### PR TITLE
Potential fix for KDRIVE-IOS-2XH

### DIFF
--- a/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/UploadQueue/PhotoLibraryUploader.swift
@@ -143,10 +143,12 @@ public class PhotoLibraryUploader {
                 }
 
                 if let image = CIImage(data: imageData) {
-                    let context = CIContext()
-                    let jpegData = context.jpegRepresentation(of: image,
-                                                              colorSpace: image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB)!)
-                    continuation.resume(returning: jpegData)
+                    autoreleasepool {
+                        let context = CIContext()
+                        let jpegData = context.jpegRepresentation(of: image,
+                                                                  colorSpace: image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB)!)
+                        continuation.resume(returning: jpegData)
+                    }
                 } else {
                     continuation.resume(returning: nil)
                 }


### PR DESCRIPTION
Use autoreleasepool to discard data as soon as possible as we are in a background queue.