### PR TITLE
fix: Ensure we enter before trying to retrieve the resource

### DIFF
--- a/kDriveCore/Utils/ExpiringActivity.swift
+++ b/kDriveCore/Utils/ExpiringActivity.swift
@@ -111,6 +111,11 @@ public final class ExpiringActivity: ExpiringActivityable {
             if shouldTerminate {
                 self.shouldTerminate = true
                 delegate?.backgroundActivityExpiring()
+
+                // At this point we should release the block, but we prefer to wait until the end 🫡⛵️🪦
+                // There is a chance endAll() is called while we wait in should terminate
+                group.wait()
+                return
             }
 
             group.enter()

--- a/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
+++ b/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
@@ -95,7 +95,7 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
                 return true
             }
 
-            // Trigger a request in order to intercept change data
+            group.enter()
             asset.requestContentEditingInput(with: options) { input, _ in
                 defer {
                     group.leave()
@@ -113,10 +113,8 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
                 // This will exclude changes related to like and albums
                 hash = url.dataRepresentation.SHA256DigestString
             }
-
-            // wait for the request to finish
-            group.enter()
             group.wait()
+
             activity.endAll()
 
             guard let error = activityDelegate.error else {
@@ -156,6 +154,7 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
                 Log.photoLibraryUploader("hashing resource \(progress * 100)% …")
             }
 
+            group.enter()
             PHAssetResourceManager.default().requestData(for: bestResource,
                                                          options: options) { data in
                 hasher.update(data)
@@ -163,10 +162,8 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
                 hasher.finalize()
                 group.leave()
             }
-
-            // wait for the request to finish
-            group.enter()
             group.wait()
+
             activity.endAll()
 
             guard let error = activityDelegate.error else {


### PR DESCRIPTION
Sometimes the upload queue is stuck when calling `bestResourceSHA256` or `baseImageSHA256` this happens if pictures are stored on iCloud. 
From what I've observed it is because `PHAssetResourceManager.default().requestData` or `asset.requestContentEditingInput` returns directly instead of switching threads. We end up calling group.leave before group.enter and so we end up waiting indefinitely on group.wait. 
This would result in a soft lock blocking all cooperative thread pools.
