### PR TITLE
fix: Make sure to set the UserID early for sentry error tracking

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -49,13 +49,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
     @LazyInjectService var backgroundDownloadSessionManager: BackgroundDownloadSessionManager
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
     @LazyInjectService var notificationHelper: NotificationsHelpable
-    @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var driveInfosManager: DriveInfosManager
     @LazyInjectService var keychainHelper: KeychainHelper
     @LazyInjectService var backgroundTasksService: BackgroundTasksServiceable
     @LazyInjectService var reviewManager: ReviewManageable
     @LazyInjectService var availableOfflineManager: AvailableOfflineManageable
     @LazyInjectService var appRestorationService: AppRestorationService
+
+    // Not lazy to force init of the object early, and set a userID in Sentry
+    @InjectService var accountManager: AccountManageable
 
     // MARK: - UIApplicationDelegate
 

--- a/kDrive/UI/Controller/LockedAppViewController.swift
+++ b/kDrive/UI/Controller/LockedAppViewController.swift
@@ -26,7 +26,7 @@ class LockedAppViewController: UIViewController {
     @LazyInjectService private var appLockHelper: AppLockHelper
 
     @IBOutlet weak var unlockAppButton: IKLargeButton!
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         tryToUnlock()

--- a/kDriveActionExtension/ActionNavigationController.swift
+++ b/kDriveActionExtension/ActionNavigationController.swift
@@ -27,7 +27,8 @@ final class ActionNavigationController: TitleSizeAdjustingNavigationController {
     /// Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .actionExtension)
 
-    @LazyInjectService var accountManager: AccountManageable
+    // Not lazy to force init of the object early, and set a userID in Sentry
+    @InjectService var accountManager: AccountManageable
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -61,6 +61,9 @@ final class FileProviderExtension: NSFileProviderExtension {
     /// Restart the dedicated `FileManager` upload queue on init
     @InjectService var uploadQueue: UploadQueueable
 
+    // Not lazy to force init of the object early, and set a userID in Sentry
+    @InjectService var accountManager: AccountManageable
+
     @LazyInjectService var uploadQueueObservable: UploadQueueObservable
     @LazyInjectService var fileProviderService: FileProviderServiceable
 
@@ -70,7 +73,6 @@ final class FileProviderExtension: NSFileProviderExtension {
         return fileCoordinator
     }()
 
-    @LazyInjectService var accountManager: AccountManageable
     lazy var driveFileManager: DriveFileManager! = setDriveFileManager()
     lazy var manager: NSFileProviderManager = {
         if let domain {

--- a/kDriveShareExtension/ShareNavigationViewController.swift
+++ b/kDriveShareExtension/ShareNavigationViewController.swift
@@ -27,7 +27,8 @@ final class ShareNavigationViewController: TitleSizeAdjustingNavigationControlle
     /// Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .shareExtension)
 
-    @LazyInjectService var accountManager: AccountManageable
+    // Not lazy to force init of the object early, and set a userID in Sentry
+    @InjectService var accountManager: AccountManageable
 
     override public func viewDidLoad() {
         // log


### PR DESCRIPTION
### Abstract

Making sure the userId is set early in sentry to track crashes in a useful way. It is now set before Realm has a chance of migrating.
Following the work done in a [sister PR](https://github.com/Infomaniak/ios-kMail/pull/1440#pullrequestreview-2085580655) on the Mail side

Did non regression tests on app and extension. Did not notice anything.
