### PR TITLE
feat: Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @Infomaniak/ios


### PR DESCRIPTION
This pull request removes the CODEOWNERS file, allowing us to select our own reviewers or fallback to the iOS team if no specific reviewer is necessary. This change is expected to improve our GitHub notifications.