### PR TITLE
feat: Explicit atlantis disabled in tests

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -102,7 +102,7 @@ let project = Project(name: "kDrive",
                                  dependencies: [
                                      .target(name: "kDrive")
                                  ],
-                                 settings: .settings(base: Constants.baseSettings)),
+                                 settings: .settings(base: Constants.testSettings)),
                           Target(name: "kDriveAPITests",
                                  platform: .iOS,
                                  product: .unitTests,
@@ -116,7 +116,7 @@ let project = Project(name: "kDrive",
                                  dependencies: [
                                      .target(name: "kDrive")
                                  ],
-                                 settings: .settings(base: Constants.baseSettings)),
+                                 settings: .settings(base: Constants.testSettings)),
                           Target(name: "kDriveUITests",
                                  platform: .iOS,
                                  product: .uiTests,
@@ -127,7 +127,8 @@ let project = Project(name: "kDrive",
                                  dependencies: [
                                      .target(name: "kDrive"),
                                      .target(name: "kDriveCore")
-                                 ]),
+                                 ],
+                                 settings: .settings(base: Constants.testSettings)),
                           Target(name: "kDriveResources",
                                  platform: .iOS,
                                  product: .staticLibrary,

--- a/Tuist/ProjectDescriptionHelpers/Constants.swift
+++ b/Tuist/ProjectDescriptionHelpers/Constants.swift
@@ -19,6 +19,10 @@
 import ProjectDescription
 
 public enum Constants {
+    public static let testSettings: [String: SettingValue] = [
+        "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "TEST DEBUG"
+    ]
+
     public static let baseSettings = SettingsDictionary()
         .automaticCodeSigning(devTeam: "864VDCS2QY")
         .currentProjectVersion("1")

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -107,7 +107,7 @@ class FileListViewModel: SelectDelegate {
     /// Internal realm collection of Files observed
     ///
     /// They should be frozen by convention.
-    #if DEBUG
+    #if DEBUG || TEST
     var _frozenFiles = AnyRealmCollection(List<File>()) {
         willSet {
             for item in newValue {

--- a/kDrive/Utils/MatomoUtils.swift
+++ b/kDrive/Utils/MatomoUtils.swift
@@ -24,7 +24,7 @@ import MatomoTracker
 class MatomoUtils {
     static let shared: MatomoTracker = {
         let tracker = MatomoTracker(siteId: "8", baseURL: URLConstants.matomo.url)
-        #if DEBUG
+        #if DEBUG || TEST
         tracker.isOptedOut = true
         #endif
         @InjectService var accountManager: AccountManageable

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -81,7 +81,7 @@ public enum Logging {
     private static func initNetworkLogging() {
         #if DEBUG && !TEST
         if !Bundle.main.isExtension {
-//                Atlantis.start(hostName: ProcessInfo.processInfo.environment["hostname"])
+            Atlantis.start(hostName: ProcessInfo.processInfo.environment["hostname"])
         }
         #endif
     }

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -50,7 +50,7 @@ public enum Logging {
         ]
         SentryDebug.capture(error: error, context: context, contextKey: "Realm")
 
-        #if DEBUG
+        #if DEBUG && !TEST
         copyDebugInformations()
         DDLogError(
             "Realm files \(realmConfiguration.fileURL?.lastPathComponent ?? "") will be deleted to prevent migration error for next launch"
@@ -79,7 +79,7 @@ public enum Logging {
     }
 
     private static func initNetworkLogging() {
-        #if DEBUG
+        #if DEBUG && !TEST
         if !Bundle.main.isExtension {
 //                Atlantis.start(hostName: ProcessInfo.processInfo.environment["hostname"])
         }
@@ -95,7 +95,7 @@ public enum Logging {
                     "AppLock enabled": UserDefaults.shared.isAppLockEnabled,
                     "Wifi only enabled": UserDefaults.shared.isWifiOnly
                 ]
-                #if DEBUG
+                #if DEBUG || TEST
                 return nil
                 #else
                 return event
@@ -105,7 +105,7 @@ public enum Logging {
     }
 
     private static func copyDebugInformations() {
-        #if DEBUG
+        #if DEBUG && !TEST
         guard !Bundle.main.isExtension else { return }
         let fileManager = FileManager.default
         let debugDirectory = (fileManager.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(

--- a/kDriveTestShared/TestsPreconditions.swift
+++ b/kDriveTestShared/TestsPreconditions.swift
@@ -1,0 +1,36 @@
+/*
+ Infomaniak Mail - iOS App
+ Copyright (C) 2022 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import XCTest
+
+/// Sanity checks of SWIFT_ACTIVE_COMPILATION_CONDITIONS
+final class TestsPreconditions: XCTestCase {
+    func testTestFlagIsSet() {
+        // WHEN
+        #if !TEST
+        XCTFail("the TEST flag is expected to be set in test target")
+        #endif
+    }
+
+    func testDebugFlagIsSet() {
+        // WHEN
+        #if !DEBUG
+        XCTFail("the DEBUG flag is expected to be set in test target")
+        #endif
+    }
+}


### PR DESCRIPTION
### Abstract 

In order to control the behaviour of the app in Test mode, a new TEST flag was introduced. (like in Mail)
It is used to disable Atlantis in Test mode between other things.

A test was also added to make sure the Flag is correctly set.