### PR TITLE
fix: Extend switch drive tappable area

### DIFF
--- a/kDrive/UI/Controller/Menu/MenuViewController.swift
+++ b/kDrive/UI/Controller/Menu/MenuViewController.swift
@@ -189,6 +189,8 @@ extension MenuViewController {
             if let currentAccount {
                 cell.configureCell(with: driveFileManager.drive, and: currentAccount)
             }
+            let tap = UITapGestureRecognizer(target: self, action: #selector(switchDriveButtonPressed(_:)))
+            cell.switchDriveStackView.addGestureRecognizer(tap)
             cell.switchDriveButton.addTarget(self, action: #selector(switchDriveButtonPressed(_:)), for: .touchUpInside)
             return cell
         } else if section == .uploads {

--- a/kDrive/UI/View/Menu/MenuTopTableViewCell.swift
+++ b/kDrive/UI/View/Menu/MenuTopTableViewCell.swift
@@ -27,6 +27,7 @@ class MenuTopTableViewCell: UITableViewCell {
     @IBOutlet var userAvatarImageView: UIImageView!
     @IBOutlet var userDisplayNameLabel: UILabel!
     @IBOutlet var userEmailLabel: UILabel!
+    @IBOutlet var switchDriveStackView: UIStackView!
     @IBOutlet var driveNameLabel: UILabel!
     @IBOutlet var driveImageView: UIImageView!
     @IBOutlet var switchDriveButton: UIButton!

--- a/kDrive/UI/View/Menu/MenuTopTableViewCell.xib
+++ b/kDrive/UI/View/Menu/MenuTopTableViewCell.xib
@@ -135,6 +135,7 @@
                 <outlet property="progressLabel" destination="Zml-xC-HzQ" id="NRn-TL-Dxj"/>
                 <outlet property="progressView" destination="Acs-ea-JHn" id="ugU-yA-MgW"/>
                 <outlet property="switchDriveButton" destination="Tyc-3X-hkw" id="dBe-RT-Bhv"/>
+                <outlet property="switchDriveStackView" destination="cA4-51-s4a" id="hOB-PT-KD1"/>
                 <outlet property="userAvatarContainerView" destination="e0w-EE-IZ4" id="Alo-Yx-dgW"/>
                 <outlet property="userAvatarImageView" destination="aiy-65-03w" id="ghV-Rz-shH"/>
                 <outlet property="userDisplayNameLabel" destination="Ed8-bN-hQH" id="6Wb-Vo-Z7M"/>


### PR DESCRIPTION
### Switch drive from the MenuViewController

**Before**
Tap only available on the button

**After**
Click anywhere on the stackView (icon, label and button)

<img width="200" alt="Simulator Screenshot - iPhone 15 - 2024-07-25 at 09 55 00" src="https://github.com/user-attachments/assets/adfe55d9-7428-4d6a-8535-596d8171d60a">