### PR TITLE
fix: Share extension crash when selecting upload photo in HEIC mode

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/ExtensionTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/ExtensionTarget.swift
@@ -29,6 +29,7 @@ public extension Target {
         var resources: [ResourceFileElement] = [
             "\(name)/**/*.storyboard",
             "kDrive/UI/Controller/Files/**/*.storyboard",
+            "kDrive/UI/Controller/Files/**/*.xib",
             "kDrive/UI/Controller/Floating Panel Information/*.storyboard",
             "kDrive/UI/Controller/NewFolder/*.storyboard",
             "kDrive/UI/View/EmptyTableView/**/*.xib",


### PR DESCRIPTION
Missing XIB in share extension make it crash when used.