### PR TITLE
feat: Private share link can be shared like on the web

### DIFF
--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -37,7 +37,7 @@ extension FileActionsFloatingPanelViewController {
         let offline = ReachabilityListener.instance.currentStatus == .offline
 
         quickActions = file.isDirectory ? FloatingPanelAction.folderQuickActions : FloatingPanelAction.quickActions
-        quickActions.forEach { action in
+        for action in quickActions {
             switch action {
             case .shareAndRights:
                 if !file.capabilities.canShare || offline {

--- a/kDrive/UI/View/Files/FileDetail/ShareLink/ShareLinkTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/ShareLink/ShareLinkTableViewCell.swift
@@ -16,6 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import InfomaniakCore
 import InfomaniakCoreUI
 import kDriveCore
 import kDriveResources
@@ -27,17 +28,18 @@ protocol ShareLinkTableViewCellDelegate: AnyObject {
 }
 
 class ShareLinkTableViewCell: InsetTableViewCell {
-    @IBOutlet weak var shareLinkTitleLabel: IKLabel!
-    @IBOutlet weak var shareIconImageView: UIImageView!
-    @IBOutlet weak var rightArrow: UIImageView!
-    @IBOutlet weak var shareLinkStackView: UIStackView!
-    @IBOutlet weak var shareLinkDescriptionLabel: UILabel!
-    @IBOutlet weak var copyButton: ImageButton!
-    @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var trailingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var leadingInnerConstraint: NSLayoutConstraint!
-    @IBOutlet weak var trailingInnerConstraint: NSLayoutConstraint!
-    @IBOutlet weak var separatorView: UIView!
+    @IBOutlet var shareLinkTitleLabel: IKLabel!
+    @IBOutlet var shareIconImageView: UIImageView!
+    @IBOutlet var rightArrow: UIImageView!
+    @IBOutlet var shareLinkStackView: UIStackView!
+    @IBOutlet var shareLinkDescriptionLabel: UILabel!
+    @IBOutlet var copyButton: ImageButton!
+    @IBOutlet var leadingConstraint: NSLayoutConstraint!
+    @IBOutlet var trailingConstraint: NSLayoutConstraint!
+    @IBOutlet var leadingInnerConstraint: NSLayoutConstraint!
+    @IBOutlet var trailingInnerConstraint: NSLayoutConstraint!
+    @IBOutlet var separatorView: UIView!
+    @IBOutlet var fileShareLinkSettingTitle: IKButton!
 
     weak var delegate: ShareLinkTableViewCellDelegate?
     var url = ""
@@ -95,7 +97,7 @@ class ShareLinkTableViewCell: InsetTableViewCell {
         } else {
             initWithoutInsets()
         }
-        layoutIfNeeded()
+
         if let shareLink = file.sharelink {
             shareLinkTitleLabel.text = KDriveResourcesStrings.Localizable.publicSharedLinkTitle
             let rightPermission = (shareLink.capabilities.canEdit ? KDriveResourcesStrings.Localizable
@@ -115,12 +117,15 @@ class ShareLinkTableViewCell: InsetTableViewCell {
                 date
             )
             shareLinkStackView.isHidden = false
+            fileShareLinkSettingTitle.alpha = 1
+            fileShareLinkSettingTitle.isUserInteractionEnabled = true
             url = shareLink.url
             shareIconImageView.image = KDriveResourcesAsset.unlock.image
         } else if file.isDropbox {
             shareLinkTitleLabel.text = KDriveResourcesStrings.Localizable.dropboxSharedLinkTitle
             shareLinkDescriptionLabel.text = KDriveResourcesStrings.Localizable.dropboxSharedLinkDescription
             shareLinkStackView.isHidden = true
+            url = ""
             rightArrow.isHidden = true
             shareIconImageView.image = KDriveResourcesAsset.folderDropBox.image
         } else {
@@ -129,9 +134,14 @@ class ShareLinkTableViewCell: InsetTableViewCell {
                 .shareLinkRestrictedRightFolderDescriptionShort : file.isOfficeFile ? KDriveResourcesStrings.Localizable
                 .shareLinkRestrictedRightDocumentDescriptionShort : KDriveResourcesStrings.Localizable
                 .shareLinkRestrictedRightFileDescriptionShort
-            shareLinkStackView.isHidden = true
+            shareLinkStackView.isHidden = false
+            url = file.privateSharePath(host: ApiEnvironment.current.driveHost)
+            fileShareLinkSettingTitle.alpha = 0
+            fileShareLinkSettingTitle.isUserInteractionEnabled = false
             shareIconImageView.image = KDriveResourcesAsset.lock.image
         }
+
+        layoutIfNeeded()
     }
 
     func initWithoutInsets() {

--- a/kDrive/UI/View/Files/FileDetail/ShareLink/ShareLinkTableViewCell.xib
+++ b/kDrive/UI/View/Files/FileDetail/ShareLink/ShareLinkTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -170,6 +170,7 @@
                 <outlet property="bottomConstraint" destination="Lkc-Sh-B1y" id="W7L-cf-7tw"/>
                 <outlet property="contentInsetView" destination="vRh-ng-z3o" id="6Jv-Eh-U01"/>
                 <outlet property="copyButton" destination="v5H-Mw-FXc" id="Wew-y0-4Gh"/>
+                <outlet property="fileShareLinkSettingTitle" destination="I4m-zt-myD" id="P4T-dP-R4Q"/>
                 <outlet property="leadingConstraint" destination="BKx-m5-0Zy" id="Frn-SJ-XAF"/>
                 <outlet property="leadingInnerConstraint" destination="vNE-RS-hpX" id="fPa-mL-nOH"/>
                 <outlet property="rightArrow" destination="5JS-W7-FAq" id="1bo-51-uEM"/>
@@ -210,7 +211,7 @@
             <color red="0.52156862745098043" green="0.63529411764705879" blue="0.71372549019607845" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="infomaniakColor">
-            <color red="0.0" green="0.59607843137254901" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.59600001573562622" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="primaryTextColor">
             <color red="0.40000000596046448" green="0.40000000596046448" blue="0.40000000596046448" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/kDriveCore/Data/Models/File+URL.swift
+++ b/kDriveCore/Data/Models/File+URL.swift
@@ -1,0 +1,28 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2023 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+public extension File {
+    /// Formats the private share link of a file
+    ///
+    /// https://kdrive.infomaniak.com/app/drive/123/redirect/456
+    func privateSharePath(host: String) -> String {
+        "https://\(host)/app/drive/\(driveId)/redirect/\(id)"
+    }
+}

--- a/kDriveCore/Data/Models/ShareLink.swift
+++ b/kDriveCore/Data/Models/ShareLink.swift
@@ -20,7 +20,7 @@ import Foundation
 import RealmSwift
 
 public enum ShareLinkPermission: String, Encodable {
-    case restricted, `public`, password
+    case restricted, `public`, password, inherit
 }
 
 public class ShareLink: EmbeddedObject, Codable {
@@ -34,6 +34,10 @@ public class ShareLink: EmbeddedObject, Codable {
         case right
         case validUntil = "valid_until"
         case capabilities
+    }
+
+    public var shareLinkPermission: ShareLinkPermission? {
+        ShareLinkPermission(rawValue: right)
     }
 }
 


### PR DESCRIPTION
Any file has a private sharing URL that can be constructed, this takes care of that and brings the iOS app on par with the web.

<img width="393" alt="Screenshot 2024-07-04 at 11 30 55" src="https://github.com/Infomaniak/ios-kDrive/assets/121806582/27068ac5-2536-4b1b-a1e0-df6a9fe44143">
