### PR TITLE
fix: Dark screen when tap under the middle TabBarButton

### DIFF
--- a/kDrive/UI/Controller/MainTabViewController.swift
+++ b/kDrive/UI/Controller/MainTabViewController.swift
@@ -24,7 +24,10 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-class MainTabViewController: UITabBarController, Restorable {
+final class MainTabViewController: UITabBarController, Restorable {
+    /// Index of the button hidden behind the center (+) one
+    private static let middleHiddenButtonIndex = 2
+
     // swiftlint:disable:next weak_delegate
     var photoPickerDelegate = PhotoPickerDelegate()
 
@@ -148,7 +151,15 @@ class MainTabViewController: UITabBarController, Restorable {
         tabBar.itemSpacing = spacing
         tabBar.itemWidth = itemWidth
         tabBar.itemPositioning = .centered
-        for item in tabBar.items ?? [] {
+
+        guard let items = tabBar.items else {
+            return
+        }
+
+        // Disable hidden button behind the middle + one
+        items[safe: Self.middleHiddenButtonIndex]?.isEnabled = false
+
+        for item in items {
             item.title = ""
             item.imageInsets = inset
         }

--- a/kDrive/UI/Controller/MainTabViewController.swift
+++ b/kDrive/UI/Controller/MainTabViewController.swift
@@ -24,7 +24,7 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-class MainTabViewController: UITabBarController, Restorable {
+final class MainTabViewController: UITabBarController, Restorable {
     // swiftlint:disable:next weak_delegate
     var photoPickerDelegate = PhotoPickerDelegate()
 

--- a/kDrive/UI/Controller/MainTabViewController.swift
+++ b/kDrive/UI/Controller/MainTabViewController.swift
@@ -24,10 +24,7 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-final class MainTabViewController: UITabBarController, Restorable {
-    /// Index of the button hidden behind the center (+) one
-    private static let middleHiddenButtonIndex = 2
-
+class MainTabViewController: UITabBarController, Restorable {
     // swiftlint:disable:next weak_delegate
     var photoPickerDelegate = PhotoPickerDelegate()
 
@@ -151,15 +148,7 @@ final class MainTabViewController: UITabBarController, Restorable {
         tabBar.itemSpacing = spacing
         tabBar.itemWidth = itemWidth
         tabBar.itemPositioning = .centered
-
-        guard let items = tabBar.items else {
-            return
-        }
-
-        // Disable hidden button behind the middle + one
-        items[safe: Self.middleHiddenButtonIndex]?.isEnabled = false
-
-        for item in items {
+        for item in tabBar.items ?? [] {
             item.title = ""
             item.imageInsets = inset
         }

--- a/kDrive/UI/Controller/MainTabViewController.swift
+++ b/kDrive/UI/Controller/MainTabViewController.swift
@@ -42,7 +42,7 @@ class MainTabViewController: UITabBarController, Restorable {
             driveFileManager: driveFileManager,
             currentDirectory: nil
         )))
-        rootViewControllers.append(UIViewController())
+        rootViewControllers.append(Self.initFakeViewController())
         rootViewControllers.append(Self.initRootViewController(with: FavoritesViewModel(
             driveFileManager: driveFileManager,
             currentDirectory: nil
@@ -117,6 +117,12 @@ class MainTabViewController: UITabBarController, Restorable {
         navigationViewController.tabBarItem.image = placeholder
         navigationViewController.tabBarItem.selectedImage = placeholderSelected
         return navigationViewController
+    }
+
+    private static func initFakeViewController() -> UIViewController {
+        let fakeViewController = UIViewController()
+        fakeViewController.tabBarItem.isEnabled = false
+        return fakeViewController
     }
 
     private static func initRootViewController(with viewModel: FileListViewModel) -> UIViewController {

--- a/kDrive/UI/View/Menu/MainTabBar.swift
+++ b/kDrive/UI/View/Menu/MainTabBar.swift
@@ -24,7 +24,7 @@ protocol MainTabBarDelegate: AnyObject {
     func plusButtonPressed()
 }
 
-final class MainTabBar: UITabBar {
+class MainTabBar: UITabBar {
     override var backgroundColor: UIColor? {
         get {
             return fillColor

--- a/kDrive/UI/View/Menu/MainTabBar.swift
+++ b/kDrive/UI/View/Menu/MainTabBar.swift
@@ -24,7 +24,7 @@ protocol MainTabBarDelegate: AnyObject {
     func plusButtonPressed()
 }
 
-class MainTabBar: UITabBar {
+final class MainTabBar: UITabBar {
     override var backgroundColor: UIColor? {
         get {
             return fillColor


### PR DESCRIPTION
### Abstract

Fix the dark screen when you tap a bit under the (+) button as there is a TabBar button that links to no ViewController.