### PR TITLE
fix: Extension main activity missing

### DIFF
--- a/kDrive/AppRestorationService.swift
+++ b/kDrive/AppRestorationService.swift
@@ -45,6 +45,7 @@ public final class AppRestorationService: AppRestorationServiceable {
         .appendingPathComponent("Saved Application State")
 
     @LazyInjectService private var accountManager: AccountManageable
+    @LazyInjectService private var appContextService: AppContextServiceable
 
     /// State restoration version
     private static let currentStateVersion = 5
@@ -61,6 +62,10 @@ public final class AppRestorationService: AppRestorationServiceable {
     }
 
     public var shouldRestoreApplicationState: Bool {
+        guard !appContextService.isExtension else {
+            return false
+        }
+
         let storedVersion = UserDefaults.shared.appRestorationVersion
         let shouldRestore = Self.currentStateVersion == storedVersion &&
             !(UserDefaults.shared.legacyIsFirstLaunch || accountManager.accounts.isEmpty)

--- a/kDriveActionExtension/Info.plist
+++ b/kDriveActionExtension/Info.plist
@@ -22,6 +22,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).mainActionActivity</string>
+	</array>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/kDriveFileProvider/Info.plist
+++ b/kDriveFileProvider/Info.plist
@@ -20,6 +20,10 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).mainFileProviderActivity</string>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>

--- a/kDriveShareExtension/Info.plist
+++ b/kDriveShareExtension/Info.plist
@@ -22,6 +22,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).mainShareExtensionActivity</string>
+	</array>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Share extension is crashing since the SceneDelegate migration. This fixes that.