### PR TITLE
fix(AppRouter): Correctly navigate to file list when in root menu

### DIFF
--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -549,27 +549,30 @@ public struct AppRouter: AppNavigable {
         rootViewController.dismiss(animated: false) {
             rootViewController.selectedIndex = MainTabBarIndex.files.rawValue
 
-            guard let navController = rootViewController.selectedViewController as? UINavigationController,
-                  let viewController = navController.topViewController as? FileListViewController else {
+            guard let navController = rootViewController.selectedViewController as? UINavigationController else {
                 return
             }
 
-            guard !file.isRoot && viewController.viewModel.currentDirectory.id != file.id else {
-                return
+            guard !file.isRoot else { return }
+
+            if let fileListViewController = navController.topViewController as? FileListViewController {
+                guard fileListViewController.viewModel.currentDirectory.id != file.id else {
+                    return
+                }
+
+                navController.popToRootViewController(animated: false)
             }
 
-            navController.popToRootViewController(animated: false)
-
-            guard let fileListViewController = navController.topViewController as? FileListViewController else {
+            guard let rootMenuViewController = navController.topViewController as? RootMenuViewController else {
                 return
             }
 
             if office {
                 OnlyOfficeViewController.open(driveFileManager: driveFileManager,
                                               file: file,
-                                              viewController: fileListViewController)
+                                              viewController: rootMenuViewController)
             } else {
-                let filePresenter = FilePresenter(viewController: fileListViewController)
+                let filePresenter = FilePresenter(viewController: rootMenuViewController)
                 filePresenter.present(for: file,
                                       files: [file],
                                       driveFileManager: driveFileManager,


### PR DESCRIPTION
The "locate" button in the snackbar after an upload wasn't correctly redirecting to the `FileListViewController` if the user wasn't already in a `FileListViewController` (eg. in the `RootMenuViewController`)