### PR TITLE
fix: FileProvider

### DIFF
--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -158,7 +158,8 @@ public enum FactoryService {
                 (loggerFactory, "BGTaskScheduling"),
                 (loggerFactory, "PhotoLibraryUploader"),
                 (loggerFactory, "AppDelegate"),
-                (loggerFactory, "FileProvider")
+                (loggerFactory, "FileProvider"),
+                (loggerFactory, "DriveInfosManager")
             ]
             return services
         } else {

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager+FileProvider.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager+FileProvider.swift
@@ -1,0 +1,174 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import CocoaLumberjackSwift
+import FileProvider
+import Foundation
+import InfomaniakConcurrency
+import InfomaniakCore
+
+public extension DriveInfosManager {
+    private typealias FilteredDomain = (new: NSFileProviderDomain, existing: NSFileProviderDomain?)
+
+    internal func initFileProviderDomains(drives: [Drive], user: InfomaniakCore.UserProfile) {
+        // Clean file provider storage if needed
+        if UserDefaults.shared.fpStorageVersion < currentFpStorageVersion {
+            do {
+                let fileURLs = try FileManager.default.contentsOfDirectory(
+                    at: NSFileProviderManager.default.documentStorageURL,
+                    includingPropertiesForKeys: nil
+                )
+                for url in fileURLs {
+                    try FileManager.default.removeItem(at: url)
+                }
+                UserDefaults.shared.fpStorageVersion = currentFpStorageVersion
+            } catch {
+                // TODO: Sentry
+            }
+        }
+
+        // TODO: Start Activity
+        Task {
+            let updatedDomains = drives.map {
+                NSFileProviderDomain(
+                    identifier: NSFileProviderDomainIdentifier($0.objectId),
+                    displayName: "\($0.name) (\(user.email))",
+                    pathRelativeToDocumentStorage: "\($0.objectId)"
+                )
+            }
+
+            do {
+                let allDomains = try await NSFileProviderManager.domains()
+                let existingDomainsForCurrentUser = allDomains.filter { $0.identifier.rawValue.hasSuffix("_\(user.id)") }
+
+                let updatedDomainsForCurrentUser: [FilteredDomain] = updatedDomains.map { newDomain in
+                    let existingDomain = existingDomainsForCurrentUser.first { $0.identifier == newDomain.identifier }
+                    return (newDomain, existingDomain)
+                }
+
+                try await updatedDomainsForCurrentUser.concurrentForEach(customConcurrency: 1) { domain in
+                    // Simply add domain if new
+                    let newDomain = domain.new
+                    guard let existingDomain = domain.existing else {
+                        try await NSFileProviderManager.add(newDomain)
+                        return
+                    }
+
+                    // Update existing accounts if necessary
+                    if existingDomain.displayName != newDomain.displayName {
+                        try await NSFileProviderManager.remove(existingDomain)
+                        try await NSFileProviderManager.add(newDomain)
+                        self.signalChanges(for: newDomain)
+                    }
+                }
+
+                // Remove domains no longer present for current user
+                let removedDomainsForCurrentUser = updatedDomains.filter { updatedDomain in
+                    guard existingDomainsForCurrentUser.contains(where: { $0.identifier == updatedDomain.identifier }) else {
+                        return true
+                    }
+
+                    return false
+                }
+
+                try await removedDomainsForCurrentUser.concurrentForEach(customConcurrency: 1) { oldDomain in
+                    try await NSFileProviderManager.remove(oldDomain)
+                }
+            } catch {
+                DDLogError("Error while updating file provider domains: \(error)")
+                // TODO: add Sentry
+            }
+
+            // TODO: notify for consistency
+        }
+    }
+
+    internal func deleteFileProviderDomains(for userId: Int) {
+        NSFileProviderManager.getDomainsWithCompletionHandler { allDomains, error in
+            if let error {
+                DDLogError("Error while getting domains: \(error)")
+            }
+
+            let domainsForCurrentUser = allDomains.filter { $0.identifier.rawValue.hasSuffix("_\(userId)") }
+            for domain in domainsForCurrentUser {
+                NSFileProviderManager.remove(domain) { error in
+                    if let error {
+                        DDLogError("Error while removing domain \(domain.displayName): \(error)")
+                    }
+                }
+            }
+        }
+    }
+
+    func deleteAllFileProviderDomains() {
+        NSFileProviderManager.removeAllDomains { error in
+            if let error {
+                DDLogError("Error while removing domains: \(error)")
+            }
+        }
+    }
+
+    internal func getFileProviderDomain(for driveId: String, completion: @escaping (NSFileProviderDomain?) -> Void) {
+        NSFileProviderManager.getDomainsWithCompletionHandler { domains, error in
+            if let error {
+                DDLogError("Error while getting domains: \(error)")
+                completion(nil)
+            } else {
+                completion(domains.first { $0.identifier.rawValue == driveId })
+            }
+        }
+    }
+
+    func getFileProviderManager(for drive: Drive, completion: @escaping (NSFileProviderManager) -> Void) {
+        getFileProviderManager(for: drive.objectId, completion: completion)
+    }
+
+    func getFileProviderManager(driveId: Int, userId: Int, completion: @escaping (NSFileProviderManager) -> Void) {
+        let objectId = DriveInfosManager.getObjectId(driveId: driveId, userId: userId)
+        getFileProviderManager(for: objectId, completion: completion)
+    }
+
+    func getFileProviderManager(for driveId: String, completion: @escaping (NSFileProviderManager) -> Void) {
+        getFileProviderDomain(for: driveId) { domain in
+            if let domain {
+                completion(NSFileProviderManager(for: domain) ?? .default)
+            } else {
+                completion(.default)
+            }
+        }
+    }
+
+    // MARK: Signal
+
+    /// Signal changes on this Drive to the File Provider Extension
+    private func signalChanges(for domain: NSFileProviderDomain) {
+        guard let driveId = domain.driveId, let userId = domain.userId else {
+            // Sentry
+            return
+        }
+
+        DriveInfosManager.instance.getFileProviderManager(driveId: driveId, userId: userId) { manager in
+            manager.signalEnumerator(for: .workingSet) { _ in
+                // META: keep SonarCloud happy
+            }
+            manager.signalEnumerator(for: .rootContainer) { _ in
+                // META: keep SonarCloud happy
+            }
+        }
+    }
+}

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
@@ -17,7 +17,6 @@
  */
 
 import CocoaLumberjackSwift
-import FileProvider
 import Foundation
 import InfomaniakCore
 import Realm

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
@@ -19,16 +19,18 @@
 import CocoaLumberjackSwift
 import FileProvider
 import Foundation
-import InfomaniakConcurrency
 import InfomaniakCore
 import Realm
 import RealmSwift
 import Sentry
 
-public class DriveInfosManager {
+public final class DriveInfosManager {
+    // TODO: use DI
     public static let instance = DriveInfosManager()
     private static let currentDbVersion: UInt64 = 9
-    private let currentFpStorageVersion = 1
+
+    let currentFpStorageVersion = 1
+
     public let realmConfiguration: Realm.Configuration
     private let dbName = "DrivesInfos.realm"
     private var fileProviderManagers: [String: NSFileProviderManager] = [:]
@@ -115,135 +117,6 @@ public class DriveInfosManager {
     private func initDriveForRealm(drive: Drive, userId: Int, sharedWithMe: Bool) {
         drive.userId = userId
         drive.sharedWithMe = sharedWithMe
-    }
-
-    private typealias FilteredDomain = (new: NSFileProviderDomain, existing: NSFileProviderDomain?)
-
-    private func initFileProviderDomains(drives: [Drive], user: InfomaniakCore.UserProfile) {
-        // Clean file provider storage if needed
-        if UserDefaults.shared.fpStorageVersion < currentFpStorageVersion {
-            do {
-                let fileURLs = try FileManager.default.contentsOfDirectory(
-                    at: NSFileProviderManager.default.documentStorageURL,
-                    includingPropertiesForKeys: nil
-                )
-                for url in fileURLs {
-                    try FileManager.default.removeItem(at: url)
-                }
-                UserDefaults.shared.fpStorageVersion = currentFpStorageVersion
-            } catch {
-                // TODO: Sentry
-            }
-        }
-
-        // TODO: Start Activity
-        Task {
-            let updatedDomains = drives.map {
-                NSFileProviderDomain(
-                    identifier: NSFileProviderDomainIdentifier($0.objectId),
-                    displayName: "\($0.name) (\(user.email))",
-                    pathRelativeToDocumentStorage: "\($0.objectId)"
-                )
-            }
-
-            do {
-                let allDomains = try await NSFileProviderManager.domains()
-                let existingDomainsForCurrentUser = allDomains.filter { $0.identifier.rawValue.hasSuffix("_\(user.id)") }
-
-                let updatedDomainsForCurrentUser: [FilteredDomain] = updatedDomains.map { newDomain in
-                    let existingDomain = existingDomainsForCurrentUser.first { $0.identifier == newDomain.identifier }
-                    return (newDomain, existingDomain)
-                }
-
-                try await updatedDomainsForCurrentUser.concurrentForEach(customConcurrency: 1) { domain in
-                    // Simply add domain if new
-                    let newDomain = domain.new
-                    guard let existingDomain = domain.existing else {
-                        try await NSFileProviderManager.add(newDomain)
-                        return
-                    }
-
-                    // Update existing accounts if necessary
-                    if existingDomain.displayName != newDomain.displayName {
-                        try await NSFileProviderManager.remove(existingDomain)
-                        try await NSFileProviderManager.add(newDomain)
-                    }
-                }
-
-                // Remove domains no longer present for current user
-                let removedDomainsForCurrentUser = updatedDomains.filter { updatedDomain in
-                    guard existingDomainsForCurrentUser.contains(where: { $0.identifier == updatedDomain.identifier }) else {
-                        return true
-                    }
-
-                    return false
-                }
-
-                try await removedDomainsForCurrentUser.concurrentForEach(customConcurrency: 1) { oldDomain in
-                    try await NSFileProviderManager.remove(oldDomain)
-                }
-            } catch {
-                DDLogError("Error while updating file provider domains: \(error)")
-                // TODO: add Sentry
-            }
-
-            // TODO: notify for consistency
-        }
-    }
-
-    func deleteFileProviderDomains(for userId: Int) {
-        NSFileProviderManager.getDomainsWithCompletionHandler { allDomains, error in
-            if let error {
-                DDLogError("Error while getting domains: \(error)")
-            }
-
-            let domainsForCurrentUser = allDomains.filter { $0.identifier.rawValue.hasSuffix("_\(userId)") }
-            for domain in domainsForCurrentUser {
-                NSFileProviderManager.remove(domain) { error in
-                    if let error {
-                        DDLogError("Error while removing domain \(domain.displayName): \(error)")
-                    }
-                }
-            }
-        }
-    }
-
-    public func deleteAllFileProviderDomains() {
-        NSFileProviderManager.removeAllDomains { error in
-            if let error {
-                DDLogError("Error while removing domains: \(error)")
-            }
-        }
-    }
-
-    func getFileProviderDomain(for driveId: String, completion: @escaping (NSFileProviderDomain?) -> Void) {
-        NSFileProviderManager.getDomainsWithCompletionHandler { domains, error in
-            if let error {
-                DDLogError("Error while getting domains: \(error)")
-                completion(nil)
-            } else {
-                completion(domains.first { $0.identifier.rawValue == driveId })
-            }
-        }
-    }
-
-    public func getFileProviderManager(for drive: Drive, completion: @escaping (NSFileProviderManager) -> Void) {
-        getFileProviderManager(for: drive.objectId, completion: completion)
-    }
-
-    public func getFileProviderManager(driveId: Int, userId: Int, completion: @escaping (NSFileProviderManager) -> Void) {
-        let objectId = DriveInfosManager.getObjectId(driveId: driveId, userId: userId)
-        getFileProviderManager(for: objectId, completion: completion)
-    }
-
-    public func getFileProviderManager(for driveId: String, completion: @escaping (NSFileProviderManager) -> Void) {
-        getFileProviderDomain(for: driveId) { domain in
-            if let domain {
-                completion(NSFileProviderManager(for: domain) ?? .default)
-            } else {
-                completion(.default)
-            }
-        }
     }
 
     @discardableResult

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
@@ -16,7 +16,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
 import Realm
@@ -24,15 +23,16 @@ import RealmSwift
 import Sentry
 
 public final class DriveInfosManager {
-    // TODO: use DI
-    public static let instance = DriveInfosManager()
+    private static let dbName = "DrivesInfos.realm"
+
     private static let currentDbVersion: UInt64 = 9
 
     let currentFpStorageVersion = 1
 
     public let realmConfiguration: Realm.Configuration
-    private let dbName = "DrivesInfos.realm"
-    private var fileProviderManagers: [String: NSFileProviderManager] = [:]
+
+    // TODO: use DI
+    public static let instance = DriveInfosManager()
 
     private class func removeDanglingObjects(ofType type: RLMObjectBase.Type, migration: Migration, ids: Set<String>) {
         migration.enumerateObjects(ofType: type.className()) { oldObject, newObject in
@@ -45,7 +45,7 @@ public final class DriveInfosManager {
 
     private init() {
         realmConfiguration = Realm.Configuration(
-            fileURL: DriveFileManager.constants.rootDocumentsURL.appendingPathComponent(dbName),
+            fileURL: DriveFileManager.constants.rootDocumentsURL.appendingPathComponent(Self.dbName),
             schemaVersion: DriveInfosManager.currentDbVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if oldSchemaVersion < DriveInfosManager.currentDbVersion {

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Notifications.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Notifications.swift
@@ -42,6 +42,11 @@ extension UploadQueue: UploadNotifiable {
 
     public func sendPausedNotificationIfNeeded() {
         Log.uploadQueue("sendPausedNotificationIfNeeded")
+        guard appContextService.context != .fileProviderExtension else {
+            Log.uploadQueue("\(#function) disabled in FileProviderExtension", level: .error)
+            return
+        }
+
         serialQueue.async { [weak self] in
             guard let self else { return }
             if !pausedNotificationSent {

--- a/kDriveCore/Utils/AbstractLog+Category.swift
+++ b/kDriveCore/Utils/AbstractLog+Category.swift
@@ -175,6 +175,39 @@ public enum Log {
               tag: tag)
     }
 
+    /// Shorthand for ABLog, with "DriveInfosManager" category.
+    ///
+    /// Sentry tracking enabled when level == .error
+    public static func driveInfosManager(_ message: @autoclosure () -> Any,
+                                         level: AbstractLogLevel = .debug,
+                                         context: Int = 0,
+                                         file: StaticString = #file,
+                                         function: StaticString = #function,
+                                         line: UInt = #line,
+                                         tag: Any? = nil) {
+        let category = "DriveInfosManager"
+        let messageAny = message()
+        guard let messageString = messageAny as? String else {
+            assertionFailure("This should always cast to a String")
+            return
+        }
+
+        // All errors are tracked on Sentry
+        if level == .error {
+            SentryDebug.addBreadcrumb(message: messageString, category: .DriveInfosManager, level: .error)
+            SentryDebug.capture(message: messageString, level: .error, extras: ["function": "\(function)", "line": "\(line)"])
+        }
+
+        ABLog(messageAny,
+              category: category,
+              level: level,
+              context: context,
+              file: file,
+              function: function,
+              line: line,
+              tag: tag)
+    }
+
     private static func defaultLogHandler(_ message: @autoclosure () -> Any,
                                           category: String,
                                           level: AbstractLogLevel,

--- a/kDriveCore/Utils/FileProvider/FileProviderDomain+Identifier.swift
+++ b/kDriveCore/Utils/FileProvider/FileProviderDomain+Identifier.swift
@@ -1,0 +1,45 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FileProvider
+import Foundation
+
+public extension NSFileProviderDomain {
+    private typealias DriveIdAndUserId = (driveId: Int, userId: Int)
+
+    private var userAndDrive: DriveIdAndUserId? {
+        let identifiers = identifier.rawValue.components(separatedBy: "_")
+
+        guard let driveIdString = identifiers[safe: 0],
+              let usedIdString = identifiers[safe: 1],
+              let driveId = Int(driveIdString),
+              let usedId = Int(usedIdString) else {
+            return nil
+        }
+
+        return (driveId, usedId)
+    }
+
+    var userId: Int? {
+        userAndDrive?.userId
+    }
+
+    var driveId: Int? {
+        userAndDrive?.driveId
+    }
+}

--- a/kDriveCore/Utils/Sentry/SentryDebug.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug.swift
@@ -38,6 +38,8 @@ public enum SentryDebug {
         case realmMigration = "RealmMigration"
         /// Photo library assets
         case PHAsset
+        /// DriveInfosManager, and communication with FileProvider APIs
+        case DriveInfosManager
     }
 
     public enum EventNames {
@@ -136,12 +138,17 @@ public enum SentryDebug {
         message: String,
         context: [String: Any]? = nil,
         contextKey: String? = nil,
+        level: SentryLevel? = nil,
         extras: [String: Any]? = nil
     ) {
         Task {
             SentrySDK.capture(message: message) { scope in
                 if let context, let contextKey {
                     scope.setContext(value: context, key: contextKey)
+                }
+
+                if let level {
+                    scope.setLevel(level)
                 }
 
                 if let extras {

--- a/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
+++ b/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
@@ -43,6 +43,10 @@ final class ITAppLaunchTest: XCTestCase {
 
         SimpleResolver.register(FactoryService.debugServices)
         let services = [
+            Factory(type: AppContextServiceable.self) { _, _ in
+                // We fake the main app context
+                return AppContextService(context: .app)
+            },
             Factory(type: InfomaniakNetworkLogin.self) { _, _ in
                 return InfomaniakNetworkLogin(config: self.loginConfig)
             },

--- a/kDriveTests/kDrive/Launch/UTRootViewControllerState.swift
+++ b/kDriveTests/kDrive/Launch/UTRootViewControllerState.swift
@@ -42,6 +42,10 @@ final class UTRootViewControllerState: XCTestCase {
         SimpleResolver.sharedResolver.removeAll()
 
         let services = [
+            Factory(type: AppContextServiceable.self) { _, _ in
+                // We fake the main app context
+                return AppContextService(context: .app)
+            },
             Factory(type: InfomaniakNetworkLogin.self) { _, _ in
                 InfomaniakNetworkLogin(config: self.loginConfig)
             },


### PR DESCRIPTION
### Abstract

Some fixes related to the `Files.app` behaviour:

- fix: Make sure no Paused Notification is produced by the FileProvider.
- fix: Removed a race condition while registering a FileProviderDomain.
- fix: Explicitly signal FileProvider when it is updated.

Also improved the situation regarding: 

- chore: Sentry tracking with a dedicated Log.driveInfosManager() channel.
- refactor: Split the _DriveInfosManager's FileProvider_ related code.