### PR TITLE
feat: Safer AccountManager

### DIFF
--- a/kDriveCore/Data/Cache/AccountManager.swift
+++ b/kDriveCore/Data/Cache/AccountManager.swift
@@ -103,12 +103,11 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
     private static let group = "com.infomaniak.drive"
     public static let appGroup = "group." + group
     public static let accessGroup: String = AccountManager.appIdentifierPrefix + AccountManager.group
-    private let tag = "ch.infomaniak.token".data(using: .utf8)!
+
     public var currentAccount: Account!
     public var accounts = [Account]()
     public var tokens = [ApiToken]()
     public let refreshTokenLockedQueue = DispatchQueue(label: "com.infomaniak.drive.refreshtoken")
-    private let keychainQueue = DispatchQueue(label: "com.infomaniak.drive.keychain")
     public weak var delegate: AccountManagerDelegate?
 
     public var currentUserId: Int {

--- a/kDriveCore/Data/Cache/AccountManager.swift
+++ b/kDriveCore/Data/Cache/AccountManager.swift
@@ -47,14 +47,6 @@ public extension InfomaniakLogin {
     }
 }
 
-@globalActor actor AccountActor: GlobalActor {
-    static let shared = AccountActor()
-
-    public static func run<T>(resultType: T.Type = T.self, body: @AccountActor @Sendable () throws -> T) async rethrows -> T {
-        try await body()
-    }
-}
-
 /// Abstract interface on AccountManager
 public protocol AccountManageable: AnyObject {
     var currentAccount: Account! { get }
@@ -320,9 +312,8 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
             throw DriveError.unknownToken
         }
 
-        let apiFetcher = await AccountActor.run {
-            getApiFetcher(for: account.userId, token: account.token)
-        }
+        let apiFetcher = getApiFetcher(for: account.userId, token: account.token)
+
         let user = try await apiFetcher.userProfile()
         account.user = user
 

--- a/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
+++ b/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
@@ -89,7 +89,7 @@ final class ITAppLaunchTest: XCTestCase {
         UserDefaults.shared.isAppLockEnabled = true
         let accountManagerFactory = Factory(type: AccountManageable.self) { _, _ in
             let accountManager = MockAccountManager()
-            accountManager.accounts = [self.fakeAccount]
+            accountManager.accounts.append(self.fakeAccount)
             accountManager.currentDriveFileManager = DriveFileManager(
                 drive: Drive(),
                 apiFetcher: DriveApiFetcher(token: self.fakeAccount.token, delegate: accountManager)

--- a/kDriveTests/kDrive/Launch/MockAccountManager.swift
+++ b/kDriveTests/kDrive/Launch/MockAccountManager.swift
@@ -29,7 +29,7 @@ class MockAccountManager: AccountManageable, RefreshTokenDelegate {
         return accounts.first!
     }
 
-    var accounts: [Account] = []
+    var accounts = SendableArray<Account>()
 
     var tokens: [ApiToken] = []
 

--- a/kDriveTests/kDrive/Launch/UTRootViewControllerState.swift
+++ b/kDriveTests/kDrive/Launch/UTRootViewControllerState.swift
@@ -143,7 +143,7 @@ final class UTRootViewControllerState: XCTestCase {
 
         let emptyAccountManagerFactory = Factory(type: AccountManageable.self) { _, _ in
             let accountManager = MockAccountManager()
-            accountManager.accounts = [self.fakeAccount]
+            accountManager.accounts.append(self.fakeAccount)
             return accountManager
         }
         SimpleResolver.sharedResolver.store(factory: emptyAccountManagerFactory)
@@ -162,7 +162,7 @@ final class UTRootViewControllerState: XCTestCase {
 
         let emptyAccountManagerFactory = Factory(type: AccountManageable.self) { _, _ in
             let accountManager = MockAccountManager()
-            accountManager.accounts = [self.fakeAccount]
+            accountManager.accounts.append(self.fakeAccount)
             return accountManager
         }
         SimpleResolver.sharedResolver.store(factory: emptyAccountManagerFactory)
@@ -181,7 +181,7 @@ final class UTRootViewControllerState: XCTestCase {
 
         let accountManagerFactory = Factory(type: AccountManageable.self) { _, _ in
             let accountManager = MockAccountManager()
-            accountManager.accounts = [self.fakeAccount]
+            accountManager.accounts.append(self.fakeAccount)
             accountManager.currentDriveFileManager = DriveFileManager(
                 drive: Drive(),
                 apiFetcher: DriveApiFetcher(token: self.fakeAccount.token, delegate: accountManager)


### PR DESCRIPTION
First PR for AccountManager improvements. The refactor of AccountManager will be splitted in multiple PRs for improved readability.

This first PRs simply uses the same thread safe types as Mail to access critical properties.