### PR TITLE
fix: ShareExtension fails to upload

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -36,7 +36,7 @@ import VersionChecker
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDelegate {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = EarlyDIHook(context: .app)
 
     private var reachabilityListener: ReachabilityListener!
     private static let currentStateVersion = 4

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
@@ -68,7 +68,7 @@ extension SaveFileViewController: FooterButtonDelegate {
 
     private func processForUpload(files: [ImportedFile], directory: File, drive: Drive) async throws {
         // We only schedule for uploading in main app target
-        let addToQueue = !Bundle.main.isExtension
+        let addToQueue = !appContextService.isExtension
         try await fileImportHelper.saveForUpload(files, in: directory, drive: drive, addToQueue: addToQueue)
         #if ISEXTENSION
         showOpenAppToContinueNotification()

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
@@ -28,6 +28,7 @@ import UIKit
 class SaveFileViewController: UIViewController {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var fileImportHelper: FileImportHelper
+    @LazyInjectService var appContextService: AppContextServiceable
 
     enum SaveFileSection {
         case alert
@@ -184,7 +185,7 @@ class SaveFileViewController: UIViewController {
     func dismiss(animated: Bool, clean: Bool = true, completion: (() -> Void)? = nil) {
         Task {
             // Cleanup file that were duplicated to appGroup on extension mode
-            if Bundle.main.isExtension && clean {
+            if appContextService.isExtension && clean {
                 await items.concurrentForEach { item in
                     try? FileManager.default.removeItem(at: item.path)
                 }

--- a/kDrive/Utils/AppFactoryService.swift
+++ b/kDrive/Utils/AppFactoryService.swift
@@ -21,14 +21,23 @@ import InfomaniakDI
 import kDriveCore
 import os.log
 
+public enum AppContext {
+    case app
+    case actionExtension
+    case fileProviderExtension
+    case shareExtension
+}
+
 /// Something that loads the DI on init
 public struct EarlyDIHook {
-    public init() {
+    public init(context: AppContext) {
         // setup DI ASAP
 
         let navigationManagerFactory = Factory(type: NavigationManageable.self) { _, _ in
             NavigationManager()
         }
+
+        // TODO: Insert context in dedicated DI object
 
         os_log("EarlyDIHook")
         FactoryService.setupDependencyInjection(other: [navigationManagerFactory])

--- a/kDrive/Utils/AppFactoryService.swift
+++ b/kDrive/Utils/AppFactoryService.swift
@@ -21,25 +21,18 @@ import InfomaniakDI
 import kDriveCore
 import os.log
 
-public enum AppContext {
-    case app
-    case actionExtension
-    case fileProviderExtension
-    case shareExtension
-}
-
 /// Something that loads the DI on init
 public struct EarlyDIHook {
-    public init(context: AppContext) {
-        // setup DI ASAP
-
-        let navigationManagerFactory = Factory(type: NavigationManageable.self) { _, _ in
-            NavigationManager()
-        }
-
-        // TODO: Insert context in dedicated DI object
-
+    public init(context: DriveAppContext) {
         os_log("EarlyDIHook")
-        FactoryService.setupDependencyInjection(other: [navigationManagerFactory])
+
+        let extraDependencies = [Factory(type: NavigationManageable.self) { _, _ in
+            NavigationManager()
+        }, Factory(type: AppContextServiceable.self) { _, _ in
+            AppContextService(context: context)
+        }]
+
+        // setup DI ASAP
+        FactoryService.setupDependencyInjection(other: extraDependencies)
     }
 }

--- a/kDriveActionExtension/ActionNavigationController.swift
+++ b/kDriveActionExtension/ActionNavigationController.swift
@@ -25,7 +25,7 @@ import VersionChecker
 
 final class ActionNavigationController: TitleSizeAdjustingNavigationController {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = EarlyDIHook(context: .actionExtension)
 
     @LazyInjectService var accountManager: AccountManageable
 

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -54,7 +54,6 @@ public class AuthenticatedImageRequestModifier: ImageDownloadRequestModifier {
 public class DriveApiFetcher: ApiFetcher {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var tokenable: InfomaniakTokenable
-    @LazyInjectService var appContextService: AppContextServiceable
 
     public var authenticatedKF: AuthenticatedImageRequestModifier!
 

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -54,6 +54,7 @@ public class AuthenticatedImageRequestModifier: ImageDownloadRequestModifier {
 public class DriveApiFetcher: ApiFetcher {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var tokenable: InfomaniakTokenable
+    @LazyInjectService var appContextService: AppContextServiceable
 
     public var authenticatedKF: AuthenticatedImageRequestModifier!
 
@@ -465,6 +466,7 @@ public class DriveApiFetcher: ApiFetcher {
 class SyncedAuthenticator: OAuthAuthenticator {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var tokenable: InfomaniakTokenable
+    @LazyInjectService var appContextService: AppContextServiceable
 
     override func refresh(
         _ credential: OAuthAuthenticator.Credential,
@@ -507,7 +509,7 @@ class SyncedAuthenticator: OAuthAuthenticator {
             let group = DispatchGroup()
             group.enter()
             var taskIdentifier: UIBackgroundTaskIdentifier = .invalid
-            if !Bundle.main.isExtension {
+            if !self.appContextService.isExtension {
                 // It is absolutely necessary that the app stays awake while we refresh the token
                 taskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "Refresh token") {
                     let message = "Refreshing token failed - Background task expired"

--- a/kDriveCore/Data/DownloadQueue/DownloadArchiveOperation.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadArchiveOperation.swift
@@ -26,6 +26,7 @@ public class DownloadArchiveOperation: Operation {
     // MARK: - Attributes
 
     @LazyInjectService var accountManager: AccountManageable
+    @LazyInjectService var appContextService: AppContextServiceable
 
     private let archiveId: String
     private let driveFileManager: DriveFileManager
@@ -85,7 +86,7 @@ public class DownloadArchiveOperation: Operation {
             return
         }
 
-        if !Bundle.main.isExtension {
+        if !appContextService.isExtension {
             backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "File Archive Downloader") {
                 DownloadQueue.instance.suspendAllOperations()
                 // We don't support task rescheduling for archive download but still need to pass error to differentiate from user

--- a/kDriveCore/Data/DownloadQueue/DownloadOperation.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadOperation.swift
@@ -36,6 +36,7 @@ public class DownloadOperation: Operation, DownloadOperationable {
 
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var downloadManager: BackgroundDownloadSessionManager
+    @LazyInjectService var appContextService: AppContextServiceable
 
     private let fileManager = FileManager.default
     private let driveFileManager: DriveFileManager
@@ -116,7 +117,7 @@ public class DownloadOperation: Operation, DownloadOperationable {
             return
         }
 
-        if !Bundle.main.isExtension {
+        if !appContextService.isExtension {
             backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "File Downloader") {
                 DownloadQueue.instance.suspendAllOperations()
                 DDLogInfo("[DownloadOperation] Background task expired")

--- a/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
@@ -58,6 +58,7 @@ public final class DownloadQueue {
     // MARK: - Attributes
 
     @LazyInjectService var accountManager: AccountManageable
+    @LazyInjectService var appContextService: AppContextServiceable
 
     public static let instance = DownloadQueue()
     public static let backgroundIdentifier = "com.infomaniak.background.download"
@@ -90,7 +91,7 @@ public final class DownloadQueue {
     )
 
     private var bestSession: FileDownloadSession {
-        if Bundle.main.isExtension {
+        if appContextService.isExtension {
             @InjectService var backgroundDownloadSessionManager: BackgroundDownloadSessionManager
             return backgroundDownloadSessionManager
         } else {
@@ -220,25 +221,25 @@ public final class DownloadQueue {
     }
 
     private func publishFileDownloaded(fileId: Int, error: DriveError?) {
-        observations.didDownloadFile.values.forEach { closure in
+        for closure in observations.didDownloadFile.values {
             closure(fileId, error)
         }
     }
 
     func publishProgress(_ progress: Double, for fileId: Int) {
-        observations.didChangeProgress.values.forEach { closure in
+        for closure in observations.didChangeProgress.values {
             closure(fileId, progress)
         }
     }
 
     private func publishArchiveDownloaded(archiveId: String, archiveUrl: URL?, error: DriveError?) {
-        observations.didDownloadArchive.values.forEach { closure in
+        for closure in observations.didDownloadArchive.values {
             closure(archiveId, archiveUrl, error)
         }
     }
 
     func publishProgress(_ progress: Double, for archiveId: String) {
-        observations.didChangeArchiveProgress.values.forEach { closure in
+        for closure in observations.didChangeArchiveProgress.values {
             closure(archiveId, progress)
         }
     }

--- a/kDriveCore/Data/UploadQueue/Chunk/RangeProviderGuts.swift
+++ b/kDriveCore/Data/UploadQueue/Chunk/RangeProviderGuts.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakDI
 
 /// The internal methods of RangeProviderGuts, made testable
 public protocol RangeProviderGutsable {
@@ -45,6 +46,8 @@ public protocol RangeProviderGutsable {
 
 /// Subdivided **RangeProvider**, so it is easier to test
 public struct RangeProviderGuts: RangeProviderGutsable {
+    @LazyInjectService private var appContextService: AppContextServiceable
+
     /// The URL of the local file to scan
     public let fileURL: URL
 
@@ -107,7 +110,7 @@ public struct RangeProviderGuts: RangeProviderGutsable {
 
     public func preferredChunkSize(for fileSize: UInt64) -> UInt64 {
         // In extension to reduce memory footprint, we reduce drastically chunk size
-        guard !Bundle.main.isExtension else {
+        guard !appContextService.isExtension else {
             let capChunkSize = min(fileSize, RangeProvider.APIConstants.chunkMinSize)
             return capChunkSize
         }

--- a/kDriveCore/Data/UploadQueue/Queue/UploadParallelismHeuristic.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadParallelismHeuristic.swift
@@ -17,6 +17,7 @@
  */
 
 import Foundation
+import InfomaniakDI
 
 /// Delegate protocol of UploadParallelismHeuristic
 protocol ParallelismHeuristicDelegate: AnyObject {
@@ -32,6 +33,8 @@ protocol ParallelismHeuristicDelegate: AnyObject {
 final class UploadParallelismHeuristic {
     /// With 2 Operations max, and a chuck of 1MiB max, the UploadQueue can spike to max 4MiB memory usage.
     private static let reducedParallelism = 2
+
+    @LazyInjectService private var appContextService: AppContextServiceable
 
     private weak var delegate: ParallelismHeuristicDelegate?
 
@@ -80,7 +83,7 @@ final class UploadParallelismHeuristic {
         }
 
         // In extension, to reduce memory footprint, we reduce drastically parallelism
-        guard !Bundle.main.isExtension else {
+        guard !appContextService.isExtension else {
             currentParallelism = Self.reducedParallelism
             return
         }

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
@@ -85,6 +85,11 @@ public final class UploadQueue: ParallelismHeuristicDelegate {
 
     /// Should suspend operation queue based on network status
     var shouldSuspendQueue: Bool {
+        // Explicitly disable the upload queue from the share extension
+        guard appContextService.context != .shareExtension else {
+            return true
+        }
+
         let status = ReachabilityListener.instance.currentStatus
         return status == .offline || (status != .wifi && UserDefaults.shared.isWifiOnly)
     }
@@ -99,6 +104,11 @@ public final class UploadQueue: ParallelismHeuristicDelegate {
     )
 
     public init() {
+        guard appContextService.context != .shareExtension else {
+            Log.uploadQueue("UploadQueue disabled in ShareExtension", level: .error)
+            return
+        }
+
         Log.uploadQueue("Starting up")
 
         uploadParallelismHeuristic = UploadParallelismHeuristic(delegate: self)

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
@@ -25,6 +25,7 @@ import Sentry
 public final class UploadQueue: ParallelismHeuristicDelegate {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var notificationHelper: NotificationsHelpable
+    @LazyInjectService var appContextService: AppContextServiceable
 
     public static let backgroundBaseIdentifier = ".backgroundsession.upload"
     public static var backgroundIdentifier: String {
@@ -53,7 +54,7 @@ public final class UploadQueue: ParallelismHeuristicDelegate {
 
         // In extension to reduce memory footprint, we reduce drastically parallelism
         let parallelism: Int
-        if Bundle.main.isExtension {
+        if appContextService.isExtension {
             parallelism = 2 // With 2 Operations max, and a chuck of 1MiB max, the UploadQueue can spike to max 4MiB.
         } else {
             parallelism = max(4, ProcessInfo.processInfo.activeProcessorCount)

--- a/kDriveCore/Services/AppContextService.swift
+++ b/kDriveCore/Services/AppContextService.swift
@@ -1,0 +1,59 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+/// All the ways some code can be executed within the __kDrive__ project
+public enum DriveAppContext {
+    /// Current execution context is the main app
+    case app
+
+    /// Current execution context is an action extension
+    case actionExtension
+
+    /// Current execution context is the file provider extension
+    case fileProviderExtension
+
+    /// Current execution context is the share extension
+    case shareExtension
+}
+
+/// Something that can provide the active execution context
+public protocol AppContextServiceable {
+    /// Get the current execution context
+    var context: DriveAppContext { get }
+
+    /// Shorthand to check if we are within the main app or any extension
+    var isExtension: Bool { get }
+}
+
+public struct AppContextService: AppContextServiceable {
+    public var context: DriveAppContext
+
+    public var isExtension: Bool {
+        guard context == .app else {
+            return true
+        }
+
+        return false
+    }
+
+    public init(context: DriveAppContext) {
+        self.context = context
+    }
+}

--- a/kDriveCore/Utils/Files/FileImportHelper.swift
+++ b/kDriveCore/Utils/Files/FileImportHelper.swift
@@ -72,6 +72,7 @@ public final class FileImportHelper {
 
     @LazyInjectService var pathProvider: AppGroupPathProvidable
     @LazyInjectService var uploadQueue: UploadQueue
+    @LazyInjectService var appContextService: AppContextServiceable
 
     let imageCompression = 0.8
 
@@ -127,7 +128,7 @@ public final class FileImportHelper {
                     }
 
                     var finalUrl: URL
-                    if Bundle.main.isExtension {
+                    if self.appContextService.isExtension {
                         // In extension, we need to copy files to a path within appGroup to be able to upload from the main app.
                         let appGroupURL = try URL.appGroupUniqueFolderURL()
 
@@ -240,7 +241,7 @@ public final class FileImportHelper {
                     let uti = UTI(filenameExtension: url.pathExtension) ?? UTI.data
 
                     var finalUrl: URL
-                    if Bundle.main.isExtension {
+                    if self.appContextService.isExtension {
                         // In extension, we need to copy files to a path within appGroup to be able to upload from the main app.
                         let appGroupURL = try URL.appGroupUniqueFolderURL()
 

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -80,7 +80,8 @@ public enum Logging {
 
     private static func initNetworkLogging() {
         #if DEBUG && !TEST
-        if !Bundle.main.isExtension {
+        @InjectService var appContextService: AppContextServiceable
+        if !appContextService.isExtension {
             Atlantis.start(hostName: ProcessInfo.processInfo.environment["hostname"])
         }
         #endif
@@ -106,7 +107,11 @@ public enum Logging {
 
     private static func copyDebugInformations() {
         #if DEBUG && !TEST
-        guard !Bundle.main.isExtension else { return }
+        @InjectService var appContextService: AppContextServiceable
+        guard !appContextService.isExtension else {
+            return
+        }
+
         let fileManager = FileManager.default
         let debugDirectory = (fileManager.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(
             "debug",

--- a/kDriveCore/Utils/NotificationsHelper.swift
+++ b/kDriveCore/Utils/NotificationsHelper.swift
@@ -20,6 +20,7 @@ import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
 import InfomaniakCoreUI
+import InfomaniakDI
 import kDriveResources
 import UserNotifications
 
@@ -45,6 +46,8 @@ public protocol NotificationsHelpable {
 }
 
 public struct NotificationsHelper: NotificationsHelpable {
+    @LazyInjectService private var appContextService: AppContextServiceable
+
     public enum CategoryIdentifier {
         public static let general = "com.kdrive.notification.general"
         public static let upload = "com.kdrive.notification.upload"
@@ -218,7 +221,7 @@ public struct NotificationsHelper: NotificationsHelpable {
                 return
             }
 
-            let isInBackground = Bundle.main.isExtension || UIApplication.shared.applicationState != .active
+            let isInBackground = appContextService.isExtension || UIApplication.shared.applicationState != .active
 
             if isInBackground {
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -26,7 +26,7 @@ import RealmSwift
 
 final class FileProviderExtension: NSFileProviderExtension {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = EarlyDIHook(context: .fileProviderExtension)
 
     /// Something to enqueue async await tasks in a serial manner.
     let asyncAwaitQueue = TaskQueue()

--- a/kDriveShareExtension/ShareNavigationViewController.swift
+++ b/kDriveShareExtension/ShareNavigationViewController.swift
@@ -25,7 +25,7 @@ import VersionChecker
 
 final class ShareNavigationViewController: TitleSizeAdjustingNavigationController {
     /// Making sure the DI is registered at a very early stage of the app launch.
-    private let dependencyInjectionHook = EarlyDIHook()
+    private let dependencyInjectionHook = EarlyDIHook(context: .shareExtension)
 
     @LazyInjectService var accountManager: AccountManageable
 


### PR DESCRIPTION
Under some circumstances, it seems the upload starts from the share extension and breaks the current expectation of only the main app runs the uploads.