### PR TITLE
fix: Correctly shutdown MQTT client on deinit

### DIFF
--- a/kDriveCore/Data/MQService/MQService.swift
+++ b/kDriveCore/Data/MQService/MQService.swift
@@ -60,6 +60,10 @@ public class MQService {
         return min(initialReconnectionTimeout * Double(2 * reconnections), maxReconnectionTimeout)
     }
 
+    deinit {
+        try? client.syncShutdownGracefully()
+    }
+
     public init() {
         // META: keep SonarCloud happy
     }


### PR DESCRIPTION
MQTT throws a fatal error in case we deinit without shutting down