### PR TITLE
fix: Ensure we only show team and private folders in root

### DIFF
--- a/kDrive/UI/Controller/Files/RootMenuViewController.swift
+++ b/kDrive/UI/Controller/Files/RootMenuViewController.swift
@@ -126,7 +126,10 @@ class RootMenuViewController: CustomLargeTitleCollectionViewController, SelectSw
             return
         }
 
-        let rootChildren = root.children
+        let rootChildren = root.children.filter(NSPredicate(
+            format: "rawVisibility IN %@",
+            [FileVisibility.isPrivateSpace.rawValue, FileVisibility.isTeamSpace.rawValue]
+        ))
         rootChildrenObservationToken = rootChildren.observe { [weak self] changes in
             guard let self else { return }
             switch changes {


### PR DESCRIPTION
This prevents showing the "Shared" folder in the root. This also restrict to only showing the folders we want.