### PR TITLE
Beta 7

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "25719300ccde5444cc4d22ce729383a87ca1984f",
-        "version" : "4.1.16"
+        "revision" : "31eb7eb0800aca871ec38d609757e64ef9f47721",
+        "version" : "4.1.17"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "c04f5e401a1ec682e6b08b1ee157e19a0f834a5f",
-        "version" : "13.17.1"
+        "revision" : "e836317e8238bd32f06086dd7ce6768ef574beb6",
+        "version" : "13.22.0"
       }
     },
     {
@@ -203,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift",
       "state" : {
-        "revision" : "330a239712af77a3b0926b9ffa9582302a0b9923",
-        "version" : "10.42.1"
+        "revision" : "8249489f28d36f9f37ed076c95029059c60b556d",
+        "version" : "10.43.0"
       }
     },
     {
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "12998398eb51e2e8ff7098163fa97d305eee6d87",
-        "version" : "8.11.0"
+        "revision" : "0a915b93ff3abee1a9752448e47808334d306980",
+        "version" : "8.13.0"
       }
     },
     {
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "cf281631ff10ec6111f2761052aa81896a83a007",
-        "version" : "2.58.0"
+        "revision" : "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
+        "version" : "2.59.0"
       }
     },
     {

--- a/kDrive/AppDelegate+BGAppRefresh.swift
+++ b/kDrive/AppDelegate+BGAppRefresh.swift
@@ -80,7 +80,7 @@ extension AppDelegate {
             task.expirationHandler = {
                 Log.bgTaskScheduling("Task \(Constants.backgroundRefreshIdentifier) EXPIRED", level: .error)
                 uploadQueue.suspendAllOperations()
-                uploadQueue.cancelRunningOperations()
+                uploadQueue.rescheduleRunningOperations()
                 task.setTaskCompleted(success: false)
             }
 
@@ -100,7 +100,7 @@ extension AppDelegate {
             task.expirationHandler = {
                 Log.bgTaskScheduling("Task \(Constants.longBackgroundRefreshIdentifier) EXPIRED", level: .error)
                 uploadQueue.suspendAllOperations()
-                uploadQueue.cancelRunningOperations()
+                uploadQueue.rescheduleRunningOperations()
                 task.setTaskCompleted(success: false)
             }
 

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -273,7 +273,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
                         // Proceed with removal
                         self.photoLibraryUploader.removePicturesFromPhotoLibrary(toRemoveItems)
                     }
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         self.window?.rootViewController?.present(alert, animated: true)
                     }
                 }
@@ -289,7 +289,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
         let rootViewController = window?.rootViewController as? SwitchAccountDelegate
 
         if preload {
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 // if isSwitching {
                 rootViewController?.didSwitchCurrentAccount(currentAccount)
                 /* } else {
@@ -546,7 +546,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
     }
 
     @objc func reloadDrive(_ notification: Notification) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             self.refreshCacheData(preload: false, isSwitching: false)
         }
     }

--- a/kDrive/Data/App Version/AppVersion.swift
+++ b/kDrive/Data/App Version/AppVersion.swift
@@ -38,7 +38,7 @@ struct AppVersion: Codable {
         URLSession.shared.dataTask(with: request) { data, _, error in
             if let data {
                 if let decodedResponse = try? JSONDecoder().decode(Response.self, from: data) {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         handler(decodedResponse.results[0])
                     }
                     return

--- a/kDrive/IAP/StoreManager.swift
+++ b/kDrive/IAP/StoreManager.swift
@@ -102,7 +102,7 @@ extension StoreManager: SKProductsRequestDelegate {
         }
 
         if !storeResponse.isEmpty {
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.delegate?.storeManagerDidReceiveResponse(self.storeResponse)
             }
         }
@@ -113,7 +113,7 @@ extension StoreManager: SKProductsRequestDelegate {
 
 extension StoreManager: SKRequestDelegate {
     func request(_ request: SKRequest, didFailWithError error: Error) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             self.delegate?.storeManagerDidReceiveMessage(error.localizedDescription)
         }
     }

--- a/kDrive/UI/Controller/Create File/PlusButtonFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Create File/PlusButtonFloatingPanelViewController.swift
@@ -247,13 +247,13 @@ class PlusButtonFloatingPanelViewController: UITableViewController, FloatingPane
                         var configuration = PHPickerConfiguration(photoLibrary: .shared())
                         configuration.selectionLimit = 0
 
-                        DispatchQueue.main.async {
+                        Task { @MainActor in
                             let picker = PHPickerViewController(configuration: configuration)
                             picker.delegate = mainTabViewController.photoPickerDelegate
                             mainTabViewController.present(picker, animated: true)
                         }
                     } else {
-                        DispatchQueue.main.async {
+                        Task { @MainActor in
                             let alert = AlertTextViewController(
                                 title: KDriveResourcesStrings.Localizable.photoLibraryAccessLimitedTitle,
                                 message: KDriveResourcesStrings.Localizable.photoLibraryAccessLimitedDescription,

--- a/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
+++ b/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
@@ -173,7 +173,7 @@ class ManageCategoriesViewController: UITableViewController {
         // Observe files changes
         for file in files {
             driveFileManager.observeFileUpdated(self, fileId: file.id) { newFile in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     guard !newFile.isInvalidated else {
                         if self?.presentingViewController != nil && viewControllersCount < 2 {
                             self?.closeButtonPressed()

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -541,7 +541,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
         if let indexPath = collectionView.indexPathForItem(at: pos) {
             multipleSelectionViewModel.isMultipleSelectionEnabled = true
             // Necessary for events to trigger in the right order
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 guard let self else { return }
                 if let file = viewModel.getFile(at: indexPath) {
                     multipleSelectionViewModel.didSelectFile(file, at: indexPath)
@@ -594,7 +594,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
     private func observeNetwork() {
         guard networkObserver == nil else { return }
         networkObserver = ReachabilityListener.instance.observeNetworkChange(self) { [weak self] status in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 guard let self else { return }
                 self.headerView?.offlineView.isHidden = status != .offline
                 self.collectionView.collectionViewLayout.invalidateLayout()

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -276,7 +276,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
         collectionView.dragDelegate = self
 
         ReachabilityListener.instance.observeNetworkChange(self) { [weak self] _ in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 guard self?.file != nil else { return }
                 self?.file.realm?.refresh()
                 if self?.file.isInvalidated == true {
@@ -307,7 +307,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             file = newFile
             fileObserver?.cancel()
             fileObserver = driveFileManager.observeFileUpdated(self, fileId: file.id) { [weak self] _ in
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self?.file.realm?.refresh()
                     if self?.file.isInvalidated == true {
                         // File has been removed
@@ -746,7 +746,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
 
     private func setLoading(_ isLoading: Bool, action: FloatingPanelAction, at indexPath: IndexPath) {
         action.isLoading = isLoading
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             self?.collectionView.reloadItems(at: [indexPath])
         }
     }
@@ -767,7 +767,7 @@ class FileActionsFloatingPanelViewController: UICollectionViewController {
             .observeFileDownloaded(observerViewController, fileId: file.id) { [weak self] _, error in
                 self?.downloadAction = nil
                 self?.setLoading(true, action: action, at: indexPath)
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     if error == nil {
                         completion()
                     } else {

--- a/kDrive/UI/Controller/Files/FileDetailViewController.swift
+++ b/kDrive/UI/Controller/Files/FileDetailViewController.swift
@@ -166,7 +166,7 @@ class FileDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         guard let file else {
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 self?.navigationController?.popViewController(animated: true)
             }
             return
@@ -216,7 +216,7 @@ class FileDetailViewController: UIViewController {
 
         // Observe file changes
         driveFileManager.observeFileUpdated(self, fileId: file.id) { newFile in
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 self?.file = newFile
                 self?.reloadTableView()
             }

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -133,7 +133,7 @@ class MultipleSelectionFloatingPanelViewController: UICollectionViewController {
                             .observeFileDownloaded(observerViewController, fileId: file.id) { [weak self] _, error in
                                 guard let self else { return }
                                 if error == nil {
-                                    DispatchQueue.main.async {
+                                    Task { @MainActor in
                                         FileActionsHelper.save(file: file, from: self, showSuccessSnackBar: false)
                                     }
                                 } else {

--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -146,11 +146,11 @@ class OnlyOfficeViewController: UIViewController {
                     if let token {
                         var request = URLRequest(url: url)
                         request.setValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
-                        DispatchQueue.main.async {
+                        Task { @MainActor in
                             self.webView.load(request)
                         }
                     } else {
-                        DispatchQueue.main.async {
+                        Task { @MainActor in
                             self.showErrorMessage()
                         }
                     }

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -214,7 +214,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
         driveFileManager?.observeFileUpdated(self, fileId: nil) { [weak self] file in
             if self?.currentFile.id == file.id {
                 self?.currentFile = file
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     guard let self else { return }
                     self.collectionView.endEditing(true)
                     self.collectionView.reloadItems(at: [self.currentIndex])
@@ -469,7 +469,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
                 previewError.pdfGenerationProgress = Progress(totalUnitCount: 10)
                 PdfPreviewCache.shared.retrievePdf(for: file, driveFileManager: driveFileManager) { downloadTask in
                     previewError.addDownloadTask(downloadTask)
-                    DispatchQueue.main.async { [weak self] in
+                    Task { @MainActor [weak self] in
                         self?.collectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
                     }
                 } completion: { url, error in
@@ -479,7 +479,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
                     } else {
                         previewError.error = error
                     }
-                    DispatchQueue.main.async { [weak self] in
+                    Task { @MainActor [weak self] in
                         self?.collectionView.reloadItems(at: [IndexPath(item: index, section: 0)])
                     }
                 }
@@ -507,7 +507,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
 
         DownloadQueue.instance.observeFileDownloaded(self, fileId: currentFile.id) { [weak self] _, error in
             guard let self else { return }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 if error == nil {
                     completion()
                     currentCell.observeProgress(false, file: self.currentFile)
@@ -530,7 +530,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
                 file: currentFile,
                 userId: accountManager.currentUserId,
                 onOperationCreated: { operation in
-                    DispatchQueue.main.async { [weak self] in
+                    Task { @MainActor [weak self] in
                         self?.currentDownloadOperation = operation
                         if let progress = self?.currentDownloadOperation?.task?.progress,
                            let cell = self?.collectionView.cellForItem(at: indexPath) as? DownloadProgressObserver {
@@ -539,7 +539,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
                     }
                 },
                 completion: { error in
-                    DispatchQueue.main.async { [weak self] in
+                    Task { @MainActor [weak self] in
                         self?.currentDownloadOperation = nil
                         if self?.view.window != nil {
                             if let error {
@@ -620,7 +620,7 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate {
         currentIndex = IndexPath(row: decodedIndex, section: 0)
 
         // Update UI
-        DispatchQueue.main.async { [self] in
+        Task { @MainActor [self] in
             collectionView.reloadData()
             updateFileForCurrentIndex()
             collectionView.scrollToItem(at: currentIndex, at: .centeredVertically, animated: false)

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
@@ -195,7 +195,7 @@ class SaveFileViewController: UIViewController {
         ) { [weak self] importedFiles, errorCount in
             self?.items = importedFiles
             self?.errorCount = errorCount
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self?.updateTableViewAfterImport()
             }
         }
@@ -209,7 +209,7 @@ class SaveFileViewController: UIViewController {
                          userPreferredPhotoFormat: userPreferredPhotoFormat) { [weak self] importedFiles, errorCount in
                 self?.items = importedFiles
                 self?.errorCount = errorCount
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self?.updateTableViewAfterImport()
                 }
             }

--- a/kDrive/UI/Controller/Files/Search/SearchViewController.swift
+++ b/kDrive/UI/Controller/Files/Search/SearchViewController.swift
@@ -292,7 +292,7 @@ class SearchViewController: FileListViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        DispatchQueue.main.async {
+        Task { @MainActor in
             self.searchController.searchBar.becomeFirstResponder()
         }
     }

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueFoldersViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueFoldersViewController.swift
@@ -107,7 +107,7 @@ class UploadQueueFoldersViewController: UITableViewController {
             .compactMap { accountManager.getDriveFileManager(for: $0.driveId, userId: userId)?.getCachedFile(id: $0.parentId) }
         // (Pop view controller if nothing to show)
         if folders.isEmpty {
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.navigationController?.popViewController(animated: true)
             }
         }

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -51,7 +51,7 @@ final class UploadQueueViewController: UIViewController {
         setUpObserver()
 
         ReachabilityListener.instance.observeNetworkChange(self) { [weak self] _ in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self?.tableView.reloadData()
             }
         }

--- a/kDrive/UI/Controller/LaunchPanelsController.swift
+++ b/kDrive/UI/Controller/LaunchPanelsController.swift
@@ -125,7 +125,7 @@ class LaunchPanelsController {
     func pickAndDisplayPanel(viewController: UIViewController) {
         DispatchQueue.global().async {
             if let panel = self.pickPanelToDisplay() {
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     viewController.present(panel.makePanelController(), animated: true, completion: panel.onDisplay)
                 }
             }

--- a/kDrive/UI/Controller/LockedAppViewController.swift
+++ b/kDrive/UI/Controller/LockedAppViewController.swift
@@ -38,7 +38,7 @@ class LockedAppViewController: UIViewController {
         if #available(iOS 8.0, *) {
             if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
                 context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         if success {
                             self.dismiss(animated: true)
                             (UIApplication.shared.delegate as! AppDelegate).setRootViewController(

--- a/kDrive/UI/Controller/Menu/AppLockSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/AppLockSettingsViewController.swift
@@ -57,7 +57,7 @@ class AppLockSettingsViewController: UIViewController {
         if #available(iOS 8.0, *) {
             if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
                 context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         if success {
                             UserDefaults.shared.isAppLockEnabled = sender.isOn
                         } else {

--- a/kDrive/UI/Controller/Menu/NotificationsSettingsTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/NotificationsSettingsTableViewController.swift
@@ -70,7 +70,7 @@ class NotificationsSettingsTableViewController: UITableViewController {
                 self.rows = [.receiveNotification, .general, .importFile, .sharedWithMe, .newComments]
                 self.disableSwitch = false
             }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.tableView.reloadData()
             }
         }

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -80,7 +80,7 @@ class PhotoSyncSettingsViewController: UIViewController {
         didSet {
             newSyncSettings.parentDirectoryId = selectedDirectory?.id ?? -1
             if oldValue == nil || selectedDirectory == nil {
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self.updateSections()
                 }
             }
@@ -317,7 +317,7 @@ extension PhotoSyncSettingsViewController: UITableViewDataSource {
                     if sender.isOn {
                         Task {
                             let status = await self.requestAuthorization()
-                            DispatchQueue.main.async {
+                            Task { @MainActor in
                                 self.driveFileManager = self.accountManager.currentDriveFileManager
                                 if status == .authorized {
                                     self.photoSyncEnabled = true
@@ -526,7 +526,7 @@ extension PhotoSyncSettingsViewController: FooterButtonDelegate {
 
         DispatchQueue.global(qos: .userInitiated).async {
             self.saveSettings()
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.navigationController?.popViewController(animated: true)
             }
 

--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -166,7 +166,7 @@ class StorageTableViewController: UITableViewController {
 
         // Reload data
         reload()
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             self?.tableView.reloadData()
         }
     }

--- a/kDrive/UI/Controller/MigrationViewController.swift
+++ b/kDrive/UI/Controller/MigrationViewController.swift
@@ -68,7 +68,7 @@ class MigrationViewController: UIViewController {
             } catch {
                 success = false
             }
-            DispatchQueue.main.async { [self] in
+            Task { @MainActor [self] in
                 buttonView.alpha = 0
                 buttonView.isHidden = false
                 retryButton.isHidden = success

--- a/kDrive/UI/View/Files/FileCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FileCollectionViewCell.swift
@@ -98,14 +98,14 @@ protocol FileCellDelegate: AnyObject {
         downloadProgressObserver?.cancel()
         downloadProgressObserver = DownloadQueue.instance
             .observeFileDownloadProgress(self, fileId: file.id) { [weak self] _, progress in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     guard let self else { return }
                     handler(!file.isAvailableOffline || progress < 1, progress >= 1 || progress == 0, progress)
                 }
             }
         downloadObserver?.cancel()
         downloadObserver = DownloadQueue.instance.observeFileDownloaded(self, fileId: file.id) { [weak self] _, _ in
-            DispatchQueue.main.async { [weak self] in
+            Task { @MainActor [weak self] in
                 guard let self else { return }
                 handler(!isAvailableOffline, true, 1)
             }

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
@@ -131,7 +131,7 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
         setProgress(showProgress ? -1 : nil)
         if showProgress {
             observationToken = DownloadQueue.instance.observeFileDownloadProgress(self, fileId: file.id) { _, progress in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     self?.setProgress(progress)
                 }
             }
@@ -143,7 +143,7 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
         setProgress(showProgress ? -1 : nil)
         if showProgress {
             observationToken = DownloadQueue.instance.observeArchiveDownloadProgress(self, archiveId: archiveId) { _, progress in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     self?.setProgress(progress)
                 }
             }

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelQuickActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelQuickActionCollectionViewCell.swift
@@ -123,7 +123,7 @@ class FloatingPanelQuickActionCollectionViewCell: UICollectionViewCell {
         } else {
             loadingIndicator.stopAnimating()
             observationToken = DownloadQueue.instance.observeFileDownloadProgress(self, fileId: file.id) { _, progress in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     guard self?.observationToken != nil else { return }
                     self?.setProgress(progress)
                     if progress >= 1 {

--- a/kDrive/UI/View/Files/Preview/AudioCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/AudioCollectionViewCell.swift
@@ -111,7 +111,7 @@ class AudioCollectionViewCell: PreviewCollectionViewCell {
                     let url = Endpoint.download(file: file).url
                     let headers = ["Authorization": "Bearer \(token.accessToken)"]
                     let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         self.player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
                         self.setUpObservers()
                     }

--- a/kDrive/UI/View/Files/Preview/NoPreviewCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/NoPreviewCollectionViewCell.swift
@@ -78,7 +78,7 @@ class NoPreviewCollectionViewCell: UICollectionViewCell, DownloadProgressObserve
         progressView.progress = 0
         if showProgress {
             observationToken = DownloadQueue.instance.observeFileDownloadProgress(self, fileId: file.id) { _, progress in
-                DispatchQueue.main.async { [weak self] in
+                Task { @MainActor [weak self] in
                     self?.progressView.progress = Float(progress)
                 }
             }

--- a/kDrive/UI/View/Files/Preview/VideoCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/VideoCollectionViewCell.swift
@@ -75,7 +75,7 @@ class VideoCollectionViewCell: PreviewCollectionViewCell {
                     let url = Endpoint.download(file: file).url
                     let headers = ["Authorization": "Bearer \(token.accessToken)"]
                     let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         self.player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
                     }
                 } else {

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -93,7 +93,7 @@ class UploadTableViewCell: InsetTableViewCell {
     }
 
     private func addThumbnail(image: UIImage) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             self.cardContentView.iconView.layer.cornerRadius = UIConstants.imageCornerRadius
             self.cardContentView.iconView.contentMode = .scaleAspectFill
             self.cardContentView.iconView.layer.masksToBounds = true

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -78,6 +78,7 @@ class UploadTableViewCell: InsetTableViewCell {
         } else {
             cardContentView.retryButton?
                 .isHidden = (uploadFile.maxRetryCount > 0) // Display retry for uploads that reached automatic retry limit
+
             var status = KDriveResourcesStrings.Localizable.uploadInProgressPending
             if ReachabilityListener.instance.currentStatus == .offline {
                 status = KDriveResourcesStrings.Localizable.uploadNetworkErrorDescription
@@ -111,7 +112,11 @@ class UploadTableViewCell: InsetTableViewCell {
         let uploadFileId = uploadFile.id
         currentFileId = uploadFileId
 
-        // Set initial progress value
+        // Set initial text
+        cardContentView.titleLabel.text = uploadFile.name
+        setStatusFor(uploadFile: uploadFile)
+
+        // Set initial progress value if any
         if let progress {
             updateProgress(fileId: uploadFileId, progress: progress, animated: true)
         }
@@ -135,9 +140,6 @@ class UploadTableViewCell: InsetTableViewCell {
             }
         }
         progressObservation = uploadFile.observe(keyPaths: ["progress"], observationClosure)
-
-        cardContentView.titleLabel.text = uploadFile.name
-        setStatusFor(uploadFile: uploadFile)
 
         cardContentView.iconView.image = uploadFile.convertedType.icon
         thumbnailRequest = uploadFile.getThumbnail { [weak self] image in

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -677,7 +677,7 @@ public final class DriveFileManager {
                         }
                     }
                     self.notifyObserversWith(file: safeFile)
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         completion(error)
                     }
                 }

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -275,7 +275,9 @@ public struct DriveError: Error, Equatable {
         return errorWithUserInfo(.serverError, info: [.status: ErrorUserInfo(intValue: statusCode)])
     }
 
-    /// Wraps a specific detailed error into a user facing localized DriveError
+    /// Wraps a specific detailed error into a user facing localized DriveError.
+    ///
+    /// Produced object has a new identity but equatable is still true
     public func wrapping(_ underlyingError: Error) -> Self {
         let error = DriveError(type: type,
                                code: code,
@@ -284,6 +286,7 @@ public struct DriveError: Error, Equatable {
         return error
     }
 
+    /// two `DriveError`s are identical if their `code` matches
     public static func == (lhs: DriveError, rhs: DriveError) -> Bool {
         return lhs.code == rhs.code
     }

--- a/kDriveCore/Data/Models/Upload/UploadFile.swift
+++ b/kDriveCore/Data/Models/Upload/UploadFile.swift
@@ -60,6 +60,8 @@ public class UploadFile: Object, UploadFilable {
     @Persisted(primaryKey: true) public var id = ""
     @Persisted public var name = ""
     @Persisted var relativePath = ""
+    @Persisted var fileProviderItemIdentifier: String?  // NSFileProviderItemIdentifier if any
+    @Persisted var assetLocalIdentifier: String?  // PHAsset source identifier if any
     @Persisted private var url: String?
     @Persisted private var rawType = "file"
     @Persisted public var parentDirectoryId = 1
@@ -152,10 +154,10 @@ public class UploadFile: Object, UploadFilable {
     }
 
     public init(
-        id: String = UUID().uuidString,
         parentDirectoryId: Int,
         userId: Int,
         driveId: Int,
+        fileProviderItemIdentifier: String? = nil,
         url: URL,
         name: String? = nil,
         conflictOption: ConflictOption = .rename,
@@ -163,12 +165,13 @@ public class UploadFile: Object, UploadFilable {
         initiatedFromFileManager: Bool = false,
         priority: Operation.QueuePriority = .normal
     ) {
+        self.id = UUID().uuidString // We need a strictly unique id for each UploadOperation
         self.parentDirectoryId = parentDirectoryId
         self.userId = userId
         self.driveId = driveId
+        self.fileProviderItemIdentifier = fileProviderItemIdentifier
         self.url = url.path
         self.name = name ?? url.lastPathComponent
-        self.id = id
         self.shouldRemoveAfterUpload = shouldRemoveAfterUpload
         self.initiatedFromFileManager = initiatedFromFileManager
         rawType = UploadFileType.file.rawValue
@@ -189,11 +192,13 @@ public class UploadFile: Object, UploadFilable {
         shouldRemoveAfterUpload: Bool = true,
         priority: Operation.QueuePriority = .normal
     ) {
+        self.id = UUID().uuidString // We need a strictly unique id for each UploadOperation
         self.parentDirectoryId = parentDirectoryId
         self.userId = userId
         self.driveId = driveId
         self.name = name
-        id = asset.localIdentifier
+        self.assetLocalIdentifier = asset.localIdentifier
+        
         localAsset = asset
         self.shouldRemoveAfterUpload = shouldRemoveAfterUpload
         rawType = UploadFileType.phAsset.rawValue

--- a/kDriveCore/Data/Models/Upload/UploadFile.swift
+++ b/kDriveCore/Data/Models/Upload/UploadFile.swift
@@ -60,8 +60,8 @@ public class UploadFile: Object, UploadFilable {
     @Persisted(primaryKey: true) public var id = ""
     @Persisted public var name = ""
     @Persisted var relativePath = ""
-    @Persisted var fileProviderItemIdentifier: String?  // NSFileProviderItemIdentifier if any
-    @Persisted var assetLocalIdentifier: String?  // PHAsset source identifier if any
+    @Persisted var fileProviderItemIdentifier: String? // NSFileProviderItemIdentifier if any
+    @Persisted var assetLocalIdentifier: String? // PHAsset source identifier if any
     @Persisted private var url: String?
     @Persisted private var rawType = "file"
     @Persisted public var parentDirectoryId = 1
@@ -165,7 +165,7 @@ public class UploadFile: Object, UploadFilable {
         initiatedFromFileManager: Bool = false,
         priority: Operation.QueuePriority = .normal
     ) {
-        self.id = UUID().uuidString // We need a strictly unique id for each UploadOperation
+        id = UUID().uuidString // We need a strictly unique id for each UploadOperation
         self.parentDirectoryId = parentDirectoryId
         self.userId = userId
         self.driveId = driveId
@@ -192,13 +192,13 @@ public class UploadFile: Object, UploadFilable {
         shouldRemoveAfterUpload: Bool = true,
         priority: Operation.QueuePriority = .normal
     ) {
-        self.id = UUID().uuidString // We need a strictly unique id for each UploadOperation
+        id = UUID().uuidString // We need a strictly unique id for each UploadOperation
         self.parentDirectoryId = parentDirectoryId
         self.userId = userId
         self.driveId = driveId
         self.name = name
-        self.assetLocalIdentifier = asset.localIdentifier
-        
+        assetLocalIdentifier = asset.localIdentifier
+
         localAsset = asset
         self.shouldRemoveAfterUpload = shouldRemoveAfterUpload
         rawType = UploadFileType.phAsset.rawValue

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+Error.swift
@@ -58,20 +58,21 @@ extension UploadOperation {
         try? transactionWithFile { file in
             let nsError = error as NSError
             if nsError.domain == NSURLErrorDomain {
-                // System/user cancelled requests silently handled
+                // System/user cancelled requests silently handled, some chunk upload in error for eg.
                 guard nsError.code == NSURLErrorCancelled else {
                     errorHandled = true
+                    // _not_ overriding file.error
                     return
                 }
 
                 Log.uploadOperation("NSURLError:\(error) ufid:\(self.uploadFileId)")
-                file.error = .networkError
+                file.error = .networkError.wrapping(error)
                 errorHandled = true
             }
 
             // Do nothing on taskRescheduled
             else if let error = error as? DriveError, error == .taskRescheduled {
-                file.error = .taskRescheduled
+                file.error = .taskRescheduled.wrapping(error)
                 errorHandled = true
             }
 
@@ -79,7 +80,7 @@ extension UploadOperation {
             else if let error = error as? DriveError, error == .fileNotFound {
                 file.maxRetryCount = 0
                 file.progress = nil
-                file.error = DriveError.taskCancelled // cascade deletion
+                file.error = .taskCancelled.wrapping(error) // cascade deletion
                 errorHandled = true
             }
 
@@ -89,7 +90,7 @@ extension UploadOperation {
                 self.uploadQueue.suspendAllOperations()
                 file.maxRetryCount = 0
                 file.progress = nil
-                file.error = DriveError.errorDeviceStorage.wrapping(error)
+                file.error = .errorDeviceStorage.wrapping(error)
                 errorHandled = true
             }
 
@@ -97,7 +98,7 @@ extension UploadOperation {
             else if let error = error as? UploadOperation.ErrorDomain {
                 switch error {
                 case .unableToBuildRequest:
-                    file.error = DriveError.localError.wrapping(error)
+                    file.error = .localError.wrapping(error)
 
                 case .unableToMatchUploadChunk,
                      .splitError,
@@ -106,26 +107,29 @@ extension UploadOperation {
                      .parseError,
                      .missingChunkHash:
                     self.cleanUploadFileSession(file: file)
-                    file.error = DriveError.localError.wrapping(error)
+                    file.error = .localError.wrapping(error)
 
                 case .uploadSessionTaskMissing,
                      .uploadSessionInvalid:
                     self.cleanUploadFileSession(file: file)
-                    file.error = DriveError.localError.wrapping(error)
+                    file.error = .localError.wrapping(error)
 
                 case .operationFinished, .operationCanceled:
                     Log.uploadOperation("catching operation is terminating")
                     // the operation is terminating, silent handling
+                    // _not_ overriding file.error
 
                 case .databaseUploadFileNotFound:
                     // Silently stop if an UploadFile is no longer in base
+                    // _not_ overriding file.error
                     self.cancel()
                 }
 
                 errorHandled = true
-            } else {
-                // Other DriveError
-                file.error = error as? DriveError
+            }
+
+            // other DriveError
+            else {
                 errorHandled = false
             }
         }
@@ -145,24 +149,25 @@ extension UploadOperation {
         try? transactionWithFile { file in
             defer {
                 Log.uploadOperation("catching remote error:\(error) ufid:\(self.uploadFileId)", level: .error)
-                file.error = error
             }
 
             switch error {
             case .fileAlreadyExistsError:
                 file.maxRetryCount = 0
                 file.progress = nil
+                file.error = error
 
             case .lock, .notAuthorized:
                 // simple retry
-                break
+                file.error = error
 
             case .productMaintenance, .driveMaintenance:
                 // We stop and hope the maintenance is finished at next execution
+                file.error = error
                 self.uploadQueue.suspendAllOperations()
 
             case .quotaExceeded:
-                file.error = DriveError.quotaExceeded
+                file.error = .quotaExceeded.wrapping(error)
                 file.maxRetryCount = 0
                 file.progress = nil
                 self.uploadQueue.suspendAllOperations()
@@ -175,15 +180,18 @@ extension UploadOperation {
                  .uploadTokenIsNotValid:
                 self.cleanUploadFileSession(file: file)
                 file.progress = nil
+                file.error = error
 
             case .uploadTokenCanceled:
                 // We cancelled the upload session, running chunks requests are failing
                 file.progress = nil
+                // _not_ overriding file.error
 
             case .objectNotFound, .uploadDestinationNotFoundError, .uploadDestinationNotWritableError:
                 // If we get an ”object not found“ error, we cancel all further uploads in this folder
                 file.maxRetryCount = 0
                 file.progress = nil
+                file.error = error
                 self.cleanUploadFileSession(file: file)
                 self.uploadQueue.cancelAllOperations(withParent: file.parentDirectoryId,
                                                      userId: file.userId,
@@ -196,12 +204,12 @@ extension UploadOperation {
                 }
 
             case .networkError:
+                // simple retry
                 file.error = error
-                self.cancel()
 
             default:
                 // simple retry
-                break
+                file.error = error
             }
 
             errorHandled = true

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -1117,13 +1117,11 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
                 file.error = .taskRescheduled
                 Log.uploadOperation("Rescheduling didReschedule .taskRescheduled ufid:\(self.uploadFileId)")
 
-                let breadcrumb = Breadcrumb(level: .info, category: "BackgroundUploadTask")
-                breadcrumb.message = "Rescheduling file \(file.name)"
-                breadcrumb.data = ["File id": self.uploadFileId,
-                                   "File name": file.name,
-                                   "File size": file.size,
-                                   "File type": file.type.rawValue]
-                SentrySDK.addBreadcrumb(breadcrumb)
+                let metadata = ["File id": self.uploadFileId,
+                                "File name": file.name,
+                                "File size": file.size,
+                                "File type": file.type.rawValue]
+                SentryDebug.uploadOperationRescheduledBreadcrumb(self.uploadFileId, metadata)
             }
 
             self.uploadNotifiable.sendPausedNotificationIfNeeded()

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -104,20 +104,16 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
     var uploadTasks = [String: URLSessionUploadTask]()
 
     private let urlSession: URLSession
-    private let itemIdentifier: NSFileProviderItemIdentifier?
     private var expiringActivity: ExpiringActivityable?
 
     public var result: UploadCompletionResult
 
     // MARK: - Public methods -
 
-    public required init(uploadFileId: String,
-                         urlSession: URLSession = URLSession.shared,
-                         itemIdentifier: NSFileProviderItemIdentifier? = nil) {
+    public required init(uploadFileId: String, urlSession: URLSession = URLSession.shared) {
         Log.uploadOperation("init ufid:\(uploadFileId)")
         self.uploadFileId = uploadFileId
         self.urlSession = urlSession
-        self.itemIdentifier = itemIdentifier
         result = UploadCompletionResult()
 
         super.init()
@@ -211,7 +207,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
 
         Log.uploadOperation("Asking for an upload Session \(uploadFileId)")
 
-        let uploadId = self.uploadFileId
+        let uploadId = uploadFileId
         var uploadingSession: UploadingSessionTask?
         var error: ErrorDomain?
         try transactionWithFile { file in

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -436,7 +436,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
             // Clean the remote session, if valid. Invalid ones are already gone server side.
             let driveId = file.driveId
             let userId = file.userId
-            let uploadingSession = file.uploadingSession
+            let uploadingSession = file.uploadingSession?.detached()
             self.enqueue {
                 guard let session = uploadingSession,
                       !session.isExpired else {

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -439,7 +439,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
             let uploadingSession = file.uploadingSession
             self.enqueue {
                 guard let session = uploadingSession,
-                      session.isExpired == false else {
+                      !session.isExpired else {
                     return
                 }
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperationable.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperationable.swift
@@ -50,14 +50,11 @@ extension Operation: Operationable {}
 
 /// Something that can upload a file.
 public protocol UploadOperationable: Operationable {
-    /// init an UploadOperationable
+    /// Central init method for `UploadOperation`
     /// - Parameters:
-    ///   - uploadFileId: the identifier of the UploadFile in base
-    ///   - urlSession: the url session to use
-    ///   - itemIdentifier: the itemIdentifier
-    init(uploadFileId: String,
-         urlSession: URLSession,
-         itemIdentifier: NSFileProviderItemIdentifier?)
+    ///   - uploadFileId: The uniq identifier of the `UploadFile` entity in database. Must be unique and not shared with other `UploadOperation`
+    ///   - urlSession: The URL session used to perform authenticated requests
+    init(uploadFileId: String, urlSession: URLSession)
 
     /// Network completion handler
     func uploadCompletion(data: Data?, response: URLResponse?, error: Error?)

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Observation.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Observation.swift
@@ -80,7 +80,7 @@ extension UploadQueue: UploadQueueObservable {
                 }
 
                 if fileId == nil || uploadFile.id == fileId {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         closure(uploadFile, driveFile)
                     }
                 }
@@ -110,7 +110,7 @@ extension UploadQueue: UploadQueueObservable {
                 }
 
                 if parentId == updatedParentId {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         closure(updatedParentId, count)
                     }
                 }
@@ -140,7 +140,7 @@ extension UploadQueue: UploadQueueObservable {
                 }
 
                 if driveId == updatedDriveId {
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         closure(updatedDriveId, count)
                     }
                 }

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Publish.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Publish.swift
@@ -60,7 +60,7 @@ extension UploadQueue: UploadPublishable {
                 let uploadCount = self.getUploadingFiles(withParent: parentId, userId: userId, driveId: driveId, using: realm)
                     .count
                 self.observations.didChangeUploadCountInParent.values.forEach { closure in
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         closure(parentId, uploadCount)
                     }
                 }
@@ -76,7 +76,7 @@ extension UploadQueue: UploadPublishable {
             try? transactionWithUploadRealm { realm in
                 let uploadCount = self.getUploadingFiles(userId: userId, driveId: driveId, using: realm).count
                 self.observations.didChangeUploadCountInDrive.values.forEach { closure in
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         closure(driveId, uploadCount)
                     }
                 }
@@ -94,7 +94,7 @@ extension UploadQueue: UploadPublishable {
                     return
                 }
 
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     closure(uploadFile, result.driveFile)
                 }
             }

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -456,7 +456,7 @@ extension UploadQueue: UploadQueueable {
         let priority = uploadFile.priority
         OperationQueueHelper.disableIdleTimer(true)
 
-        let operation = UploadOperation(uploadFileId: uploadFileId, urlSession: bestSession, itemIdentifier: itemIdentifier)
+        let operation = UploadOperation(uploadFileId: uploadFileId, urlSession: bestSession)
         operation.queuePriority = priority
         operation.completionBlock = { [weak self] in
             guard let self else { return }

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -119,7 +119,7 @@ extension UploadQueue: UploadQueueable {
                                          itemIdentifier: NSFileProviderItemIdentifier? = nil) -> UploadOperationable? {
         Log.uploadQueue("saveToRealmAndAddToQueue ufid:\(uploadFile.id)")
         SentryDebug.uploadQueueBreadcrumb(metadata: ["uploadFile.id": uploadFile.id])
-        
+
         assert(!uploadFile.isManagedByRealm, "we expect the file to be outside of realm at the moment")
 
         // Save drive and directory

--- a/kDriveCore/UI/Alert/AlertChoiceViewController.swift
+++ b/kDriveCore/UI/Alert/AlertChoiceViewController.swift
@@ -149,7 +149,7 @@ public class AlertChoiceViewController: AlertViewController {
             setLoading(true)
             DispatchQueue.global(qos: .userInitiated).async {
                 self.handler?(self.selectedIndex)
-                DispatchQueue.main.async {
+                Task { @MainActor in
                     self.setLoading(false)
                     self.dismiss(animated: true)
                 }

--- a/kDriveCore/Utils/AbstractLog+Category.swift
+++ b/kDriveCore/Utils/AbstractLog+Category.swift
@@ -32,6 +32,9 @@ public enum Log {
                                     line: UInt = #line,
                                     tag: Any? = nil) {
         let category = "FileProvider"
+
+        SentryDebug.loggerBreadcrumb(caller: "\(function)", category: category)
+
         ABLog(message(),
               category: category,
               level: level,
@@ -54,6 +57,9 @@ public enum Log {
                                    line: UInt = #line,
                                    tag: Any? = nil) {
         let category = "AppDelegate"
+
+        SentryDebug.loggerBreadcrumb(caller: "\(function)", category: category)
+
         ABLog(message(),
               category: category,
               level: level,
@@ -76,6 +82,7 @@ public enum Log {
                                             line: UInt = #line,
                                             tag: Any? = nil) {
         let category = "PhotoLibraryUploader"
+
         ABLog(message(),
               category: category,
               level: level,
@@ -98,6 +105,9 @@ public enum Log {
                                         line: UInt = #line,
                                         tag: Any? = nil) {
         let category = "BGTaskScheduling"
+
+        SentryDebug.loggerBreadcrumb(caller: "\(function)", category: category)
+
         ABLog(message(),
               category: category,
               level: level,
@@ -120,6 +130,9 @@ public enum Log {
                                         line: UInt = #line,
                                         tag: Any? = nil) {
         let category = "BackgroundSessionManager"
+
+        SentryDebug.loggerBreadcrumb(caller: "\(function)", category: category)
+
         ABLog(message(),
               category: category,
               level: level,

--- a/kDriveCore/Utils/NotificationsHelper.swift
+++ b/kDriveCore/Utils/NotificationsHelper.swift
@@ -149,7 +149,7 @@ public struct NotificationsHelper: NotificationsHelpable {
 
         // We capture all upload errors presented to the user, with underlyingError if any
         SentryDebug.uploadNotificationError(metadata)
-        
+
         // Add a breadcrumb
         SentryDebug.uploadNotificationBreadcrumb(metadata)
     }

--- a/kDriveCore/Utils/NotificationsHelper.swift
+++ b/kDriveCore/Utils/NotificationsHelper.swift
@@ -223,7 +223,7 @@ public struct NotificationsHelper: NotificationsHelpable {
     // MARK: - Private
 
     private func sendImmediately(notification: UNMutableNotificationContent, id: String, action: IKSnackBar.Action? = nil) {
-        DispatchQueue.main.async {
+        Task { @MainActor in
             if notification.categoryIdentifier == CategoryIdentifier.upload && !NotificationsHelper.importNotificationsEnabled {
                 return
             }

--- a/kDriveCore/Utils/OperationQueueHelper.swift
+++ b/kDriveCore/Utils/OperationQueueHelper.swift
@@ -24,7 +24,7 @@ enum OperationQueueHelper {
         Log.uploadQueue("disableIdleTimer shouldBeDisabled:\(shouldBeDisabled) hasOperationsInQueue:\(hasOperationsInQueue)")
 
         #if !ISEXTENSION
-        DispatchQueue.main.async {
+        Task { @MainActor in
             if shouldBeDisabled {
                 UIApplication.shared.isIdleTimerDisabled = true
             } else if !hasOperationsInQueue {

--- a/kDriveCore/Utils/SentryDebug.swift
+++ b/kDriveCore/Utils/SentryDebug.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Sentry
+import UIKit
 
 /// Something to track errors
 public enum SentryDebug {
@@ -78,6 +79,12 @@ public enum SentryDebug {
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 
+    static func uploadOperationRetryCountDecreaseBreadcrumb(_ uploadFileId: String, _ retryCount: Int) {
+        let breadcrumb = Breadcrumb(level: .info, category: Category.uploadOperation)
+        breadcrumb.message = "Background task for \(uploadFileId) try decrement retryCount:\(retryCount)"
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
     static func uploadOperationErrorHandling(_ error: Error, _ metadata: [String: Any]) {
         // Add a breadcrumb for any error
         let breadcrumb = Breadcrumb(level: .error, category: Category.uploadOperation)
@@ -121,5 +128,18 @@ public enum SentryDebug {
             breadcrumb.data = metadata
         }
         SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    // MARK: - Logger
+
+    public static func loggerBreadcrumb(caller: String, category: String) {
+        Task { @MainActor in
+            let message = "\(caller) foreground:\(UIApplication.shared.applicationState != .background)"
+            Task {
+                let breadcrumb = Breadcrumb(level: .info, category: category)
+                breadcrumb.message = message
+                SentrySDK.addBreadcrumb(breadcrumb)
+            }
+        }
     }
 }

--- a/kDriveCore/Utils/SentryDebug.swift
+++ b/kDriveCore/Utils/SentryDebug.swift
@@ -81,7 +81,14 @@ public enum SentryDebug {
 
     static func uploadOperationRetryCountDecreaseBreadcrumb(_ uploadFileId: String, _ retryCount: Int) {
         let breadcrumb = Breadcrumb(level: .info, category: Category.uploadOperation)
-        breadcrumb.message = "Background task for \(uploadFileId) try decrement retryCount:\(retryCount)"
+        breadcrumb.message = "Try decrement retryCount:\(retryCount) for \(uploadFileId)"
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+    
+    static func uploadOperationRescheduledBreadcrumb(_ uploadFileId: String, _ metadata: [String: Any]) {
+        let breadcrumb = Breadcrumb(level: .info, category: Category.uploadOperation)
+        breadcrumb.message = "UploadOperation for \(uploadFileId) rescheduled"
+        breadcrumb.data = metadata
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 

--- a/kDriveCore/Utils/SentryDebug.swift
+++ b/kDriveCore/Utils/SentryDebug.swift
@@ -60,6 +60,12 @@ public enum SentryDebug {
         SentrySDK.addBreadcrumb(breadcrumb)
     }
 
+    static func uploadOperationCleanSessionRemotelyBreadcrumb(_ uploadFileId: String, _ success: Bool) {
+        let breadcrumb = Breadcrumb(level: .error, category: Category.uploadOperation)
+        breadcrumb.message = "Clean uploading session remotely for \(uploadFileId), success:\(success)"
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
     static func uploadOperationCleanSessionBreadcrumb(_ uploadFileId: String) {
         let breadcrumb = Breadcrumb(level: .error, category: Category.uploadOperation)
         breadcrumb.message = "Clean uploading session for \(uploadFileId)"

--- a/kDriveFileProvider/FileProviderExtension+Thumbnail.swift
+++ b/kDriveFileProvider/FileProviderExtension+Thumbnail.swift
@@ -61,7 +61,7 @@ extension FileProviderExtension {
                     // Call the per thumbnail completion handler for each thumbnail requested.
                     perThumbnailCompletionHandler(identifier, mappedDataOrNil, myErrorOrNil)
 
-                    DispatchQueue.main.async {
+                    Task { @MainActor in
                         if progress.isFinished {
                             // Call this completion handler once all thumbnails are complete
                             completionHandler(nil)

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -302,14 +302,14 @@ final class FileProviderExtension: NSFileProviderExtension {
     }
 
     func backgroundUploadItem(_ item: FileProviderItem, completion: (() -> Void)? = nil) {
-        let uploadFileId = item.itemIdentifier.rawValue
-        Log.fileProvider("backgroundUploadItem uploadFileId:\(uploadFileId)")
+        let fileProviderItemIdentifier = item.itemIdentifier.rawValue
+        Log.fileProvider("backgroundUploadItem fileProviderItemIdentifier:\(fileProviderItemIdentifier)")
         enqueue {
             let uploadFile = UploadFile(
-                id: uploadFileId,
                 parentDirectoryId: item.parentItemIdentifier.toFileId()!,
                 userId: self.driveFileManager.drive.userId,
                 driveId: self.driveFileManager.drive.id,
+                fileProviderItemIdentifier: fileProviderItemIdentifier,
                 url: item.storageUrl,
                 name: item.filename,
                 conflictOption: .version,
@@ -318,7 +318,7 @@ final class FileProviderExtension: NSFileProviderExtension {
             )
 
             var observationToken: ObservationToken?
-            observationToken = self.uploadQueueObservable.observeFileUploaded(self, fileId: uploadFileId) { uploadedFile, _ in
+            observationToken = self.uploadQueueObservable.observeFileUploaded(self, fileId: uploadFile.id) { uploadedFile, _ in
                 observationToken?.cancel()
                 defer {
                     self.manager.signalEnumerator(for: item.parentItemIdentifier) { _ in


### PR DESCRIPTION
### Changes
- feat(UploadOperation): at restart, an invalid upload session will be regenerated before we go further.
- refactor(UploadOperation+Error): reviewed and reworked error handling for more coherency.
- feat(UploadOperation): delete remote uplaod session when cleaning session if it is still valid.
- chore: Update to latest package versions
- More breadcrumbs for app lifecycle and background task scheduling events
- feat(AppDelegate): Suspend upload and download queue on app termination (user intend to stop the app)
- fix(UploadOperation): retry count at zero will throw
- fix(UploadFile): the identifier is always a UUID.
- feat(UploadFile): New fields to track FileProviderIdentifier and PHAsset.localIdentifier
- chore(UploadOperation): Minor refactor of init method

