### PR TITLE
fix: Storage space report improvements

### DIFF
--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -58,7 +58,7 @@ final class StorageTableViewController: UITableViewController {
         // Get directories
         let temporaryCacheItem = CacheItem.fileSystem(url: FileManager.default.temporaryDirectory)
         var directoryStorage: [CacheItem] = [
-            CacheItem.fileSystem(url: DriveFileManager.constants.rootDocumentsURL),
+            CacheItem.fileSystem(url: DriveFileManager.constants.realmRootURL),
             CacheItem.fileSystem(url: DriveFileManager.constants.fileProviderDirectoryURL),
             CacheItem.fileSystem(url: DriveFileManager.constants.importDirectoryURL),
             temporaryCacheItem,

--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -98,7 +98,6 @@ final class StorageTableViewController: UITableViewController {
             appSize = 0
         }
 
-        // Total app usage and monitor difference to sentry
         let usedSize = appSize + appGroupSize
 
         Task { @MainActor [weak self] in
@@ -123,8 +122,6 @@ final class StorageTableViewController: UITableViewController {
                 "appGroupSize": appGroupSize
             ]
             SentryDebug.appSizeUsage(metadata)
-
-            print("size \(usedSize) VS legacySize \(legacySize) - appSize:\(appSize) appGroupSize:\(appGroupSize)")
         }
     }
 

--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -89,16 +89,17 @@ final class StorageTableViewController: UITableViewController {
         let appSize: UInt64
         if let documentsURL = DriveFileManager.constants.appDocumentsDirectoryURL,
            let libraryURL = DriveFileManager.constants.appLibraryDirectoryURL {
-            // image cache is contained within the app library folder
+            // Image cache is contained within the app library folder
             let librarySize = CacheItem.fileSystem(url: libraryURL).size
             let documentSize = CacheItem.fileSystem(url: documentsURL).size
-            appSize = documentSize + librarySize
+            let temporarySize = temporaryCacheItem.size
+            appSize = documentSize + librarySize + temporarySize
         } else {
             appSize = 0
         }
 
         // Total app usage and monitor difference to sentry
-        let usedSize = temporaryCacheItem.size + appSize + appGroupSize
+        let usedSize = appSize + appGroupSize
 
         Task { @MainActor [weak self] in
             guard let self else {

--- a/kDriveCore/Data/Cache/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager.swift
@@ -51,13 +51,58 @@ public final class DriveFileManager {
             DropBoxSize.self,
             DropBoxValidity.self
         ]
+
         private let fileManager = FileManager.default
+
+        // MARK: appDirectory URL
+
+        /// App files url
+        public var appDirectoryURL: URL? {
+            guard let appDirectory = FileManager.default.urls(for: .applicationDirectory,
+                                                              in: .userDomainMask).first else {
+                return nil
+            }
+
+            return appDirectory
+        }
+
+        public var appDocumentsDirectoryURL: URL? {
+            guard let appDocumentDirectory = FileManager.default.urls(for: .documentDirectory,
+                                                                      in: .userDomainMask).first else {
+                return nil
+            }
+
+            return appDocumentDirectory
+        }
+
+        public var appLibraryDirectoryURL: URL? {
+            guard let appLibraryDirectory = FileManager.default.urls(for: .libraryDirectory,
+                                                                     in: .userDomainMask).first else {
+                return nil
+            }
+
+            return appLibraryDirectory
+        }
+
+        /// Documents folder, within appDirectoryURL
         public let rootDocumentsURL: URL
-        public let importDirectoryURL: URL
-        public let groupDirectoryURL: URL
-        public var cacheDirectoryURL: URL
+
+        // MARK: system cache URL
+
         public var tmpDirectoryURL: URL
+
+        // MARK: groupDirectory URL
+
+        /// AppGroup url
+        public let groupDirectoryURL: URL
+
+        public let importDirectoryURL: URL
+        public var cacheDirectoryURL: URL
         public let openInPlaceDirectoryURL: URL?
+
+        /// The URL of the files of Files.app, within the appGroup.
+        public let fileProviderDirectoryURL: URL = NSFileProviderManager.default.documentStorageURL
+
         public let rootID = 1
         public let currentVersionCode = 1
         public lazy var migrationBlock = { [weak self] (migration: Migration, oldSchemaVersion: UInt64) in
@@ -203,9 +248,7 @@ public final class DriveFileManager {
             cacheDirectoryURL = pathProvider.cacheDirectoryURL
             openInPlaceDirectoryURL = pathProvider.openInPlaceDirectoryURL
 
-            DDLogInfo(
-                "App working path is: \(fileManager.urls(for: .documentDirectory, in: .userDomainMask).first?.absoluteString ?? "")"
-            )
+            DDLogInfo("App working path is: \(appDirectoryURL?.absoluteString ?? "")")
             DDLogInfo("Group container path is: \(groupDirectoryURL.absoluteString)")
         }
     }

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
@@ -45,7 +45,7 @@ public final class DriveInfosManager {
 
     private init() {
         realmConfiguration = Realm.Configuration(
-            fileURL: DriveFileManager.constants.rootDocumentsURL.appendingPathComponent(Self.dbName),
+            fileURL: DriveFileManager.constants.realmRootURL.appendingPathComponent(Self.dbName),
             schemaVersion: DriveInfosManager.currentDbVersion,
             migrationBlock: { migration, oldSchemaVersion in
                 if oldSchemaVersion < DriveInfosManager.currentDbVersion {

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -491,7 +491,7 @@ public final class File: Object, Codable {
     }
 
     public var localContainerUrl: URL {
-        let directory = isAvailableOffline ? DriveFileManager.constants.rootDocumentsURL : DriveFileManager.constants
+        let directory = isAvailableOffline ? DriveFileManager.constants.realmRootURL : DriveFileManager.constants
             .cacheDirectoryURL
         return directory.appendingPathComponent("\(driveId)", isDirectory: true)
             .appendingPathComponent("\(id)", isDirectory: true)

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -37,7 +37,7 @@ public struct FreeSpaceService {
         case unavailable(wrapping: Error)
     }
 
-    private static let temporaryDirectoryURL = DriveFileManager.constants.tmpDirectoryURL
+    private static let temporaryDirectoryURL = FileManager.default.temporaryDirectory
 
     private static let importDirectoryURL = DriveFileManager.constants.importDirectoryURL
 

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -39,8 +39,6 @@ public struct FreeSpaceService {
 
     private static let temporaryDirectoryURL = FileManager.default.temporaryDirectory
 
-    private static let importDirectoryURL = DriveFileManager.constants.importDirectoryURL
-
     private static let groupDirectoryURL = DriveFileManager.constants.groupDirectoryURL
 
     private let fileManager = FileManager.default
@@ -140,7 +138,7 @@ public struct FreeSpaceService {
 
     /// Check for orphan files in the import folder, clean if file is not tracked in DB.
     private func cleanOrphanImportFolderFiles() {
-        let importDirectory = Self.importDirectoryURL
+        let importDirectory = DriveFileManager.constants.importDirectoryURL
         do {
             // Read content of import folder
             let cachedFiles = try fileManager.contentsOfDirectory(at: importDirectory, includingPropertiesForKeys: nil)

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -41,6 +41,10 @@ public struct FreeSpaceService {
 
     private static let importDirectoryURL = DriveFileManager.constants.importDirectoryURL
 
+    private static let groupDirectoryURL = DriveFileManager.constants.groupDirectoryURL
+
+    private let fileManager = FileManager.default
+
     ///  The minimum available space required to start uploading with chunks
     ///
     /// ≈ n chunks with a max chunk size of 50 meg + 20%. 220MiB for 4 cores.
@@ -69,41 +73,107 @@ public struct FreeSpaceService {
     }
 
     /// Run cache consistency checks
+    ///
+    /// Removes orphan import files, and cache if constrained in space
+    /// This works on the assumption that the UploadQueue is stopped
     public func auditCache() {
-        cleanOrphanFiles()
+        assert(uploadQueue.operationQueue.isSuspended, "expecting the uploadQueue to be suspended")
+
+        cleanOrphanImportFolderFiles()
+        cleanOrphanRootImportFiles()
         cleanCacheIfAlmostFull()
     }
 
+    /// Check for legacy imports files, clean if file is not tracked in DB.
+    ///
+    /// This checks within the appGroup directory, not in the import one.
+    private func cleanOrphanRootImportFiles() {
+        // Read content of app group folder
+        guard let cachedFiles = try? fileManager.contentsOfDirectory(at: Self.groupDirectoryURL, includingPropertiesForKeys: nil)
+        else {
+            Log.uploadOperation("unable to enumerate groupDirectoryURL \(Self.groupDirectoryURL)")
+            return
+        }
+
+        Log.uploadOperation("found \(cachedFiles.count) in the group directory \(cachedFiles)")
+
+        // Keep only folders, where names are a UUID
+        let UUIDsFolders: [URL] = cachedFiles.compactMap { url in
+            guard Self.isDirectory(url: url) else {
+                return nil
+            }
+
+            let uuid = url.lastPathComponent
+            guard UUID(uuidString: uuid) != nil else {
+                return nil
+            }
+
+            return url
+        }
+
+        Log.uploadOperation("found \(UUIDsFolders.count) legacy import folders in the group directory")
+
+        // Keep only folders that are not present in any upload in progress
+        let uploadingFiles = uploadQueue.getAllUploadingFilesFrozen()
+        let foldersToClean: [URL] = UUIDsFolders.compactMap { folderUrl in
+            let folderName = folderUrl.lastPathComponent
+            let isUploading = uploadingFiles.contains { uploadFile in
+                guard let uploadFilePath = uploadFile.url else {
+                    return false
+                }
+
+                return uploadFilePath.contains(folderName)
+            }
+
+            guard !isUploading else {
+                return nil
+            }
+
+            return folderUrl
+        }
+
+        Log.uploadOperation("found \(foldersToClean.count) orphan foldersToClean")
+        for folderToClean in foldersToClean {
+            Log.uploadOperation("removing orphan folder \(folderToClean)")
+            try? fileManager.removeItem(at: folderToClean)
+        }
+    }
+
     /// Check for orphan files in the import folder, clean if file is not tracked in DB.
-    private func cleanOrphanFiles() {
-        let fileManager = FileManager.default
+    private func cleanOrphanImportFolderFiles() {
+        let importDirectory = Self.importDirectoryURL
         do {
             // Read content of import folder
-            let cachedFiles = try fileManager.contentsOfDirectory(atPath: Self.importDirectoryURL.path)
-            Log.uploadOperation("found \(cachedFiles.count) in the import directory")
+            let cachedFiles = try fileManager.contentsOfDirectory(at: importDirectory, includingPropertiesForKeys: nil)
+            guard !cachedFiles.isEmpty else {
+                Log.uploadOperation("no cache files in \(importDirectory) folder, exiting")
+                return
+            }
 
+            Log.uploadOperation("found \(cachedFiles.count) in the \(importDirectory) folder")
             // Get uploading in progress tracked in DB
             let uploadingFiles = uploadQueue.getAllUploadingFilesFrozen()
 
             // Match files on SSD against DB, delete if not matched.
-            let filesToClean = cachedFiles.filter { cachedFileName in
+            let cachedFilesNames = cachedFiles.map { $0.lastPathComponent }
+            let filesNamesToClean = cachedFilesNames.filter { cachedFileName in
                 let cachedFileIsUploading = uploadingFiles.contains { uploadFile in
-                    guard let uploadFileUrl = uploadFile.url else {
+                    guard let uploadFilePath = uploadFile.url else {
                         return false
                     }
-                    return uploadFileUrl.hasSuffix(cachedFileName)
+                    return uploadFilePath.hasSuffix(cachedFileName)
                 }
 
                 return !cachedFileIsUploading
             }
 
-            Log.uploadOperation("cleanning \(filesToClean.count) files in import folder", level: .info)
-            for fileToClean in filesToClean {
-                let fileToCleanURL = Self.importDirectoryURL.appendingPathComponent(fileToClean)
+            Log.uploadOperation("cleanning \(filesNamesToClean.count) files in \(importDirectory) folder", level: .info)
+            for fileToClean in filesNamesToClean {
+                let fileToCleanURL = importDirectory.appendingPathComponent(fileToClean)
                 try? fileManager.removeItem(at: fileToCleanURL)
             }
         } catch {
-            Log.uploadOperation("Unexpected error working with import folder:\(error)", level: .error)
+            Log.uploadOperation("Unexpected error working with \(importDirectory) folder:\(error)", level: .error)
         }
     }
 
@@ -131,7 +201,11 @@ public struct FreeSpaceService {
         try? FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
     }
 
-    // MARK: - private
+    private static func isDirectory(url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
 
     private func freeSpace(url: URL) throws -> Int64 {
         do {

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -37,7 +37,7 @@ public struct FreeSpaceService {
         case unavailable(wrapping: Error)
     }
 
-    private static let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    private static let temporaryDirectoryURL = DriveFileManager.constants.tmpDirectoryURL
 
     private static let importDirectoryURL = DriveFileManager.constants.importDirectoryURL
 
@@ -125,7 +125,7 @@ public struct FreeSpaceService {
         Log.uploadOperation("Almost not enough space for chunk upload, clearing temporary files")
 
         // Clean temp files we are absolutely sure will not end up with a data loss.
-        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let temporaryDirectory = Self.temporaryDirectoryURL
         try? FileManager.default.removeItem(at: temporaryDirectory)
         // Recreate directory to avoid any issue
         try? FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -95,8 +95,6 @@ public struct FreeSpaceService {
             return
         }
 
-        Log.uploadOperation("found \(cachedFiles.count) in the group directory \(cachedFiles)")
-
         // Keep only folders, where names are a UUID
         let importUUIDsFolders: [URL] = cachedFiles.compactMap { url in
             guard Self.isDirectory(url: url) else {
@@ -111,7 +109,9 @@ public struct FreeSpaceService {
             return url
         }
 
-        Log.uploadOperation("found \(importUUIDsFolders.count) legacy import folders in the group directory")
+        Log.uploadOperation(
+            "found \(importUUIDsFolders.count) legacy import folders in the group directory, within \(cachedFiles.count) objects"
+        )
 
         // Keep only folders that are not present in any upload in progress
         let uploadingFiles = uploadQueue.getAllUploadingFilesFrozen()
@@ -132,9 +132,8 @@ public struct FreeSpaceService {
             return folderUrl
         }
 
-        Log.uploadOperation("found \(foldersToClean.count) orphan foldersToClean")
+        Log.uploadOperation("found \(foldersToClean.count) orphan folders to clean")
         for folderToClean in foldersToClean {
-            Log.uploadOperation("removing orphan folder \(folderToClean)")
             try? fileManager.removeItem(at: folderToClean)
         }
     }

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -98,7 +98,7 @@ public struct FreeSpaceService {
         Log.uploadOperation("found \(cachedFiles.count) in the group directory \(cachedFiles)")
 
         // Keep only folders, where names are a UUID
-        let UUIDsFolders: [URL] = cachedFiles.compactMap { url in
+        let importUUIDsFolders: [URL] = cachedFiles.compactMap { url in
             guard Self.isDirectory(url: url) else {
                 return nil
             }
@@ -111,11 +111,11 @@ public struct FreeSpaceService {
             return url
         }
 
-        Log.uploadOperation("found \(UUIDsFolders.count) legacy import folders in the group directory")
+        Log.uploadOperation("found \(importUUIDsFolders.count) legacy import folders in the group directory")
 
         // Keep only folders that are not present in any upload in progress
         let uploadingFiles = uploadQueue.getAllUploadingFilesFrozen()
-        let foldersToClean: [URL] = UUIDsFolders.compactMap { folderUrl in
+        let foldersToClean: [URL] = importUUIDsFolders.compactMap { folderUrl in
             let folderName = folderUrl.lastPathComponent
             let isUploading = uploadingFiles.contains { uploadFile in
                 guard let uploadFilePath = uploadFile.url else {

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -131,8 +131,8 @@ public enum Logging {
             try? fileManager.removeItem(atPath: documentDrivesPath)
             try? fileManager.removeItem(atPath: documentLogsPath)
 
-            if fileManager.fileExists(atPath: DriveFileManager.constants.rootDocumentsURL.path) {
-                try fileManager.copyItem(atPath: DriveFileManager.constants.rootDocumentsURL.path, toPath: documentDrivesPath)
+            if fileManager.fileExists(atPath: DriveFileManager.constants.realmRootURL.path) {
+                try fileManager.copyItem(atPath: DriveFileManager.constants.realmRootURL.path, toPath: documentDrivesPath)
             }
             let cachedLogsUrl = DriveFileManager.constants.cacheDirectoryURL.appendingPathComponent("logs", isDirectory: true)
             if fileManager.fileExists(atPath: cachedLogsUrl.path) {

--- a/kDriveCore/Utils/Sentry/SentryDebug+Misc.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Misc.swift
@@ -1,7 +1,6 @@
-//
 /*
  Infomaniak kDrive - iOS App
- Copyright (C) 2023 Infomaniak Network SA
+ Copyright (C) 2024 Infomaniak Network SA
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/kDriveCore/Utils/Sentry/SentryDebug+Misc.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Misc.swift
@@ -1,0 +1,28 @@
+//
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+public extension SentryDebug {
+    // MARK: - Space usage
+
+    static func appSizeUsage(_ metadata: [String: Any] = [:]) {
+        SentryDebug.capture(message: EventNames.appSizeUsage, extras: metadata)
+    }
+}

--- a/kDriveCore/Utils/Sentry/SentryDebug.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug.swift
@@ -44,6 +44,7 @@ public enum SentryDebug {
 
     public enum EventNames {
         static let uploadCompletedSuccess = "UploadCompletedSuccess"
+        static let appSizeUsage = "appSizeUsage"
     }
 
     public enum ErrorNames {


### PR DESCRIPTION
### Abstract

Last beta shown that some files were still missing from `StorageTableViewController`
This PR aims at displaying a more correct total app space usage and to cleanup legacy import files.

### Changes
- Calculation of the total Space used is more complete
  - Counting Entire App Group directory, App Library and App Documents directory.
  - Sentry event to keep a dashboard of space usage.
- Clean legacy import folders automatically on existing clean-up process.