### PR TITLE
fix: FileImportHelper use the dedicated import folder, not group app folder

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
@@ -208,10 +208,14 @@ class SaveFileViewController: UIViewController {
             assetIdentifiers,
             userPreferredPhotoFormat: userPreferredPhotoFormat
         ) { [weak self] importedFiles, errorCount in
-            self?.items = importedFiles
-            self?.errorCount = errorCount
+            guard let self else {
+                return
+            }
+
+            items = importedFiles
+            self.errorCount = errorCount
             Task { @MainActor in
-                self?.updateTableViewAfterImport()
+                self.updateTableViewAfterImport()
             }
         }
     }
@@ -222,10 +226,14 @@ class SaveFileViewController: UIViewController {
         importProgress = fileImportHelper
             .importItems(itemProviders,
                          userPreferredPhotoFormat: userPreferredPhotoFormat) { [weak self] importedFiles, errorCount in
-                self?.items = importedFiles
-                self?.errorCount = errorCount
+                guard let self else {
+                    return
+                }
+
+                items = importedFiles
+                self.errorCount = errorCount
                 Task { @MainActor in
-                    self?.updateTableViewAfterImport()
+                    self.updateTableViewAfterImport()
                 }
             }
     }

--- a/kDriveCore/Utils/Files/FileImportHelper.swift
+++ b/kDriveCore/Utils/Files/FileImportHelper.swift
@@ -133,7 +133,7 @@ public final class FileImportHelper {
                     var finalUrl: URL
                     if self.appContextService.isExtension {
                         // In extension, we need to copy files to a path within appGroup to be able to upload from the main app.
-                        let appGroupURL = try URL.appGroupUniqueFolderURL()
+                        let appGroupURL = try URL.appGroupImportUniqueFolderURL()
 
                         // Get import URL
                         let appGroupFileURL = appGroupURL.appendingPathComponent(fileName)
@@ -249,7 +249,7 @@ public final class FileImportHelper {
                     var finalUrl: URL
                     if self.appContextService.isExtension {
                         // In extension, we need to copy files to a path within appGroup to be able to upload from the main app.
-                        let appGroupURL = try URL.appGroupUniqueFolderURL()
+                        let appGroupURL = try URL.appGroupImportUniqueFolderURL()
 
                         // Get import URL
                         let appGroupFileURL = appGroupURL.appendingPathComponent(fileName)
@@ -281,10 +281,12 @@ public final class FileImportHelper {
 // TODO: move to core
 extension URL {
     /// Build a path where a file can be moved within the appGroup while preventing collisions
-    static func appGroupUniqueFolderURL() throws -> URL {
+    ///
+    /// Uses the importDirectoryURL, that exists within the appGroup, to allow for easy cleaning.
+    static func appGroupImportUniqueFolderURL() throws -> URL {
         // Use a unique folder to prevent collisions
         @InjectService var pathProvider: AppGroupPathProvidable
-        let targetFolderURL = pathProvider.groupDirectoryURL
+        let targetFolderURL = pathProvider.importDirectoryURL
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: targetFolderURL, withIntermediateDirectories: true)
         return targetFolderURL


### PR DESCRIPTION
The app was keeping a copy of files outside the import folder in specific conditions.
The app no longer does that, and uses the import folder.

A further PR will make sure on cleanup to remove said files if no longer in use.