### PR TITLE
fix: Correct get drive method.

### DIFF
--- a/kDriveCore/Data/Cache/AccountManager.swift
+++ b/kDriveCore/Data/Cache/AccountManager.swift
@@ -65,8 +65,6 @@ public protocol AccountManageable: AnyObject {
     func getDriveFileManager(for driveId: Int, userId: Int) -> DriveFileManager?
     func getFirstAvailableDriveFileManager(for userId: Int) throws -> DriveFileManager
     func getApiFetcher(for userId: Int, token: ApiToken) -> DriveApiFetcher
-    func getDrive(for accountId: Int, driveId: Int) -> Drive?
-    func getDrive(for accountId: Int, driveId: Int, using realm: Realm) -> Drive?
     func getTokenForUserId(_ id: Int) -> ApiToken?
     func didUpdateToken(newToken: ApiToken, oldToken: ApiToken)
     func didFailRefreshToken(_ token: ApiToken)
@@ -232,18 +230,6 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
             apiFetchers[userId] = apiFetcher
             return apiFetcher
         }
-    }
-
-    // TODO: Move to DriveInfosManager
-    public func getDrive(for accountId: Int, driveId: Int) -> Drive? {
-        return try? driveInfosManager.fetchObject(ofType: Drive.self) { realm in
-            self.getDrive(for: accountId, driveId: driveId, using: realm)
-        }
-    }
-
-    // TODO: Move to DriveInfosManager
-    public func getDrive(for accountId: Int, driveId: Int, using realm: Realm) -> Drive? {
-        return driveInfosManager.getDrive(id: driveId, userId: accountId, using: realm)
     }
 
     public func getTokenForUserId(_ id: Int) -> ApiToken? {

--- a/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadQueue.swift
@@ -70,6 +70,7 @@ public final class DownloadQueue: ParallelismHeuristicDelegate {
 
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var appContextService: AppContextServiceable
+    @LazyInjectService var driveInfosManager: DriveInfosManager
 
     public static let instance = DownloadQueue()
     public static let backgroundIdentifier = "com.infomaniak.background.download"
@@ -118,7 +119,7 @@ public final class DownloadQueue: ParallelismHeuristicDelegate {
         let file = file.freezeIfNeeded()
 
         dispatchQueue.async {
-            guard let drive = self.accountManager.getDrive(for: userId, driveId: file.driveId) else {
+            guard let drive = self.driveInfosManager.getDrive(id: file.driveId, userId: userId) else {
                 Log.downloadQueue("Unable to get a drive", level: .error)
                 return
             }
@@ -156,7 +157,7 @@ public final class DownloadQueue: ParallelismHeuristicDelegate {
     public func addToQueue(archiveId: String, driveId: Int, userId: Int) {
         Log.downloadQueue("addToQueue archiveId:\(archiveId)")
         dispatchQueue.async {
-            guard let drive = self.accountManager.getDrive(for: userId, driveId: driveId),
+            guard let drive = self.driveInfosManager.getDrive(id: driveId, userId: userId),
                   let driveFileManager = self.accountManager.getDriveFileManager(for: drive) else {
                 return
             }
@@ -190,7 +191,7 @@ public final class DownloadQueue: ParallelismHeuristicDelegate {
             fileId = file.id,
             isManagedByRealm = file.isManagedByRealm
         ] in
-            guard let drive = self.accountManager.getDrive(for: userId, driveId: driveId),
+            guard let drive = self.driveInfosManager.getDrive(id: driveId, userId: userId),
                   let driveFileManager = self.accountManager.getDriveFileManager(for: drive),
                   let file = isManagedByRealm ? driveFileManager.getCachedFile(id: fileId) : file,
                   !self.hasOperation(for: file.id) else {


### PR DESCRIPTION
FileProvider was broken by dead code. Now calling directly the correct `getDrive` method.