### PR TITLE
Use ios-core 1.16

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core.git",
       "state" : {
-        "revision" : "6589ba5e17838023ea27dae78e56b75c565e09ca",
-        "version" : "1.1.15"
+        "revision" : "41a14e9e4444e85c4a1b53479e45514365486d11",
+        "version" : "1.1.16"
       }
     },
     {

--- a/Project.swift
+++ b/Project.swift
@@ -23,7 +23,7 @@ import Foundation
 let project = Project(name: "kDrive",
                       packages: [
                           .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.2")),
-                          .package(url: "https://github.com/Infomaniak/ios-core.git", .upToNextMajor(from: "1.1.13")),
+                          .package(url: "https://github.com/Infomaniak/ios-core.git", .upToNextMajor(from: "1.1.16")),
                           .package(url: "https://github.com/Infomaniak/ios-login.git", .upToNextMajor(from: "2.1.0")),
                           .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.0.0")),
                           .package(url: "https://github.com/SCENEE/FloatingPanel", .upToNextMajor(from: "2.0.0")),


### PR DESCRIPTION
ios-core 1.16 fixes concurrent access on ReachabilityListener which could help with issues related to KDRIVE-IOS-2N8.