### PR TITLE
Manage categories: only use API call with several files

### DIFF
--- a/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
+++ b/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
@@ -31,7 +31,6 @@ class ManageCategoriesViewController: UITableViewController {
 
     var driveFileManager: DriveFileManager!
     var files: Set<File>?
-    var fromMultiselect = false
     /// Disable category edition (can just add/remove).
     var canEdit = true
     var selectedCategories = [kDriveCore.Category]()
@@ -291,11 +290,7 @@ class ManageCategoriesViewController: UITableViewController {
         if let files = files {
             Task { [proxyFiles = files.map { $0.proxify() }] in
                 do {
-                    if !fromMultiselect, let proxyFile = proxyFiles.first {
-                        try await driveFileManager.add(category: category, to: proxyFile)
-                    } else {
-                        try await driveFileManager.add(category: category, to: proxyFiles)
-                    }
+                    try await driveFileManager.add(category: category, to: proxyFiles)
                 } catch {
                     category.isSelected = false
                     tableView.deselectRow(at: indexPath, animated: true)
@@ -318,11 +313,7 @@ class ManageCategoriesViewController: UITableViewController {
         if let files = files {
             Task { [proxyFiles = files.map { $0.proxify() }] in
                 do {
-                    if !fromMultiselect, let proxyFile = proxyFiles.first {
-                        try await driveFileManager.remove(category: category, from: proxyFile)
-                    } else {
-                        try await driveFileManager.remove(category: category, from: proxyFiles)
-                    }
+                    try await driveFileManager.remove(category: category, from: proxyFiles)
                 } catch {
                     category.isSelected = true
                     tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -114,8 +114,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                                                driveFileManager: driveFileManager,
                                                from: self,
                                                group: group,
-                                               presentingParent: presentingParent,
-                                               fromMultiselect: true)
+                                               presentingParent: presentingParent)
         case .folderColor:
             FileActionsHelper.folderColor(files: files,
                                           driveFileManager: driveFileManager,

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -374,12 +374,11 @@ public class FileActionsHelper {
     }
 
     public static func manageCategories(files: [File], driveFileManager: DriveFileManager, from viewController: UIViewController,
-                                        group: DispatchGroup? = nil, presentingParent: UIViewController?, fromMultiselect: Bool = false) {
+                                        group: DispatchGroup? = nil, presentingParent: UIViewController?) {
         group?.enter()
         let navigationManageCategoriesViewController = ManageCategoriesViewController.instantiateInNavigationController(files: files, driveFileManager: driveFileManager)
         let manageCategoriesViewController = (navigationManageCategoriesViewController.topViewController as? ManageCategoriesViewController)
         manageCategoriesViewController?.fileListViewController = presentingParent as? FileListViewController
-        manageCategoriesViewController?.fromMultiselect = fromMultiselect
         manageCategoriesViewController?.completionHandler = {
             group?.leave()
         }


### PR DESCRIPTION
To follow the same logic as android: [android#937](https://github.com/Infomaniak/android-kDrive/pull/937)