### PR TITLE
fix: Experimental fix for crash in FileListViewController

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -410,9 +410,10 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
                 collectionView.moveItem(at: IndexPath(item: source, section: 0), to: IndexPath(item: target, section: 0))
             }
             SentryDebug.updateFileListBreadcrumb(id: reloadId, step: "performBatchUpdates end")
-        } completion: { _ in
-            SentryDebug.updateFileListBreadcrumb(id: reloadId, step: "performBatchUpdates completion")
+        } completion: { success in
+            SentryDebug.updateFileListBreadcrumb(id: reloadId, step: "performBatchUpdates completion :\(success)")
         }
+
         // Reload corners (outside of batch to prevent incompatible operations)
         reloadFileCorners(insertions: insertions, deletions: deletions)
     }
@@ -724,9 +725,14 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
         case .grid:
             cellType = FileGridCollectionViewCell.self
         }
-        let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath) as! FileCollectionViewCell
 
-        let file = viewModel.getFile(at: indexPath)!
+        let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath) as! FileCollectionViewCell
+        guard let file = viewModel.getFile(at: indexPath) else {
+            assertionFailure("Did not match a File at \(indexPath)")
+            cell.setEnabled(false)
+            return cell
+        }
+
         cell.initStyle(isFirst: indexPath.item == 0, isLast: indexPath.item == viewModel.files.count - 1)
         cell.configureWith(
             driveFileManager: viewModel.driveFileManager,
@@ -739,6 +745,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
         } else {
             cell.setEnabled(true)
         }
+
         if viewModel.configuration.fromActivities {
             cell.moreButton.isHidden = true
         }

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -127,11 +127,30 @@ class FileListViewModel: SelectDelegate {
             _frozenFiles
         }
         set {
+            let setIdentifier = UUID().uuidString
+            SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "entry point")
+
             // On change of observed files, we force to restart the realm observation to prevent a loss of sync
             realmObservationToken?.invalidate()
             realmObservationToken = nil
+
+            // Set an internal frozen representation
             _frozenFiles = newValue.freezeIfNeeded()
+
+            // Execute the first update, if linked to a view controller.
+            // This may not be handled by observation alone
+            if let onFileListUpdated {
+                SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "pre onFileListUpdated set")
+                onFileListUpdated([], [], [], [], _frozenFiles.isEmpty, true)
+                SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "post onFileListUpdated set")
+            } else {
+                SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "onFileListUpdated nil")
+            }
+
+            // Restart observation
+            SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "pre setup observation")
             updateRealmObservation()
+            SentryDebug.setFileListViewModelBreadcrumb(id: setIdentifier, step: "post setup observation")
         }
     }
 

--- a/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
@@ -92,6 +92,11 @@ extension SentryDebug {
         addBreadcrumb(message: message, category: .uploadOperation, level: .error)
     }
 
+    public static func setFileListViewModelBreadcrumb(id: String, step: String) {
+        let message = "setFileList opId: \(id) step: \(step)"
+        addBreadcrumb(message: message, category: .uploadOperation, level: .error)
+    }
+
     public static func filesObservationBreadcrumb(state: String) {
         let message = "files modified: \(state)"
         addBreadcrumb(message: message, category: .uploadOperation, level: .error)


### PR DESCRIPTION
### Hypothesis

When the relatively complex layers of inheritance of `FileListViewController` are calling the public setter of `viewModel.files`, this update is not covered by observation and does not propagate back to the viewController. 

Therefore, an extra update call should be generated to be consistent.

This would also match the observation I made that this bug tends to show up near the init of the view controller, and crash quickly when it appears. This can also be seen in the Sentry breadcrumbs.

### Changes

I generate an extra update when and only when the public setter is called. 

This has no change on the existing realm observation of uploading content for instance, and does not change the animations (I tested a bit, looks fine)

The first init of the view controller generates an extra update that I hope will fix the last big crash we have on Drive.

Finally, if this does nothing we can roll back this change after a public beta.
