### PR TITLE
Revert file naming convention

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "892e9f6f37b12f3d67bd8987958aaa356d253e8e",
-        "version" : "4.1.14"
+        "revision" : "25719300ccde5444cc4d22ce729383a87ca1984f",
+        "version" : "4.1.16"
       }
     },
     {

--- a/Project.swift
+++ b/Project.swift
@@ -23,7 +23,7 @@ import ProjectDescriptionHelpers
 let project = Project(name: "kDrive",
                       packages: [
                           .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.2.2")),
-                          .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "4.1.13")),
+                          .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "4.1.16")),
                           .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "2.5.2")),
                           .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "4.0.0")),
                           .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "1.1.9")),

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -235,7 +235,7 @@ public struct DriveError: Error, Equatable {
     private static let decoder = JSONDecoder()
 
     /// A specific, not user facing, not localized error
-    internal var underlyingError: Error?
+    var underlyingError: Error?
 
     public init(apiErrorCode: String, httpStatus: Int = 400) {
         if let error = DriveError.allErrors.first(where: { $0.type == .serverError && $0.code == apiErrorCode }) {

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -235,7 +235,7 @@ public struct DriveError: Error, Equatable {
     private static let decoder = JSONDecoder()
 
     /// A specific, not user facing, not localized error
-    private var underlyingError: Error?
+    internal var underlyingError: Error?
 
     public init(apiErrorCode: String, httpStatus: Int = 400) {
         if let error = DriveError.allErrors.first(where: { $0.type == .serverError && $0.code == apiErrorCode }) {

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
@@ -272,8 +272,6 @@ extension UploadOperation {
                 // Log uploadingSession.uploadSession state
                 metadata["file.uploadingSession.uploadSession"] =
                     "result:\(uploadSession.result) - token:\(uploadSession.token)"
-
-                return
             }
             return metadata
         } catch {

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -208,7 +208,7 @@ public extension PhotoLibraryUploader {
 
         // Build the same name as importing manually a file
         correctName = asset
-            .getFilename(fileExtension: fileExtension.lowercased(), burstCount: burstCount)
+            .getFilename(fileExtension: fileExtension.lowercased(), creationDate: asset.creationDate, burstCount: burstCount)
             ?? "No-name-\(URL.defaultFileName())"
 
         return correctName

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -207,9 +207,10 @@ public extension PhotoLibraryUploader {
         burstIdentifier = asset.burstIdentifier
 
         // Build the same name as importing manually a file
-        correctName = asset
-            .getFilename(fileExtension: fileExtension.lowercased(), creationDate: asset.creationDate, burstCount: burstCount)
-            ?? "No-name-\(URL.defaultFileName())"
+        correctName = asset.getFilename(fileExtension: fileExtension,
+                                        creationDate: asset.creationDate,
+                                        burstCount: burstCount,
+                                        burstIdentifier: burstIdentifier)
 
         return correctName
     }

--- a/kDriveCore/Utils/ExpiringActivity.swift
+++ b/kDriveCore/Utils/ExpiringActivity.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakCore
 
 /// Delegation mechanism to notify the end of an `ExpiringActivity`
 public protocol ExpiringActivityDelegate: AnyObject {
@@ -36,7 +37,7 @@ public protocol ExpiringActivityable {
 
 public final class ExpiringActivity: ExpiringActivityable {
     /// Keep track of the locks on blocks
-    private var locks = [DispatchGroup]()
+    private var locks = [TolerantDispatchGroup]()
 
     /// For thread safety
     private let queue = DispatchQueue(label: "com.infomaniak.ExpiringActivity.sync")
@@ -61,7 +62,7 @@ public final class ExpiringActivity: ExpiringActivityable {
     }
 
     public func start() {
-        let group = DispatchGroup()
+        let group = TolerantDispatchGroup()
 
         queue.sync {
             self.locks.append(group)

--- a/kDriveCore/Utils/PHAsset/PHAsset+Exension.swift
+++ b/kDriveCore/Utils/PHAsset/PHAsset+Exension.swift
@@ -37,52 +37,19 @@ public extension PHAsset {
 
     // MARK: - Filename
 
-    /// The date formatter specific to kDrive and file name format
-    private static let fileNameDateFormatter: DateFormatter = {
-        var dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyyMMdd_HHmmss_SSSS"
-        return dateFormatter
-    }()
-
     /// Get a filename that can be used by kDrive, taking into consideration the edits that may exists on a PHAsset.
-    func getFilename(fileExtension: String, creationDate: Date? = nil, burstCount: Int? = nil) -> String? {
-        guard let resource = bestResource() else { return nil }
-
-        let burstString: String
-        if let burstCount, burstCount > 0 {
-            burstString = "_\(burstCount)"
-        } else {
-            burstString = ""
-        }
-
-        let originalFilename = resource.originalFilename
-        let lastPathComponent = originalFilename.split(separator: ".")
-        let filename = lastPathComponent[0]
-
-        // Edited pictures will have a "FullSizeRender" name
-        guard filename != "FullSizeRender" else {
-            // Differentiate the file with edit date
-            let editDate = modificationDate ?? Date()
-
-            // Making sure edited pictures on Photo.app have a unique name that will trigger an upload and do not collide.
-            guard let creationDate else {
-                return "No-name-\(Self.fileNameDateFormatter.string(from: editDate))\(burstString).\(fileExtension)"
-            }
-            return "\(Self.fileNameDateFormatter.string(from: creationDate))-\(Self.fileNameDateFormatter.string(from: editDate))\(burstString).\(fileExtension)"
-        }
-
-        // Standard kDrive date formating
-        guard let creationDate else {
-            return nil
-        }
-
-        var correctName = Self.fileNameDateFormatter.string(from: creationDate)
-        if burstIdentifier != nil {
-            correctName += "_" + burstString
-        }
-        correctName += "." + fileExtension
-
-        return correctName
+    func getFilename(fileExtension: String,
+                     creationDate: Date? = nil,
+                     modificationDate: Date? = nil,
+                     burstCount: Int? = nil,
+                     burstIdentifier: String? = nil) -> String {
+        let nameProvider = PHAssetNameProvider()
+        return nameProvider.getFilename(fileExtension: fileExtension,
+                                        originalFilename: bestResource()?.originalFilename,
+                                        creationDate: creationDate,
+                                        modificationDate: modificationDate,
+                                        burstCount: burstCount,
+                                        burstIdentifier: burstIdentifier)
     }
 
     /// Get a filename that can be used by kDrive, taking into consideration the edits that may exists on a PHAsset.

--- a/kDriveCore/Utils/PHAsset/PHAsset+Exension.swift
+++ b/kDriveCore/Utils/PHAsset/PHAsset+Exension.swift
@@ -73,19 +73,6 @@ public extension PHAsset {
         return nil
     }
 
-    /// Fetches the original name of an Asset, before edition
-    /// - Returns: The original name if any
-    private func originalResourceName() -> String? {
-        switch mediaType {
-        case .video:
-            return firstResourceMatchingAnyType(of: [.video])?.originalFilename
-        case .image:
-            return firstResourceMatchingAnyType(of: [.photo])?.originalFilename
-        default:
-            return nil
-        }
-    }
-
     // MARK: - Resource
 
     func bestResource() -> PHAssetResource? {

--- a/kDriveCore/Utils/PHAsset/PHAssetNameProvider.swift
+++ b/kDriveCore/Utils/PHAsset/PHAssetNameProvider.swift
@@ -1,0 +1,84 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakCore
+
+/// Something to generate a File Name, testable
+struct PHAssetNameProvider {
+    /// The date formatter specific to kDrive and file name format
+    static let fileNameDateFormatter: DateFormatter = {
+        var dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMdd_HHmmss_SSSS"
+        return dateFormatter
+    }()
+
+    static let noName = "No-name"
+    
+    /// Default file name
+    func defaultFileName(_ burstString: String, _ fileExtension: String, _ now: Date) -> String {
+        "\(Self.noName)-\(URL.defaultFileName(date: now))\(burstString).\(fileExtension)"
+    }
+
+    /// Get a filename that can be used by kDrive, taking into consideration burst and edits of a PHAsset.
+    public func getFilename(fileExtension: String,
+                            originalFilename: String?,
+                            creationDate: Date?,
+                            modificationDate: Date?,
+                            burstCount: Int?,
+                            burstIdentifier: String?,
+                            now: Date = Date()) -> String {
+        let fileExtension = fileExtension.lowercased()
+        let burstString: String
+        if let burstCount,
+            burstCount > 0,
+            let burstIdentifier,
+            !burstIdentifier.isEmpty {
+            burstString = "_\(burstCount)"
+        } else {
+            burstString = ""
+        }
+
+        // Require a valid originalFilename
+        guard let originalFilename, !originalFilename.isEmpty else {
+            return defaultFileName(burstString, fileExtension, now)
+        }
+
+        let lastPathComponent = originalFilename.split(separator: ".")
+        let filename = lastPathComponent[0]
+
+        // Edited pictures will have a "FullSizeRender" name
+        guard filename != "FullSizeRender" else {
+            // Differentiate the file with edit date
+            let editDate = modificationDate ?? now
+
+            // Making sure edited pictures on Photo.app have a unique name that will trigger an upload and do not collide.
+            guard let creationDate else {
+                return "\(Self.noName)-\(Self.fileNameDateFormatter.string(from: editDate))\(burstString).\(fileExtension)"
+            }
+            return "\(Self.fileNameDateFormatter.string(from: creationDate))-\(Self.fileNameDateFormatter.string(from: editDate))\(burstString).\(fileExtension)"
+        }
+
+        // Standard kDrive date formating
+        guard let creationDate else {
+            return defaultFileName(burstString, fileExtension, now)
+        }
+
+        return "\(Self.fileNameDateFormatter.string(from: creationDate))\(burstString).\(fileExtension)"
+    }
+}

--- a/kDriveTests/kDriveCore/Files/UTPHAssetNameProvider.swift
+++ b/kDriveTests/kDriveCore/Files/UTPHAssetNameProvider.swift
@@ -1,0 +1,513 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@testable import kDriveCore
+import Photos
+import XCTest
+
+/// Unit tests of image asset name generation
+final class UTPHAssetNameProvider: XCTestCase {
+    // MARK: - Fallback Name
+
+    func testDefaultName() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: nil,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testEmptyOriginalFilename() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let emptyFileName = ""
+        let fileExtension = "exe"
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: emptyFileName,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testDefaultNameWithNonZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+        let burstCount = 1337
+        let burstIdentifier = "cafebabe"
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate)_\(burstCount).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: nil,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testDefaultNameWithZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+        let burstCount = 0
+        let burstIdentifier = "cafebabe"
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: nil,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testDefaultNameWithNonZeroBurstsEmptyBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+        let burstCount = 1337
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: nil,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testDefaultNameWithNonZeroBurstsNilBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+        let burstCount = 1337
+        let burstIdentifier = ""
+        let now = Date()
+        let formattedNowDate = URL.defaultFileName(date: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: nil,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureNoCreationDate() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let fileExtension = "exe"
+        let now = Date()
+        let formattedNowDate = PHAssetNameProvider.fileNameDateFormatter.string(from: now)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedNowDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: nil,
+                                            modificationDate: nil,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureNoCreationDateModificationDate() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let defaultPrefix = "No-name-"
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let now = Date()
+        let modificationDate = Date(timeIntervalSince1970: 1337)
+        let formattedModificationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate)
+
+        let expectedFormat = "\(defaultPrefix)\(formattedModificationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: nil,
+                                            modificationDate: modificationDate,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    // MARK: - Modified assets
+
+    func testModifiedPicture() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+        let modificationDate = Date(timeIntervalSince1970: 420)
+        let formattedModificationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate)
+
+        let expectedFormat = "\(formattedCreationDate)-\(formattedModificationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: modificationDate,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureWithNonZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let burstCount = 1337
+        let burstIdentifier = "cafebabe"
+
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let modificationDate = Date(timeIntervalSince1970: 420)
+
+        let expectedFormat =
+            "\(PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate))-\(PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate))_\(burstCount).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: modificationDate,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureWithZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let burstCount = 0
+        let burstIdentifier = "cafebabe"
+
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let modificationDate = Date(timeIntervalSince1970: 420)
+
+        let expectedFormat =
+            "\(PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate))-\(PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate)).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: modificationDate,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureWithNonZeroBurstsEmptyBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let burstCount = 1337
+        let burstIdentifier = ""
+
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let modificationDate = Date(timeIntervalSince1970: 420)
+
+        let expectedFormat =
+            "\(PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate))-\(PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate)).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: modificationDate,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testModifiedPictureWithNonZeroBurstsNilBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileWithModificationsFilename = "FullSizeRender"
+        let burstCount = 1337
+
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let modificationDate = Date(timeIntervalSince1970: 420)
+
+        let expectedFormat =
+            "\(PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate))-\(PHAssetNameProvider.fileNameDateFormatter.string(from: modificationDate)).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileWithModificationsFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: modificationDate,
+                                            burstCount: burstCount,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    // MARK: - Asset no modification
+
+    func testNotModifiedPicture() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileOriginalFilename = "DSC-30032"
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+
+        let expectedFormat = "\(formattedCreationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileOriginalFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: nil,
+                                            burstCount: nil,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testNotModifiedPictureWithNonZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileOriginalFilename = "DSC-30032"
+        let burstCount = 1337
+        let burstIdentifier = "cafebabe"
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+
+        let expectedFormat = "\(formattedCreationDate)_\(burstCount).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileOriginalFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testNotModifiedPictureWithNonZeroBurstsEmptyBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileOriginalFilename = "DSC-30032"
+        let burstCount = 1337
+        let burstIdentifier = ""
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+
+        let expectedFormat = "\(formattedCreationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileOriginalFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testNotModifiedPictureWithNonZeroBurstsNilBurstIdentifier() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileOriginalFilename = "DSC-30032"
+        let burstCount = 1337
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+
+        let expectedFormat = "\(formattedCreationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileOriginalFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: nil,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    func testNotModifiedPictureWithZeroBursts() {
+        // GIVEN
+        let nameProvider = PHAssetNameProvider()
+        let fileExtension = "exe"
+        let fileOriginalFilename = "DSC-30032"
+        let burstCount = 0
+        let burstIdentifier = "cafebabe"
+        let now = Date()
+        let creationDate = Date(timeIntervalSince1970: 69)
+        let formattedCreationDate = PHAssetNameProvider.fileNameDateFormatter.string(from: creationDate)
+
+        let expectedFormat = "\(formattedCreationDate).\(fileExtension)"
+
+        // WHEN
+        let name = nameProvider.getFilename(fileExtension: fileExtension,
+                                            originalFilename: fileOriginalFilename,
+                                            creationDate: creationDate,
+                                            modificationDate: nil,
+                                            burstCount: burstCount,
+                                            burstIdentifier: burstIdentifier,
+                                            now: now)
+
+        // THEN
+        XCTAssertEqual(name, expectedFormat)
+    }
+
+    // MARK: - Date formatter checks
+
+    func testFileNameDateFormatter() {
+        // GIVEN
+        let primaryDate = Date(timeIntervalSince1970: 2_357_111_317)
+
+        // WHEN
+        let formattedDate = PHAssetNameProvider.fileNameDateFormatter.string(from: primaryDate)
+
+        // THEN
+        XCTAssertEqual(formattedDate, "20440910_110837_0000")
+    }
+
+    func testURLFileNameDateFormatter() {
+        // GIVEN
+        let primaryDate = Date(timeIntervalSince1970: 2_357_111_317)
+
+        // WHEN
+        let formattedDate = URL.defaultFileName(date: primaryDate)
+
+        // THEN
+        XCTAssertEqual(formattedDate, "20440910_11083700")
+    }
+}


### PR DESCRIPTION
- Added more logging for errors presented to the user
- Rollback to the original upload naming scheme
- Unit test upload naming scheme
- Use TolerantDispatchGroup to harden ExpiringActivity