### PR TITLE
fix: Clean ophan files master

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -153,7 +153,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
         uploadQueue.waitForCompletion {
             // Clean temp files once the upload queue is stoped if needed
             @LazyInjectService var freeSpaceService: FreeSpaceService
-            freeSpaceService.cleanCacheIfAlmostFull()
+            freeSpaceService.auditCache()
 
             group.leave()
         }

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -88,20 +88,8 @@ public enum FactoryService {
             Factory(type: TokenStore.self) { _, _ in
                 TokenStore()
             },
-            Factory(type: UploadQueue.self) { _, resolver in
-                // TODO: Remove
-                guard let freeSpaceService = try? resolver.resolve(
-                    type: FreeSpaceService.self,
-                    forCustomTypeIdentifier: nil,
-                    factoryParameters: nil,
-                    resolver: resolver
-                ) else {
-                    fatalError("woops")
-                }
-
-                freeSpaceService.auditCache()
-
-                return UploadQueue()
+            Factory(type: UploadQueue.self) { _, _ in
+                UploadQueue()
             },
             Factory(type: UploadQueueable.self) { _, resolver in
                 try resolver.resolve(type: UploadQueue.self,

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -88,8 +88,20 @@ public enum FactoryService {
             Factory(type: TokenStore.self) { _, _ in
                 TokenStore()
             },
-            Factory(type: UploadQueue.self) { _, _ in
-                UploadQueue()
+            Factory(type: UploadQueue.self) { _, resolver in
+                // TODO: Remove
+                guard let freeSpaceService = try? resolver.resolve(
+                    type: FreeSpaceService.self,
+                    forCustomTypeIdentifier: nil,
+                    factoryParameters: nil,
+                    resolver: resolver
+                ) else {
+                    fatalError("woops")
+                }
+
+                freeSpaceService.auditCache()
+
+                return UploadQueue()
             },
             Factory(type: UploadQueueable.self) { _, resolver in
                 try resolver.resolve(type: UploadQueue.self,

--- a/kDriveCore/Data/Models/Upload/UploadFile.swift
+++ b/kDriveCore/Data/Models/Upload/UploadFile.swift
@@ -63,7 +63,7 @@ public final class UploadFile: Object, UploadFilable {
     @Persisted(primaryKey: true) public var id = UUID().uuidString
     @Persisted public var name = ""
     @Persisted var relativePath = ""
-    @Persisted private var url: String?
+    @Persisted var url: String?
     @Persisted private var rawType = "file"
     @Persisted public var parentDirectoryId = 1
     @Persisted public var userId = 0

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue.swift
@@ -172,6 +172,15 @@ public final class UploadQueue: ParallelismHeuristicDelegate {
             .sorted(byKeyPath: "taskCreationDate")
     }
 
+    /// Returns all the UploadFiles currently uploading regardless of execution context
+    public func getAllUploadingFilesFrozen() -> Results<UploadFile> {
+        // TODO: Refactor for Transactionable
+        let realm = DriveFileManager.constants.uploadsRealm
+        return realm.objects(UploadFile.self)
+            .filter("uploadDate = nil")
+            .freeze()
+    }
+
     public func getUploadingFiles(userId: Int,
                                   driveIds: [Int],
                                   using realm: Realm = DriveFileManager.constants.uploadsRealm) -> Results<UploadFile> {


### PR DESCRIPTION
Making sure files in the import folder are used by an upload in progress tracked in DB, else the file is orphan and meets the void.

Note: The upload queue must be stopped to perform this work, therefore processing it when closing the app is preferable for now.

Superseeding https://github.com/Infomaniak/ios-kDrive/pull/1176