### PR TITLE
fix: Prevent refetching PHAsset

### DIFF
--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -29,7 +29,7 @@ public final class DriveFileManager {
     /// Something to centralize schema versioning
     enum RealmSchemaVersion {
         /// Current version of the Upload Realm
-        static let upload: UInt64 = 17
+        static let upload: UInt64 = 18
 
         /// Current version of the Drive Realm
         static let drive: UInt64 = 9

--- a/kDriveCore/Data/Models/Upload/UploadingSessionTask.swift
+++ b/kDriveCore/Data/Models/Upload/UploadingSessionTask.swift
@@ -30,9 +30,6 @@ public final class UploadingSessionTask: EmbeddedObject {
     @Persisted public var sessionExpiration: Date
     @Persisted public var chunkTasks: List<UploadingChunkTask>
 
-    /// The source file path
-    @Persisted public var filePath: String
-
     override public init() {
         // Required by Realm
         super.init()
@@ -40,14 +37,12 @@ public final class UploadingSessionTask: EmbeddedObject {
 
     public convenience init(uploadSession: UploadSession,
                             sessionExpiration: Date,
-                            chunkTasks: List<UploadingChunkTask>,
-                            filePath: String) {
+                            chunkTasks: List<UploadingChunkTask>) {
         self.init()
 
         self.uploadSession = uploadSession
         self.sessionExpiration = sessionExpiration
         self.chunkTasks = chunkTasks
-        self.filePath = filePath
     }
 
     // MARK: - Computed Properties

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+PHAsset.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+PHAsset.swift
@@ -38,6 +38,16 @@ extension UploadOperation {
             return
         }
 
+        // Check if we are not restarting a session for an already imported asset
+        if let existingFileURL = file.pathURL,
+           fileManager.fileExists(atPath: existingFileURL.path) {
+            try transactionWithFile { file in
+                file.uploadingSession?.filePath = existingFileURL.path
+            }
+
+            return
+        }
+
         // Async load the url of the asset
         guard let url = await photoLibraryUploader.getUrl(for: asset) else {
             Log.uploadOperation("Failed to get photo asset URL ufid:\(uploadFileId)", level: .error)

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+PHAsset.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+PHAsset.swift
@@ -41,10 +41,6 @@ extension UploadOperation {
         // Check if we are not restarting a session for an already imported asset
         if let existingFileURL = file.pathURL,
            fileManager.fileExists(atPath: existingFileURL.path) {
-            try transactionWithFile { file in
-                file.uploadingSession?.filePath = existingFileURL.path
-            }
-
             return
         }
 
@@ -58,7 +54,6 @@ extension UploadOperation {
         Log.uploadOperation("Got photo asset, writing URL:\(url) ufid:\(uploadFileId)")
         try transactionWithFile { file in
             file.pathURL = url
-            file.uploadingSession?.filePath = url.path
         }
     }
 }

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -32,7 +32,7 @@ extension UploadOperation {
                 throw ErrorDomain.uploadSessionTaskMissing
             }
 
-            filePath = uploadingSessionTask.filePath
+            filePath = file.pathURL?.path ?? ""
             let sessionToken = uploadingSessionTask.token
 
             // Look for the next chunk to generate

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadSession.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadSession.swift
@@ -405,9 +405,6 @@ extension UploadOperation {
             // Store the session token asap as a non null ivar
             uploadingSessionTask.token = session.token
 
-            // The file at the moment we created the UploadingSessionTask
-            uploadingSessionTask.filePath = fileUrl.path
-
             // Store the session
             uploadingSessionTask.uploadSession = session
 


### PR DESCRIPTION
Currently a new file corresponding to the PHAsset is fetched every time an upload session is restarted.
Because of how we get the PHAsset the new file has a new file and is effectively duplicated with a new name. Old files are never cleared because we only clear the new file upon upload completion.