### PR TITLE
fix: Mic storage cache issue

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -62,7 +62,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate, AccountManagerDeleg
                      willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         Logging.initLogging()
         Log.appDelegate("Application starting in foreground ? \(UIApplication.shared.applicationState != .background)")
+
         ImageCache.default.memoryStorage.config.totalCostLimit = Constants.memoryCacheSizeLimit
+        // Must define a limit, unlimited otherwise
+        ImageCache.default.diskStorage.config.sizeLimit = Constants.diskCacheSizeLimit
+
         reachabilityListener = ReachabilityListener.instance
         ApiEnvironment.current = .prod
 

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -73,7 +73,9 @@ public enum Logging {
                 isDirectory: true
             ).path)
         let fileLogger = DDFileLogger(logFileManager: logFileManager)
-        fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
+        // 24-hour rolling, 50 MB max per file, 7 files max.
+        fileLogger.rollingFrequency = 60 * 60 * 24
+        fileLogger.maximumFileSize = 50 * 1024 * 1024
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7
         DDLog.add(fileLogger)
     }


### PR DESCRIPTION
- Make sure `logs` have a maximum size on local storage
- Make sure `Image Cache` has a maximum size on local storage

- [ ] Cleaning cache will clean image cache on local storage