### PR TITLE
feat(DriveError): Handle `limit_exceeded_error`

### DIFF
--- a/kDrive/Resources/de.lproj/Localizable.strings
+++ b/kDrive/Resources/de.lproj/Localizable.strings
@@ -1,11 +1,10 @@
 /*
  * Loco ios export: iOS Localizable.strings
  * Project: kDrive
- * Release: Working copy
  * Locale: de, German
  * Tagged: ios
- * Exported by: Adrien Coye
- * Exported at: Wed, 13 Mar 2024 11:10:26 +0100
+ * Exported by: Valentin Perignon
+ * Exported at: Tue, 21 May 2024 09:34:00 +0200
  */
 
 /* loco:610a8791fa12ab20713c09e4 */
@@ -763,6 +762,9 @@
 
 /* loco:60e2d1ed77622d4af14f5a72 */
 "errorFileLocked" = "Diese Datei ist bereits von einem Benutzer geöffnet und kann nicht verändert werden";
+
+/* loco:664c499b09f1290486001cb2 */
+"errorFilesLimitExceeded" = "Limit der Dateien im Ordner erreicht";
 
 /* loco:605b1b5f49d7ff61223fcfe2 */
 "errorGeneric" = "Ein Fehler ist aufgetreten";
@@ -1563,7 +1565,7 @@
 "recentActivitySeeMore" = "Mehr neue Dateien anzeigen";
 
 /* loco:6049df4d5c2c3a04bc397a2c */
-"refreshTokenError" = "Sie wurden aufgrund eines Problems getrennt. Bitte verbinden Sie sich erneut.";
+"refreshTokenError" = "Ihre Verbindung wurde unterbrochen";
 
 /* loco:6049df4d5c2c3a04bc397a3b */
 "restrictedSharedLinkTitle" = "Eingeschränkter Freigabelink";

--- a/kDrive/Resources/en.lproj/Localizable.strings
+++ b/kDrive/Resources/en.lproj/Localizable.strings
@@ -1,11 +1,10 @@
 /*
  * Loco ios export: iOS Localizable.strings
  * Project: kDrive
- * Release: Working copy
  * Locale: en, English
  * Tagged: ios
- * Exported by: Adrien Coye
- * Exported at: Wed, 13 Mar 2024 11:10:26 +0100
+ * Exported by: Valentin Perignon
+ * Exported at: Tue, 21 May 2024 09:34:00 +0200
  */
 
 /* loco:610a8791fa12ab20713c09e4 */
@@ -763,6 +762,9 @@
 
 /* loco:60e2d1ed77622d4af14f5a72 */
 "errorFileLocked" = "This file is currently opened by another user and cannot be modified";
+
+/* loco:664c499b09f1290486001cb2 */
+"errorFilesLimitExceeded" = "Limit of files in folder reached";
 
 /* loco:605b1b5f49d7ff61223fcfe2 */
 "errorGeneric" = "An error has occurred";
@@ -1563,7 +1565,7 @@
 "recentActivitySeeMore" = "View more recent files";
 
 /* loco:6049df4d5c2c3a04bc397a2c */
-"refreshTokenError" = "You’ve been disconnected due to a problem. Please log in again";
+"refreshTokenError" = "You have been disconnected";
 
 /* loco:6049df4d5c2c3a04bc397a3b */
 "restrictedSharedLinkTitle" = "Restricted sharing link";

--- a/kDrive/Resources/es.lproj/Localizable.strings
+++ b/kDrive/Resources/es.lproj/Localizable.strings
@@ -1,11 +1,10 @@
 /*
  * Loco ios export: iOS Localizable.strings
  * Project: kDrive
- * Release: Working copy
  * Locale: es, Spanish
  * Tagged: ios
- * Exported by: Adrien Coye
- * Exported at: Wed, 13 Mar 2024 11:10:26 +0100
+ * Exported by: Valentin Perignon
+ * Exported at: Tue, 21 May 2024 09:34:01 +0200
  */
 
 /* loco:610a8791fa12ab20713c09e4 */
@@ -763,6 +762,9 @@
 
 /* loco:60e2d1ed77622d4af14f5a72 */
 "errorFileLocked" = "El archivo está actualmente abierto por un usuario y no puede ser modificado";
+
+/* loco:664c499b09f1290486001cb2 */
+"errorFilesLimitExceeded" = "Límite de archivos alcanzado en la carpeta";
 
 /* loco:605b1b5f49d7ff61223fcfe2 */
 "errorGeneric" = "Se ha producido un error";
@@ -1563,7 +1565,7 @@
 "recentActivitySeeMore" = "Ver más archivos recientes";
 
 /* loco:6049df4d5c2c3a04bc397a2c */
-"refreshTokenError" = "Te has desconectado por un problema. Vuelve a conectarte";
+"refreshTokenError" = "Ha sido desconectado";
 
 /* loco:6049df4d5c2c3a04bc397a3b */
 "restrictedSharedLinkTitle" = "Enlace de uso compartido restringido";

--- a/kDrive/Resources/fr.lproj/Localizable.strings
+++ b/kDrive/Resources/fr.lproj/Localizable.strings
@@ -1,11 +1,10 @@
 /*
  * Loco ios export: iOS Localizable.strings
  * Project: kDrive
- * Release: Working copy
  * Locale: fr, French
  * Tagged: ios
- * Exported by: Adrien Coye
- * Exported at: Wed, 13 Mar 2024 11:10:26 +0100
+ * Exported by: Valentin Perignon
+ * Exported at: Tue, 21 May 2024 09:34:00 +0200
  */
 
 /* loco:610a8791fa12ab20713c09e4 */
@@ -763,6 +762,9 @@
 
 /* loco:60e2d1ed77622d4af14f5a72 */
 "errorFileLocked" = "Le fichier est actuellement ouvert par un utilisateur et ne peut être modifié";
+
+/* loco:664c499b09f1290486001cb2 */
+"errorFilesLimitExceeded" = "Limite de fichiers dans le dossier atteinte";
 
 /* loco:605b1b5f49d7ff61223fcfe2 */
 "errorGeneric" = "Une erreur est survenue";
@@ -1563,7 +1565,7 @@
 "recentActivitySeeMore" = "Voir plus de fichiers récents";
 
 /* loco:6049df4d5c2c3a04bc397a2c */
-"refreshTokenError" = "Vous avez été déconnecté en raison d’un problème. Veuillez vous reconnecter";
+"refreshTokenError" = "Vous avez été déconnecté";
 
 /* loco:6049df4d5c2c3a04bc397a3b */
 "restrictedSharedLinkTitle" = "Lien de partage restreint";

--- a/kDrive/Resources/it.lproj/Localizable.strings
+++ b/kDrive/Resources/it.lproj/Localizable.strings
@@ -1,11 +1,10 @@
 /*
  * Loco ios export: iOS Localizable.strings
  * Project: kDrive
- * Release: Working copy
  * Locale: it, Italian
  * Tagged: ios
- * Exported by: Adrien Coye
- * Exported at: Wed, 13 Mar 2024 11:10:26 +0100
+ * Exported by: Valentin Perignon
+ * Exported at: Tue, 21 May 2024 09:34:01 +0200
  */
 
 /* loco:610a8791fa12ab20713c09e4 */
@@ -763,6 +762,9 @@
 
 /* loco:60e2d1ed77622d4af14f5a72 */
 "errorFileLocked" = "Il file è attualmente aperto da un utente e non può essere modificato";
+
+/* loco:664c499b09f1290486001cb2 */
+"errorFilesLimitExceeded" = "Limite file raggiunto nella cartella";
 
 /* loco:605b1b5f49d7ff61223fcfe2 */
 "errorGeneric" = "Si è verificato un errore";
@@ -1563,7 +1565,7 @@
 "recentActivitySeeMore" = "Mostra più file recenti";
 
 /* loco:6049df4d5c2c3a04bc397a2c */
-"refreshTokenError" = "Sei stato disconnesso a causa di un problema. Riconnettiti";
+"refreshTokenError" = "Siete stati disconnessi";
 
 /* loco:6049df4d5c2c3a04bc397a3b */
 "restrictedSharedLinkTitle" = "Link di condivisione limitato";

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -218,11 +218,17 @@ public struct DriveError: Error, Equatable {
 
     public static let uploadTokenCanceled = DriveError(type: .serverError, code: "upload_token_canceled")
 
-    // MARK: - Network
+    public static let limitExceededError = DriveError(
+        type: .serverError,
+        code: "limit_exceeded_error",
+        localizedString: KDriveResourcesStrings.Localizable.errorFilesLimitExceeded
+    )
 
-    public static let networkError = DriveError(type: .networkError,
-                                                code: "networkError",
-                                                localizedString: KDriveResourcesStrings.Localizable.errorNetwork)
+    public static let networkError = DriveError(
+        type: .networkError,
+        code: "networkError",
+        localizedString: KDriveResourcesStrings.Localizable.errorNetwork
+    )
 
     private static let allErrors: [DriveError] = [fileNotFound,
                                                   photoAssetNoLongerExists,
@@ -258,7 +264,8 @@ public struct DriveError: Error, Equatable {
                                                   uploadFailedError,
                                                   uploadTokenIsNotValid,
                                                   fileAlreadyExistsError,
-                                                  errorDeviceStorage]
+                                                  errorDeviceStorage,
+                                                  limitExceededError]
 
     private static let encoder = JSONEncoder()
     private static let decoder = JSONDecoder()

--- a/kDriveCore/Data/Models/DriveError.swift
+++ b/kDriveCore/Data/Models/DriveError.swift
@@ -182,7 +182,7 @@ public struct DriveError: Error, Equatable {
     public static let lock = DriveError(type: .serverError,
                                         code: "lock_error",
                                         localizedString: KDriveResourcesStrings.Localizable.errorFileLocked)
-    public static let donwloadPermission = DriveError(type: .serverError,
+    public static let downloadPermission = DriveError(type: .serverError,
                                                       code: "you_must_add_at_least_one_file",
                                                       localizedString: KDriveResourcesStrings.Localizable.errorDownloadPermission)
     public static let categoryAlreadyExists = DriveError(type: .serverError,
@@ -245,7 +245,7 @@ public struct DriveError: Error, Equatable {
                                                   productMaintenance,
                                                   driveMaintenance,
                                                   lock,
-                                                  donwloadPermission,
+                                                  downloadPermission,
                                                   categoryAlreadyExists,
                                                   stillUploadingError,
                                                   uploadNotTerminated,


### PR DESCRIPTION
A folder cannot contain more than 100'000 files. If we try to upload a file in such a folder, the operation will fail.
We now display a more explicit message when the `limit_exceeded_error` occurs.

![CleanShot 2024-05-21 at 09 43 43@2x](https://github.com/Infomaniak/ios-kDrive/assets/25110022/dfa56cf9-2e1f-420b-a9a7-edc016d0e960)
