### PR TITLE
Prevent loop in cancel session

### DIFF
--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
@@ -89,15 +89,19 @@ extension UploadOperation {
                 case .unableToBuildRequest:
                     file.error = DriveError.localError.wrapping(error)
 
-                case .uploadSessionTaskMissing,
-                     .uploadSessionInvalid,
-                     .unableToMatchUploadChunk,
+                case .unableToMatchUploadChunk,
                      .splitError,
                      .chunkError,
                      .fileIdentityHasChanged,
                      .parseError,
                      .missingChunkHash:
-                    self.cleanUploadFileSession(file: file)
+                    self.cleanUploadFileSession(file: file, remotely: true)
+                    file.error = DriveError.localError.wrapping(error)
+
+                case .uploadSessionTaskMissing,
+                     .uploadSessionInvalid:
+                    // We do not clean remotely, as we expect the session to not exist remotely anymore
+                    self.cleanUploadFileSession(file: file, remotely: false)
                     file.error = DriveError.localError.wrapping(error)
 
                 case .operationFinished, .operationCanceled:

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -439,13 +439,17 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
             // Clean the remote session, and current tasks, to free resources.
             let driveId = file.driveId
             let userId = file.userId
-            self.enqueueCatching {
-                let driveFileManager = try self.getDriveFileManager(for: driveId, userId: userId)
+            self.enqueue {
+                guard let driveFileManager = try? self.getDriveFileManager(for: driveId, userId: userId) else {
+                    return
+                }
+
                 let abstractToken = AbstractTokenWrapper(token: sessionTokenToCancel)
                 let apiFetcher = driveFileManager.apiFetcher
                 let drive = driveFileManager.drive
 
-                let cancelledSession = try await apiFetcher.cancelSession(drive: drive, sessionToken: abstractToken)
+                // We try to cancel the upload session, we do not watch results
+                let cancelledSession = try? await apiFetcher.cancelSession(drive: drive, sessionToken: abstractToken)
                 Log.uploadOperation("remove cancelledSession:\(cancelledSession) for \(self.uploadFileId)")
 
                 for (key, value) in self.uploadTasks {

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -423,7 +423,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
         return fileUrl
     }
 
-    public func cleanUploadFileSession(file: UploadFile? = nil) {
+    public func cleanUploadFileSession(file: UploadFile? = nil, remotely: Bool = true) {
         Log.uploadOperation("Clean uploading session for \(uploadFileId)")
 
         let cleanFileClosure: (UploadFile) -> Void = { file in
@@ -433,6 +433,10 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
             file.progress = nil
 
             guard let sessionTokenToCancel = sessionTokenToCancel else {
+                return
+            }
+
+            guard remotely == true else {
                 return
             }
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -436,7 +436,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
                 return
             }
 
-            guard remotely == true else {
+            guard remotely else {
                 return
             }
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperationable.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperationable.swift
@@ -67,7 +67,8 @@ public protocol UploadOperationable: Operationable {
 
     /// Clean the local session and send an API call to free the session
     /// - Parameter file: An UploadFile within a transaction
-    func cleanUploadFileSession(file: UploadFile?)
+    /// - Parameter remotely: try to delete remote session object if true
+    func cleanUploadFileSession(file: UploadFile?, remotely: Bool)
 
     /// Process errors and terminate the operation
     func end()

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -194,7 +194,7 @@ extension UploadQueue: UploadQueueable {
         concurrentQueue.async {
             if let operation = self.keyedUploadOperations.getObject(forKey: uploadFileId) {
                 Log.uploadQueue("operation to cancel:\(operation)")
-                operation.cleanUploadFileSession(file: nil)
+                operation.cleanUploadFileSession(file: nil, remotely: true)
                 operation.cancel()
             }
             self.keyedUploadOperations.removeObject(forKey: uploadFileId)


### PR DESCRIPTION
- A loop may occur when a session is not valid, we try to delete it from the remote, which fails, so we try to remove it …
- Also refactored a bit to differenciate more in the error handling.