### PR TITLE
fix: Correctly load root on switch

### DIFF
--- a/kDrive/UI/Controller/Home/SelectSwitchDriveDelegate.swift
+++ b/kDrive/UI/Controller/Home/SelectSwitchDriveDelegate.swift
@@ -36,6 +36,12 @@ extension SelectSwitchDriveDelegate {
             let driveUserId = drive.userId
 
             Task {
+                @InjectService var accountManager: AccountManageable
+                let driveFileManager = accountManager.getDriveFileManager(for: driveId, userId: driveUserId)
+                try await driveFileManager?.initRoot()
+            }
+
+            Task {
                 @InjectService var appRestorationService: AppRestorationServiceable
                 await appRestorationService.reloadAppUI(for: driveId, userId: driveUserId)
             }

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -232,8 +232,8 @@ public final class DriveFileManager {
     }
 
     public func initRoot() async throws {
-        let root = try await file(id: DriveFileManager.constants.rootID, forceRefresh: true)
-        _ = try await files(in: root.proxify(), forceRefresh: true)
+        let root = ProxyFile(driveId: drive.id, id: DriveFileManager.constants.rootID)
+        _ = try await files(in: root, forceRefresh: true)
     }
 
     public func files(in directory: ProxyFile, cursor: String? = nil, sortType: SortType = .nameAZ,


### PR DESCRIPTION
Root is loaded for the current drive and the current account on update but not once we switch drive. 
Also the root was loaded twice in `initRoot` by 2 different calls.

This PR ensures we load in the background the root while we switch.
It also removes the second call.