### PR TITLE
fix: Fix import folder taking a lot of space

### DIFF
--- a/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
@@ -212,10 +212,6 @@ public final class DownloadQueue: ParallelismHeuristicDelegate {
         operationQueue.cancelAllOperations()
     }
 
-    public func cancelRunningOperations() {
-        operationQueue.operations.filter(\.isExecuting).forEach { $0.cancel() }
-    }
-
     /// Check if a file is been uploaded
     ///
     /// Thread safe

--- a/kDriveCore/Data/Models/Upload/UploadFile.swift
+++ b/kDriveCore/Data/Models/Upload/UploadFile.swift
@@ -320,6 +320,7 @@ public extension UploadFile {
     }
 }
 
+/// Cleaning
 public extension UploadFile {
     /// Centralise error cleaning
     func clearErrorsForRetry() {
@@ -327,6 +328,25 @@ public extension UploadFile {
         error = nil
         // Reset retry count to default
         maxRetryCount = UploadFile.defaultMaxRetryCount
+    }
+
+    /// Centralise source file cleaning
+    @discardableResult
+    func cleanSourceFileIfNeeded() -> Bool {
+        guard let path = pathURL,
+              shouldRemoveAfterUpload else {
+            return false
+        }
+
+        do {
+            try FileManager.default.removeItem(at: path)
+            assert(!FileManager.default.fileExists(atPath: path.path), "expecting the file to be removed")
+
+            return true
+
+        } catch {
+            return false
+        }
     }
 }
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -287,16 +287,14 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 )
             }
 
-            if file.uploadDate != nil {
-                Log.uploadOperation("Remove local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)")
-                if file.cleanSourceFileIfNeeded() {
-                    Log.uploadOperation(
-                        "File removed after upload at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
-                    )
-                }
+            if let path = file.pathURL,
+               file.shouldRemoveAfterUpload && file.uploadDate != nil {
+                Log.uploadOperation("Remove local file at path:\(path) ufid:\(self.uploadFileId)")
+                try? self.fileManager.removeItem(at: path)
+
             } else {
                 Log.uploadOperation(
-                    "Not removing local file as not uploaded yet, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
+                    "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
                     level: .warning
                 )
             }

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -287,14 +287,16 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 )
             }
 
-            if let path = file.pathURL,
-               file.shouldRemoveAfterUpload && file.uploadDate != nil {
-                Log.uploadOperation("Remove local file at path:\(path) ufid:\(self.uploadFileId)")
-                try? self.fileManager.removeItem(at: path)
-
+            if file.uploadDate != nil {
+                Log.uploadOperation("Remove local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)")
+                if file.cleanSourceFileIfNeeded() {
+                    Log.uploadOperation(
+                        "File removed after upload at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
+                    )
+                }
             } else {
                 Log.uploadOperation(
-                    "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
+                    "Not removing local file as not uploaded yet, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
                     level: .warning
                 )
             }

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -269,29 +269,11 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
             // Remove source file if uploaded with success and required.
             if file.uploadDate != nil {
-                let removed = file.cleanSourceFileIfNeeded()
-                if removed {
+                if file.cleanSourceFileIfNeeded() {
                     Log.uploadOperation(
                         "Removed local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
                     )
-                } else {
-                    Log.uploadOperation(
-                        "Unable to remove local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
-                        level: .error
-                    )
                 }
-            } else {
-                Log.uploadOperation(
-                    "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
-                    level: .warning
-                )
-            }
-
-            if let path = file.pathURL,
-               file.shouldRemoveAfterUpload && file.uploadDate != nil {
-                Log.uploadOperation("Remove local file at path:\(path) ufid:\(self.uploadFileId)")
-                try? self.fileManager.removeItem(at: path)
-
             } else {
                 Log.uploadOperation(
                     "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -267,10 +267,36 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 Log.uploadOperation("end file ufid:\(self.uploadFileId)")
             }
 
+            // Remove source file if uploaded with success and required.
+            if file.uploadDate != nil {
+                let removed = file.cleanSourceFileIfNeeded()
+                if removed {
+                    Log.uploadOperation(
+                        "Removed local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
+                    )
+                } else {
+                    Log.uploadOperation(
+                        "Unable to remove local file at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
+                        level: .error
+                    )
+                }
+            } else {
+                Log.uploadOperation(
+                    "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
+                    level: .warning
+                )
+            }
+
             if let path = file.pathURL,
                file.shouldRemoveAfterUpload && file.uploadDate != nil {
                 Log.uploadOperation("Remove local file at path:\(path) ufid:\(self.uploadFileId)")
                 try? self.fileManager.removeItem(at: path)
+
+            } else {
+                Log.uploadOperation(
+                    "Not removing local file, shouldRemove:\(file.shouldRemoveAfterUpload)  at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)",
+                    level: .warning
+                )
             }
 
             // If task is cancelled, remove it from list

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -22,60 +22,6 @@ import Foundation
 import InfomaniakCore
 import RealmSwift
 
-public protocol UploadQueueable {
-    func getOperation(forUploadFileId uploadFileId: String) -> UploadOperationable?
-
-    /// Read database to enqueue all non finished upload tasks.
-    func rebuildUploadQueueFromObjectsInRealm(_ caller: StaticString)
-
-    /// Save an UploadFile in base and optionally enqueue the upload in main app
-    /// - Parameters:
-    ///   - uploadFile: The upload file to be processed
-    ///   - itemIdentifier: Optional item identifier
-    ///   - addToQueue: Should we schedule the upload as well ?
-    /// - Returns: An UploadOperation if any
-    func saveToRealm(_ uploadFile: UploadFile, itemIdentifier: NSFileProviderItemIdentifier?, addToQueue: Bool)
-        -> UploadOperationable?
-
-    func suspendAllOperations()
-
-    func resumeAllOperations()
-
-    /// Wait for all (started or not) enqueued operations to finish.
-    func waitForCompletion(_ completionHandler: @escaping () -> Void)
-
-    // Retry to upload a specific file, this re-enqueue the task.
-    func retry(_ uploadFileId: String)
-
-    // Retry all uploads within a specified graph, this re-enqueue the tasks.
-    func retryAllOperations(withParent parentId: Int, userId: Int, driveId: Int)
-
-    func cancelAllOperations(withParent parentId: Int, userId: Int, driveId: Int)
-
-    /// Mark all running `UploadOperation` as rescheduled, and terminate gracefully
-    ///
-    /// Takes more time than `cancel`, yet prefer it over a `cancel` for the sake of consistency.
-    /// Further uploads will start from the mail app
-    func rescheduleRunningOperations()
-
-    /// Cancel all running operations, regardless of state
-    func cancelRunningOperations()
-
-    /// Cancel an upload from an UploadFile. The UploadFile is removed and a matching operation is removed.
-    /// - Parameter file: the upload file id to cancel.
-    func cancel(uploadFile: UploadFile)
-
-    /// Cancel an upload from an UploadFile.id. The UploadFile is removed and a matching operation is removed.
-    /// - Parameter uploadFileId: the upload file id to cancel.
-    /// - Returns: true if fileId matched
-    func cancel(uploadFileId: String) -> Bool
-
-    /// Clean errors linked to any upload operation in base. Does not restart the operations.
-    ///
-    /// Also make sure that UploadFiles initiated in FileManager will restart at next retry.
-    func cleanNetworkAndLocalErrorsForAllOperations()
-}
-
 // MARK: - Publish
 
 extension UploadQueue: UploadQueueable {
@@ -292,6 +238,8 @@ extension UploadQueue: UploadQueueable {
             Log.uploadQueue("\(#function) disabled in ShareExtension", level: .error)
             return
         }
+
+        uploadFile.cleanSourceFileIfNeeded()
 
         let uploadFileId = uploadFile.id
         let userId = uploadFile.userId

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -199,16 +199,6 @@ extension UploadQueue: UploadQueueable {
         }
     }
 
-    public func cancelRunningOperations() {
-        Log.uploadQueue("cancelRunningOperations")
-        guard appContextService.context != .shareExtension else {
-            Log.uploadQueue("\(#function) disabled in ShareExtension", level: .error)
-            return
-        }
-
-        operationQueue.operations.filter(\.isExecuting).forEach { $0.cancel() }
-    }
-
     @discardableResult
     public func cancel(uploadFileId: String) -> Bool {
         Log.uploadQueue("cancel uploadFileId:\(uploadFileId)")

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -282,6 +282,11 @@ extension UploadQueue: UploadQueueable {
                                                             userId: userId,
                                                             driveId: driveId,
                                                             using: realm)
+
+                for file in uploadingFiles {
+                    file.cleanSourceFileIfNeeded()
+                }
+
                 Log.uploadQueue("cancelAllOperations count:\(uploadingFiles.count) parentId:\(parentId)")
                 uploadingFilesIds = uploadingFiles.map(\.id)
                 Log.uploadQueue("cancelAllOperations IDS count:\(uploadingFilesIds.count) parentId:\(parentId)")

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueueable.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueueable.swift
@@ -60,9 +60,6 @@ public protocol UploadQueueable {
 
     func cancelAllOperations(withParent parentId: Int, userId: Int, driveId: Int)
 
-    /// Cancel all running operations, regardless of state
-    func cancelRunningOperations()
-
     /// Cancel an upload from an UploadFile. The UploadFile is removed and a matching operation is removed.
     /// - Parameter file: the upload file id to cancel.
     func cancel(uploadFile: UploadFile)

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueueable.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueueable.swift
@@ -1,0 +1,74 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import FileProvider
+import Foundation
+
+public protocol UploadQueueable {
+    func getOperation(forUploadFileId uploadFileId: String) -> UploadOperationable?
+
+    /// Read database to enqueue all non finished upload tasks.
+    func rebuildUploadQueueFromObjectsInRealm(_ caller: StaticString)
+
+    /// Save an UploadFile in base and optionally enqueue the upload in main app
+    /// - Parameters:
+    ///   - uploadFile: The upload file to be processed
+    ///   - itemIdentifier: Optional item identifier
+    ///   - addToQueue: Should we schedule the upload as well ?
+    /// - Returns: An UploadOperation if any
+    func saveToRealm(_ uploadFile: UploadFile, itemIdentifier: NSFileProviderItemIdentifier?, addToQueue: Bool)
+        -> UploadOperationable?
+
+    func suspendAllOperations()
+
+    func resumeAllOperations()
+
+    /// Wait for all (started or not) enqueued operations to finish.
+    func waitForCompletion(_ completionHandler: @escaping () -> Void)
+
+    // Retry to upload a specific file, this re-enqueue the task.
+    func retry(_ uploadFileId: String)
+
+    // Retry all uploads within a specified graph, this re-enqueue the tasks.
+    func retryAllOperations(withParent parentId: Int, userId: Int, driveId: Int)
+
+    /// Mark all running `UploadOperation` as rescheduled, and terminate gracefully
+    ///
+    /// Takes more time than `cancel`, yet prefer it over a `cancel` for the sake of consistency.
+    /// Further uploads will start from the mail app
+    func rescheduleRunningOperations()
+
+    /// Clean errors linked to any upload operation in base. Does not restart the operations.
+    ///
+    /// Also make sure that UploadFiles initiated in FileManager will restart at next retry.
+    func cleanNetworkAndLocalErrorsForAllOperations()
+
+    func cancelAllOperations(withParent parentId: Int, userId: Int, driveId: Int)
+
+    /// Cancel all running operations, regardless of state
+    func cancelRunningOperations()
+
+    /// Cancel an upload from an UploadFile. The UploadFile is removed and a matching operation is removed.
+    /// - Parameter file: the upload file id to cancel.
+    func cancel(uploadFile: UploadFile)
+
+    /// Cancel an upload from an UploadFile.id. The UploadFile is removed and a matching operation is removed.
+    /// - Parameter uploadFileId: the upload file id to cancel.
+    /// - Returns: true if fileId matched
+    func cancel(uploadFileId: String) -> Bool
+}

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -291,7 +291,7 @@ final class FileProviderExtension: NSFileProviderExtension {
             url: item.storageUrl,
             name: item.filename,
             conflictOption: .version,
-            shouldRemoveAfterUpload: false
+            shouldRemoveAfterUpload: true
         )
 
         var observationToken: ObservationToken?


### PR DESCRIPTION
### Abstract

A copy of a file was kept when an upload was cancelled. This is no longer the case.