### PR TITLE
fix: Use correct endpoints

### DIFF
--- a/kDriveAPITests/kDriveCore/DriveApiTests.swift
+++ b/kDriveAPITests/kDriveCore/DriveApiTests.swift
@@ -608,26 +608,6 @@ final class DriveApiTests: XCTestCase {
         tearDownTest(directory: testDirectory)
     }
 
-    func testGetFilesActivities() async throws {
-        let (testDirectory, file) = try await initOfficeFile(testName: "Get files activities")
-        let secondFile = try await currentApiFetcher.createFile(
-            in: testDirectory,
-            name: "Get files activities-\(Date())",
-            type: "docx"
-        ).proxify()
-        let activities = try await currentApiFetcher.filesActivities(
-            drive: proxyDrive,
-            files: [file, secondFile],
-            from: Date(timeIntervalSince1970: 0)
-        ).validApiResponse.data
-        XCTAssertEqual(activities.count, 2, "Array should contain two activities")
-        for activity in activities {
-            XCTAssertTrue(activity.result, TestsMessages.shouldReturnTrue)
-            XCTAssertNil(activity.message, TestsMessages.noError)
-        }
-        tearDownTest(directory: testDirectory)
-    }
-
     // MARK: Trashed files
 
     func testTrashedFiles() async throws {

--- a/kDriveAPITests/kDriveCore/DriveApiTests.swift
+++ b/kDriveAPITests/kDriveCore/DriveApiTests.swift
@@ -597,14 +597,14 @@ final class DriveApiTests: XCTestCase {
 
     func testGetFileActivities() async throws {
         let testDirectory = try await setUpTest(testName: "Get file detail activity")
-        _ = try await currentApiFetcher.fileActivities(file: testDirectory, page: 1)
+        _ = try await currentApiFetcher.fileActivities(file: testDirectory, cursor: nil)
         tearDownTest(directory: testDirectory)
     }
 
     func testGetFileActivitiesFromDate() async throws {
         let earlyDate = Calendar.current.date(byAdding: .hour, value: -1, to: Date())!
         let (testDirectory, file) = try await initOfficeFile(testName: "Get file activity from date")
-        _ = try await currentApiFetcher.fileActivities(file: file, from: earlyDate, page: 1)
+        _ = try await currentApiFetcher.fileActivities(file: file, from: earlyDate, cursor: nil)
         tearDownTest(directory: testDirectory)
     }
 

--- a/kDriveAPITests/kDriveCore/DriveApiTests.swift
+++ b/kDriveAPITests/kDriveCore/DriveApiTests.swift
@@ -646,7 +646,8 @@ final class DriveApiTests: XCTestCase {
             drive: proxyDrive,
             query: "officeFile",
             categories: [],
-            belongToAllCategories: true
+            belongToAllCategories: true,
+            sortType: .newer
         ).validApiResponse.data
         let fileFound = files.contains { $0.id == file.id }
         XCTAssertTrue(fileFound, "File created should be in response")

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -406,7 +406,7 @@ public class DriveApiFetcher: ApiFetcher {
         categories: [Category],
         belongToAllCategories: Bool,
         cursor: String? = nil,
-        sortType: SortType = .nameAZ
+        sortType: SortType
     ) async throws -> ValidServerResponse<[File]> {
         try await perform(request: authenticatedRequest(.search(
             drive: drive,

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -325,12 +325,6 @@ public class DriveApiFetcher: ApiFetcher {
         return activities
     }
 
-    public func filesActivities(drive: AbstractDrive, files: [ProxyFile],
-                                from date: Date) async throws
-        -> ValidServerResponse<[ActivitiesForFile]> {
-        try await perform(request: authenticatedRequest(.filesActivities(drive: drive, fileIds: files.map(\.id), from: date)))
-    }
-
     public func favorite(file: ProxyFile) async throws -> Bool {
         try await perform(request: authenticatedRequest(.favorite(file: file), method: .post))
     }

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -273,7 +273,7 @@ public class DriveApiFetcher: ApiFetcher {
     }
 
     public func deleteDefinitely(file: ProxyFile) async throws -> Bool {
-        try await perform(request: authenticatedRequest(.trashedInfo(file: file), method: .delete))
+        try await perform(request: authenticatedRequest(.trashedInfoV2(file: file), method: .delete))
     }
 
     public func rename(file: ProxyFile, newName: String) async throws -> CancelableResponse {

--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -298,19 +298,20 @@ public class DriveApiFetcher: ApiFetcher {
         try await perform(request: authenticatedRequest(.recentActivity(drive: drive).cursored(cursor)))
     }
 
-    public func fileActivities(file: ProxyFile, page: Int) async throws -> [FileActivity] {
+    public func fileActivities(file: ProxyFile, cursor: String? = nil) async throws -> ValidServerResponse<[FileActivity]> {
         var queryItems = [URLQueryItem(name: "with", value: "user")]
         queryItems
             .append(contentsOf: FileActivityType.displayedFileActivities
                 .map { URLQueryItem(name: "actions[]", value: $0.rawValue) })
         let endpoint = Endpoint.fileActivities(file: file)
             .appending(path: "", queryItems: queryItems)
-            .paginated(page: page)
+            .cursored(cursor)
         return try await perform(request: authenticatedRequest(endpoint))
     }
 
-    public func fileActivities(file: ProxyFile, from date: Date,
-                               page: Int) async throws -> ValidServerResponse<[FileActivity]> {
+    public func fileActivities(file: ProxyFile,
+                               from date: Date,
+                               cursor: String? = nil) async throws -> ValidServerResponse<[FileActivity]> {
         var queryItems = [
             FileWith.fileActivitiesWithExtra.toQueryItem(),
             URLQueryItem(name: "depth", value: "children"),
@@ -319,7 +320,7 @@ public class DriveApiFetcher: ApiFetcher {
         queryItems.append(contentsOf: FileActivityType.fileActivities.map { URLQueryItem(name: "actions[]", value: $0.rawValue) })
         let endpoint = Endpoint.fileActivities(file: file)
             .appending(path: "", queryItems: queryItems)
-            .paginated(page: page)
+            .cursored(cursor)
         let activities: ValidServerResponse<[FileActivity]> = try await perform(request: authenticatedRequest(endpoint))
         return activities
     }

--- a/kDriveCore/Data/Api/Endpoint.swift
+++ b/kDriveCore/Data/Api/Endpoint.swift
@@ -236,17 +236,6 @@ public extension Endpoint {
         return .fileInfo(file).appending(path: "/activities")
     }
 
-    static func filesActivities(drive: AbstractDrive, fileIds: [Int], from date: Date) -> Endpoint {
-        return .recentActivity(drive: drive).appending(path: "/batch", queryItems: [
-            noAvatarDefault(),
-            FileWith.fileActivities.toQueryItem(),
-            URLQueryItem(name: "actions[]", value: "file_rename"),
-            URLQueryItem(name: "actions[]", value: "file_update"),
-            URLQueryItem(name: "file_ids", value: fileIds.map(String.init).joined(separator: ",")),
-            URLQueryItem(name: "from_date", value: "\(Int(date.timeIntervalSince1970))")
-        ])
-    }
-
     static func trashedFileActivities(file: AbstractFile) -> Endpoint {
         return .trashedInfo(file: file).appending(path: "/activities")
     }

--- a/kDriveCore/Data/Api/Endpoint.swift
+++ b/kDriveCore/Data/Api/Endpoint.swift
@@ -649,6 +649,10 @@ public extension Endpoint {
         return .driveInfo(drive: drive).appending(path: "/trash", queryItems: [FileWith.fileMinimal.toQueryItem()])
     }
 
+    static func trashV2(drive: AbstractDrive) -> Endpoint {
+        return .driveInfoV2(drive: drive).appending(path: "/trash")
+    }
+
     static func emptyTrash(drive: AbstractDrive) -> Endpoint {
         return .driveInfoV2(drive: drive).appending(path: "/trash")
     }
@@ -664,12 +668,16 @@ public extension Endpoint {
         )
     }
 
+    static func trashedInfoV2(file: AbstractFile) -> Endpoint {
+        return .trashV2(drive: ProxyDrive(id: file.driveId)).appending(path: "/\(file.id)")
+    }
+
     static func trashedFiles(of directory: AbstractFile) -> Endpoint {
         return .trashedInfo(file: directory).appending(path: "/files", queryItems: [FileWith.fileMinimal.toQueryItem()])
     }
 
     static func restore(file: AbstractFile) -> Endpoint {
-        return .trashedInfo(file: file).appending(path: "/restore")
+        return .trashedInfoV2(file: file).appending(path: "/restore")
     }
 
     static func trashThumbnail(file: AbstractFile, at date: Date) -> Endpoint {

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -546,7 +546,7 @@ public final class DriveFileManager {
         // Get all pages and assemble
         let fetchedFile = try file.resolve(within: self).freeze()
         let timestamp = TimeInterval(timestamp ?? fetchedFile.responseAt)
-        var page = 1
+        var cursor: String?
         var moreComing = true
         var pagedActions = [String: FileActivityType]()
         var pagedActivities = ActivitiesResult()
@@ -557,12 +557,12 @@ public final class DriveFileManager {
             let response = try await apiFetcher.fileActivities(
                 file: file,
                 from: Date(timeIntervalSince1970: timestamp),
-                page: page
+                cursor: cursor
             )
 
             let activities = response.validApiResponse.data
-            moreComing = activities.count == Endpoint.itemsPerPage
-            page += 1
+            moreComing = response.validApiResponse.hasMore
+            cursor = response.validApiResponse.cursor
             responseAt = response.validApiResponse.responseAt ?? Int(Date().timeIntervalSince1970)
 
             try database.writeTransaction { writableRealm in


### PR DESCRIPTION
Read commit by commit:
- (417cc90fabb154f77d13f951ed00a9a89d76d902) Trash -> restore / delete permanently use V2
- (12387860dc3153893c21d3d95fdb98a4024f603a) Activities for file details -> use cursor
- (5391da64ea1b9e13bcd68d00e0a6447f7437a681) Remove dead code
- (f6df90dfabfca9a40956c36a068b180da95a2964) Remove default argument for searchFiles