### PR TITLE
fix: Update gallery after a file suppression

### DIFF
--- a/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
+++ b/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
@@ -71,6 +71,10 @@ class HomeRecentFilesController {
         self.homeViewController = homeViewController
     }
 
+    func viewDidAppear(_ animated: Bool) {
+        refresh()
+    }
+
     func getFiles() async throws -> [File] {
         fatalError(#function + " needs to be overwritten")
     }
@@ -100,6 +104,12 @@ class HomeRecentFilesController {
     func forceRefresh() {
         lastUpdate = Date()
         loadNextPage(forceRefresh: true)
+    }
+
+    // Reload content from DB without triggering a network call
+    func refresh() {
+        resetController()
+        loadNextPage(forceRefresh: false)
     }
 
     func resetController() {

--- a/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
+++ b/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
@@ -71,7 +71,7 @@ class HomeRecentFilesController {
         self.homeViewController = homeViewController
     }
 
-    func viewDidAppear() {
+    func viewDidAppear(_ animated: Bool) {
         refresh()
     }
 

--- a/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
+++ b/kDrive/UI/Controller/Home/HomeRecentFilesController.swift
@@ -71,7 +71,7 @@ class HomeRecentFilesController {
         self.homeViewController = homeViewController
     }
 
-    func viewDidAppear(_ animated: Bool) {
+    func viewDidAppear() {
         refresh()
     }
 

--- a/kDrive/UI/Controller/Home/HomeViewController.swift
+++ b/kDrive/UI/Controller/Home/HomeViewController.swift
@@ -247,6 +247,7 @@ class HomeViewController: UICollectionViewController, UpdateAccountDelegate, Top
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateNavbarAppearance()
+        currentRecentFilesController.viewDidAppear(animated)
         MatomoUtils.track(view: ["Home"])
     }
 

--- a/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
@@ -21,6 +21,7 @@ import InfomaniakCore
 import InfomaniakCoreUI
 import kDriveCore
 import kDriveResources
+import Kingfisher
 import RealmSwift
 import UIKit
 
@@ -305,6 +306,10 @@ class MultipleSelectionTrashViewModel: MultipleSelectionFileListViewModel {
             let alert = TrashViewModelHelper.deleteAlertForFiles(selectedItems.map { $0.proxify() },
                                                                  firstFilename: firstSelectedItem.name,
                                                                  driveFileManager: driveFileManager) { [weak self] deletedFiles in
+                // quickwin for privacy, remove all image cache after a permanent clean
+                ImageCache.default.diskStorage.removeAll()
+                ImageCache.default.memoryStorage.removeAll()
+
                 MatomoUtils.trackBulkEvent(eventWithCategory: .trash, name: "DeleteFromTrash", numberOfItems: selectedItemCount)
                 self?.removeFromRealm(realmConfiguration, deletedFiles: deletedFiles)
             }

--- a/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
@@ -306,12 +306,12 @@ class MultipleSelectionTrashViewModel: MultipleSelectionFileListViewModel {
             let alert = TrashViewModelHelper.deleteAlertForFiles(selectedItems.map { $0.proxify() },
                                                                  firstFilename: firstSelectedItem.name,
                                                                  driveFileManager: driveFileManager) { [weak self] deletedFiles in
-                // quickwin for privacy, remove all image cache after a permanent clean
-                ImageCache.default.diskStorage.removeAll()
-                ImageCache.default.memoryStorage.removeAll()
-
                 MatomoUtils.trackBulkEvent(eventWithCategory: .trash, name: "DeleteFromTrash", numberOfItems: selectedItemCount)
                 self?.removeFromRealm(realmConfiguration, deletedFiles: deletedFiles)
+
+                // quickwin for privacy, remove all image cache after a permanent clean
+                try? ImageCache.default.diskStorage.removeAll()
+                ImageCache.default.memoryStorage.removeAll()
             }
             onPresentViewController?(.modal, alert, true)
         case .more:

--- a/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
@@ -124,6 +124,10 @@ class TrashListViewModel: InMemoryFileListViewModel {
 
     private func emptyTrash() async {
         do {
+            // Quickwin for privacy, remove all image cache after a permanent clean
+            try? ImageCache.default.diskStorage.removeAll()
+            ImageCache.default.memoryStorage.removeAll()
+
             let success = try await driveFileManager.apiFetcher.emptyTrash(drive: driveFileManager.drive)
             let message = success ? KDriveResourcesStrings.Localizable.snackbarEmptyTrashConfirmation : KDriveResourcesStrings
                 .Localizable.errorDelete
@@ -185,6 +189,10 @@ class TrashListViewModel: InMemoryFileListViewModel {
         // TODO: Split code away from the ViewController, so it is not pinned to the main thread, and we can remove the .detached
         Task.detached { [weak self] in
             await self?.removeFiles(deletedFiles)
+
+            // Quickwin for privacy, remove all image cache after a permanent clean
+            try? ImageCache.default.diskStorage.removeAll()
+            ImageCache.default.memoryStorage.removeAll()
         }
     }
 }
@@ -308,10 +316,6 @@ class MultipleSelectionTrashViewModel: MultipleSelectionFileListViewModel {
                                                                  driveFileManager: driveFileManager) { [weak self] deletedFiles in
                 MatomoUtils.trackBulkEvent(eventWithCategory: .trash, name: "DeleteFromTrash", numberOfItems: selectedItemCount)
                 self?.removeFromRealm(realmConfiguration, deletedFiles: deletedFiles)
-
-                // quickwin for privacy, remove all image cache after a permanent clean
-                try? ImageCache.default.diskStorage.removeAll()
-                ImageCache.default.memoryStorage.removeAll()
             }
             onPresentViewController?(.modal, alert, true)
         case .more:

--- a/kDrive/UI/View/Home/HomeLastPicCollectionViewCell.swift
+++ b/kDrive/UI/View/Home/HomeLastPicCollectionViewCell.swift
@@ -57,6 +57,8 @@ class HomeLastPicCollectionViewCell: UICollectionViewCell {
         super.prepareForReuse()
         thumbnailDownloadTask?.cancel()
         darkLayer.isHidden = true
+        checkmarkImage.isHidden = true
+        videoData.isHidden = true
         fileImage.image = nil
         fileImage.backgroundColor = nil
     }
@@ -70,6 +72,7 @@ class HomeLastPicCollectionViewCell: UICollectionViewCell {
     func configureLoading() {
         darkLayer.isHidden = true
         checkmarkImage.isHidden = true
+        videoData.isHidden = true
         fileImage.backgroundColor = KDriveResourcesAsset.loaderDarkerDefaultColor.color
         contentInsetView.cornerRadius = UIConstants.cornerRadius
     }

--- a/kDriveCore/Data/Models/DriveUser.swift
+++ b/kDriveCore/Data/Models/DriveUser.swift
@@ -19,7 +19,6 @@
 import Foundation
 import InfomaniakCore
 import kDriveResources
-import Kingfisher
 import RealmSwift
 import UIKit
 


### PR DESCRIPTION
- [x] Clear image cache at definitive file suppression.
- [x] Remove a picture, removes it from the Gallery immediately.


https://github.com/Infomaniak/ios-kDrive/assets/121806582/04d9bd34-05e2-4c3e-a258-087db7441368

