### PR TITLE
fix: Prevent a crash message on TestFlight when force closing the app.

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -152,7 +152,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
 
         // The documentation specifies `approximately five seconds [to] return` from applicationWillTerminate
         // Therefore to not display a crash feedback on TestFlight, we give up after 4.5 seconds
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 4.5) {
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + AppDelegateConstants.closeApplicationGiveUpTime) {
             group.leave()
         }
 

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -152,7 +152,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
 
         // The documentation specifies `approximately five seconds [to] return` from applicationWillTerminate
         // Therefore to not display a crash feedback on TestFlight, we give up after 4.5 seconds
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 4.5) {
             group.leave()
         }
 

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -149,6 +149,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
         uploadQueue.waitForCompletion {
             group.leave()
         }
+
+        // The documentation specifies `approximately five seconds [to] return` from applicationWillTerminate
+        // Therefore to not display a crash feedback on TestFlight, we give up after 4.5 seconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
+            group.leave()
+        }
+
         group.enter()
         group.wait()
     }
@@ -167,7 +174,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
         }
     }
 
-    func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         shortcutItemToProcess = shortcutItem
     }
 
@@ -264,7 +275,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
                 MatomoUtils.track(eventWithCategory: .shortcuts, name: "scan")
             case Constants.applicationShortcutSearch:
                 let viewModel = SearchFilesViewModel(driveFileManager: driveFileManager)
-                viewController.present(SearchViewController.instantiateInNavigationController(viewModel: viewModel), animated: true)
+                viewController.present(
+                    SearchViewController.instantiateInNavigationController(viewModel: viewModel),
+                    animated: true
+                )
                 MatomoUtils.track(eventWithCategory: .shortcuts, name: "search")
             case Constants.applicationShortcutUpload:
                 let openMediaHelper = OpenMediaHelper(driveFileManager: driveFileManager)

--- a/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
@@ -44,7 +44,7 @@ public final class DownloadTask: Object {
                 sessionUrl: String) {
         super.init()
         // primary key is set as default value
-        
+
         self.fileId = fileId
         self.isDirectory = isDirectory
         self.driveId = driveId

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -16,11 +16,11 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Algorithms
 import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
 import RealmSwift
-import Algorithms
 
 public protocol UploadQueueable {
     func getOperation(forUploadFileId uploadFileId: String) -> UploadOperationable?

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -123,7 +123,7 @@ public extension PhotoLibraryUploader {
                     return
                 }
 
-                let algorithmImportVersion = self.currentDiffAlgorithmVersion
+                let algorithmImportVersion = currentDiffAlgorithmVersion
 
                 // New UploadFile to be uploaded
                 let uploadFile = UploadFile(
@@ -234,7 +234,10 @@ public extension PhotoLibraryUploader {
                bestResourceSHA256 ?? "NULL"
            ))
            .first != nil {
-            Log.photoLibraryUploader("AlreadyUploaded match with identifier:\(localIdentifier) hash:\(String(describing: bestResourceSHA256)) ")
+            Log
+                .photoLibraryUploader(
+                    "AlreadyUploaded match with identifier:\(localIdentifier) hash:\(String(describing: bestResourceSHA256)) "
+                )
             return true
         }
 

--- a/kDriveCore/Utils/Constants.swift
+++ b/kDriveCore/Utils/Constants.swift
@@ -169,3 +169,12 @@ public enum Constants {
         }
     }
 }
+
+/// App lifecycle Constants
+public enum AppDelegateConstants {
+    /// Amount of time we can use max in `applicationWillTerminate`
+    ///
+    /// The documentation specifies `approximately five seconds [to] return` from applicationWillTerminate
+    /// Therefore to not display a crash feedback on TestFlight, we give up after 4.5 seconds
+    public static let closeApplicationGiveUpTime = 4.5
+}

--- a/kDriveCore/Utils/KeychainHelper.swift
+++ b/kDriveCore/Utils/KeychainHelper.swift
@@ -148,7 +148,12 @@ public enum KeychainHelper {
                 DDLogInfo("Successfully saved token ? \(resultCode == noErr)")
 
                 let metadata = token.breadcrumbMetadata(keychainError: resultCode)
-                SentryDebug.addBreadcrumb(message: "Successfully saved token", category: .apiToken, level: .info, metadata: metadata)
+                SentryDebug.addBreadcrumb(
+                    message: "Successfully saved token",
+                    category: .apiToken,
+                    level: .info,
+                    metadata: metadata
+                )
             }
         }
         if resultCode != noErr {

--- a/kDriveCore/Utils/Sentry/SentryDebug+Realm.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Realm.swift
@@ -47,6 +47,6 @@ extension SentryDebug {
                                        "form": form,
                                        "to": to,
                                        "function": function]
-        Self.addBreadcrumb(message: Category.realmMigration.rawValue, category: .realmMigration, level: .info, metadata: metadata)
+        addBreadcrumb(message: Category.realmMigration.rawValue, category: .realmMigration, level: .info, metadata: metadata)
     }
 }

--- a/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
@@ -22,11 +22,11 @@ extension SentryDebug {
     // MARK: - UploadOperation
 
     static func uploadOperationBeginBreadcrumb(_ uploadFileId: String) {
-        Self.addBreadcrumb(message: "Begin for \(uploadFileId)", category: .uploadOperation, level: .info)
+        addBreadcrumb(message: "Begin for \(uploadFileId)", category: .uploadOperation, level: .info)
     }
 
     static func uploadOperationEndBreadcrumb(_ uploadFileId: String, _ error: Error?) {
-        Self.addBreadcrumb(
+        addBreadcrumb(
             message: "End for \(uploadFileId)",
             category: .uploadOperation,
             level: (error == nil) ? .info : .error,
@@ -35,37 +35,37 @@ extension SentryDebug {
     }
 
     static func uploadOperationFinishedBreadcrumb(_ uploadFileId: String) {
-        Self.addBreadcrumb(message: "Finished for \(uploadFileId)", category: .uploadOperation, level: .info)
+        addBreadcrumb(message: "Finished for \(uploadFileId)", category: .uploadOperation, level: .info)
     }
 
     static func uploadOperationCloseSessionAndEndBreadcrumb(_ uploadFileId: String) {
         let message = "Close session and end for \(uploadFileId)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .info)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .info)
     }
 
     static func uploadOperationCleanSessionRemotelyBreadcrumb(_ uploadFileId: String, _ success: Bool) {
         let message = "Clean uploading session remotely for \(uploadFileId), success:\(success)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
     static func uploadOperationCleanSessionBreadcrumb(_ uploadFileId: String) {
         let message = "Clean uploading session for \(uploadFileId)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
     static func uploadOperationBackgroundExpiringBreadcrumb(_ uploadFileId: String) {
         let message = "Background task expiring for \(uploadFileId)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
     static func uploadOperationRetryCountDecreaseBreadcrumb(_ uploadFileId: String, _ retryCount: Int) {
         let message = "Try decrement retryCount:\(retryCount) for \(uploadFileId)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .info)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .info)
     }
 
     static func uploadOperationRescheduledBreadcrumb(_ uploadFileId: String, _ metadata: [String: Any]) {
         let message = "UploadOperation for \(uploadFileId) rescheduled"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .info)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .info)
     }
 
     static func uploadOperationErrorHandling(_ message: String, _ error: Error, _ metadata: [String: Any]) {
@@ -84,27 +84,27 @@ extension SentryDebug {
 
     static func uploadOperationChunkInFailureCannotCloseSessionBreadcrumb(_ uploadFileId: String, _ metadata: [String: Any]) {
         let message = "Cannot close session for \(uploadFileId)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error, metadata: metadata)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error, metadata: metadata)
     }
 
     public static func updateFileListBreadcrumb(id: String, step: String) {
         let message = "updateFileList opId: \(id) step: \(step)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
     public static func filesObservationBreadcrumb(state: String) {
         let message = "files modified: \(state)"
-        Self.addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
     // MARK: - Upload notifications
 
     static func uploadNotificationError(_ metadata: [String: Any]) {
-        Self.capture(message: ErrorNames.uploadErrorUserNotification, extras: metadata)
+        capture(message: ErrorNames.uploadErrorUserNotification, extras: metadata)
     }
 
     static func uploadNotificationBreadcrumb(_ metadata: [String: Any]) {
-        Self.addBreadcrumb(
+        addBreadcrumb(
             message: ErrorNames.uploadErrorUserNotification,
             category: .uploadOperation,
             level: .error,

--- a/kDriveCore/Utils/Sentry/SentryDebug.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug.swift
@@ -52,8 +52,8 @@ public enum SentryDebug {
         let metadata = ["function": function]
         let message = "The ViewModel is not linked to a view to dispatch changes"
 
-        Self.addBreadcrumb(message: message, category: .viewModel, level: .error, metadata: metadata)
-        Self.capture(message: ErrorNames.viewModelNotConnectedToView, extras: metadata)
+        addBreadcrumb(message: message, category: .viewModel, level: .error, metadata: metadata)
+        capture(message: ErrorNames.viewModelNotConnectedToView, extras: metadata)
     }
 
     // MARK: - Logger
@@ -63,14 +63,14 @@ public enum SentryDebug {
             let isForeground = await UIApplication.shared.applicationState != .background
             let message = "\(caller) foreground:\(isForeground)"
 
-            Self.addBreadcrumb(message: message, category: .uploadOperation, level: isError ? .error : .info, metadata: metadata)
+            addBreadcrumb(message: message, category: .uploadOperation, level: isError ? .error : .info, metadata: metadata)
         }
     }
 
     // MARK: - No Window
 
     public static func captureNoWindow() {
-        Self.capture(message: "Trying to call show with no window")
+        capture(message: "Trying to call show with no window")
     }
 
     // MARK: - SHARED -


### PR DESCRIPTION
If stopping the upload queue takes too much time when trying to force close the app.
We gracefully exit before the system kills the app. 
Which currently shows a crash message to end users on TestFlight and counting as a crash in statistics.