### PR TITLE
Fix offline sync

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -425,6 +425,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
                                 // Update file to get the new modification date
                                 Task {
                                     let file = try await driveFileManager.file(id: fileId, forceRefresh: true)
+                                    try? FileManager.default.setAttributes([.modificationDate: file.lastModifiedAt], ofItemAtPath: file.localUrl.path)
                                     driveFileManager.notifyObserversWith(file: file)
                                 }
                             }

--- a/kDriveCore/Data/UploadQueue/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/UploadOperation.swift
@@ -269,6 +269,9 @@ public class UploadOperation: Operation {
                 let queue = BackgroundRealm.getQueue(for: driveFileManager.realmConfiguration)
                 queue.execute { realm in
                     if driveFileManager.getCachedFile(id: driveFile.id, freeze: false, using: realm) != nil || file.relativePath.isEmpty {
+                        if let oldFile = realm.object(ofType: File.self, forPrimaryKey: driveFile.id), oldFile.isAvailableOffline {
+                            driveFile.isAvailableOffline = true
+                        }
                         let parent = driveFileManager.getCachedFile(id: file.parentDirectoryId, freeze: false, using: realm)
                         queue.bufferedWrite(in: parent, file: driveFile)
                         result.driveFile = File(value: driveFile)


### PR DESCRIPTION
Fixes #910 

- When we upload a file which is available offline, we should keep this info
- When we upload a file edited locally, the `lastModifiedAt` provided by the back-end is slightly greater than the `modificationDate` attribute of the local file