### PR TITLE
fix: Keep sortedName as lowercased

### DIFF
--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -756,7 +756,7 @@ public final class File: Object, Codable {
         uid = File.uid(driveId: driveId, fileId: id)
         let decodedName = try container.decode(String.self, forKey: .name)
         name = decodedName
-        sortedName = try container.decodeIfPresent(String.self, forKey: .sortedName) ?? decodedName
+        sortedName = try container.decodeIfPresent(String.self, forKey: .sortedName)?.lowercased() ?? decodedName.lowercased()
         path = try container.decodeIfPresent(String.self, forKey: .path)
         rawType = try container.decode(String.self, forKey: .rawType)
         rawStatus = try container.decodeIfPresent(String.self, forKey: .rawStatus)

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -756,7 +756,10 @@ public final class File: Object, Codable {
         uid = File.uid(driveId: driveId, fileId: id)
         let decodedName = try container.decode(String.self, forKey: .name)
         name = decodedName
-        sortedName = try container.decodeIfPresent(String.self, forKey: .sortedName)?.lowercased() ?? decodedName.lowercased()
+        sortedName = try (container.decodeIfPresent(String.self, forKey: .sortedName) ?? decodedName).lowercased().folding(
+            options: .diacriticInsensitive,
+            locale: .current
+        )
         path = try container.decodeIfPresent(String.self, forKey: .path)
         rawType = try container.decode(String.self, forKey: .rawType)
         rawStatus = try container.decodeIfPresent(String.self, forKey: .rawStatus)


### PR DESCRIPTION
Realm can't sort files correctly: [issue](https://github.com/realm/realm-swift/issues/2970).
Keep sortedName as lowercased to sort files alphabetically (and case insensitive).