### PR TITLE
Prevent re-uploading the same picture on automatic sync

### DIFF
--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader.swift
@@ -218,16 +218,36 @@ public class PhotoLibraryUploader {
         }
     }
 
+    static let uploadedAssetPredicate = NSPredicate(format: "rawType = %@ AND uploadDate != nil", "phAsset")
+
     func assetAlreadyUploaded(assetName: String, realm: Realm) -> Bool {
-        // TODO: optimize query
-        guard let object = realm.objects(UploadFile.self).first(where: { uploadFile in
+        let start = CFAbsoluteTimeGetCurrent()
+        let obj = realm
+            .objects(UploadFile.self)
+            .filter(Self.uploadedAssetPredicate)
+            .filter(NSPredicate(format: "name = %@", assetName))
+            .first
+        // run your work
+        let diff = CFAbsoluteTimeGetCurrent() - start
+        
+        let start2 = CFAbsoluteTimeGetCurrent()
+        guard let _ = realm.objects(UploadFile.self).first(where: { uploadFile in
             uploadFile.type == .phAsset
                 && uploadFile.name == assetName
                 && uploadFile.uploadDate != nil
         }) else {
             return false
         }
+        let diff2 = CFAbsoluteTimeGetCurrent() - start2
 
+        if diff > diff2 {
+            print("•>")
+        } else {
+            print("•<")
+        }
+
+        print("diff:\(diff)")
+        print("diff2:\(diff2)")
         return true
     }
 


### PR DESCRIPTION
## Abstract

Prevent from reuploading the same picture on automatic syncronisation.
Mimmic the Android way of doing it. Based on generated name (not URI) as it is built differently.

## Misc

Optimized Realm request.