### PR TITLE
fix(ColorSelectionFloatingPanelViewController): Base sizing of collectionView on parent panel

### DIFF
--- a/kDrive/UI/Controller/Files/ColorSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/ColorSelectionFloatingPanelViewController.swift
@@ -90,7 +90,7 @@ class ColorSelectionFloatingPanelViewController: UICollectionViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        width = view.frame.width
+        width = Double(floatingPanelController?.view.frame.width ?? 0)
         setUpHeight()
     }
 


### PR DESCRIPTION
Something changed in the sizing mecanism of the lib we are using for panel presentation. This resulted in always getting a 0 width view. 

Width of the content is now calculated directly using the container panel size.