### PR TITLE
fix: Upload Session retry sends 404

### DIFF
--- a/kDriveCore/Data/Api/Endpoint.swift
+++ b/kDriveCore/Data/Api/Endpoint.swift
@@ -701,7 +701,7 @@ public extension Endpoint {
     }
 
     static func getUploadSession(drive: AbstractDrive, sessionToken: AbstractToken) -> Endpoint {
-        return .driveInfo(drive: drive).appending(
+        return .driveInfoV2(drive: drive).appending(
             path: "/upload/session/\(sessionToken.token)",
             queryItems: [URLQueryItem(name: "with", value: "chunks")]
         )


### PR DESCRIPTION
Upload restart / Session negotiation was broken on APIV3 branch.
Looks like the getSession call was to be kept in V2, V3 does not exist