### PR TITLE
fix: Use revisedAt instead of lastModifiedAt where possible

### DIFF
--- a/kDrive/SceneDelegate.swift
+++ b/kDrive/SceneDelegate.swift
@@ -287,7 +287,7 @@ extension SceneDelegate {
                 let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
                 let modificationDate = attributes?[.modificationDate] as? Date ?? Date(timeIntervalSince1970: 0)
 
-                guard modificationDate > file.lastModifiedAt else {
+                guard modificationDate > file.revisedAt else {
                     continue
                 }
 
@@ -312,7 +312,7 @@ extension SceneDelegate {
                             // Update file to get the new modification date
                             Task {
                                 let file = try await driveFileManager.file(id: fileId, forceRefresh: true)
-                                try? FileManager.default.setAttributes([.modificationDate: file.lastModifiedAt],
+                                try? FileManager.default.setAttributes([.modificationDate: file.revisedAt],
                                                                        ofItemAtPath: file.localUrl.path)
                                 driveFileManager.notifyObserversWith(file: file)
                             }

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -53,7 +53,7 @@ public final class FileActionsHelper {
             if FileManager.default.fileExists(atPath: fileUrl.path) {
                 let attributes = try FileManager.default.attributesOfItem(atPath: fileUrl.path)
                 let modificationDate = attributes[.modificationDate] as? Date ?? Date(timeIntervalSince1970: 0)
-                if file.lastModifiedAt > modificationDate {
+                if file.revisedAt > modificationDate {
                     try FileManager.default.removeItem(at: fileUrl)
                 } else {
                     shouldCopy = false

--- a/kDriveCore/Data/Cache/PdfPreviewCache.swift
+++ b/kDriveCore/Data/Cache/PdfPreviewCache.swift
@@ -36,7 +36,7 @@ public class PdfPreviewCache {
         do {
             if let modifiedDate = try FileManager.default
                 .attributesOfItem(atPath: pdfPreviewUrl(for: file).path)[.modificationDate] as? Date {
-                if modifiedDate >= file.lastModifiedAt {
+                if modifiedDate >= file.revisedAt {
                     return false
                 }
             }

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -687,7 +687,7 @@ public final class File: Object, Codable {
     }
 
     public func applyLastModifiedDateToLocalFile() {
-        try? fileManager.setAttributes([.modificationDate: lastModifiedAt], ofItemAtPath: localUrl.path)
+        try? fileManager.setAttributes([.modificationDate: revisedAt], ofItemAtPath: localUrl.path)
     }
 
     public func excludeFileFromSystemBackup() {

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -383,7 +383,7 @@ public final class File: Object, Codable {
     @Persisted public var addedAt: Date
     /// Date of modification of content / path / name
     @Persisted public var updatedAt: Date
-    /// Date of modification of metadata
+    /// Date of modification of the content by manual upload or OnlyOffice
     @Persisted public var lastModifiedAt: Date
     /// Date of deleted resource, only visible when the File is trashed
     @Persisted public var deletedBy: Int?


### PR DESCRIPTION
Now that we have access to `revisedAt` which gives a date for the modification of the file we can use it to compare with the local file date.