### PR TITLE
fix: Only display in gallery items that can be displayed without refreshing File entity

### DIFF
--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
@@ -156,6 +156,13 @@ final class PhotoListViewController: FileListViewController {
         }
     }
 
+    @objc override func forceRefresh() {
+        Task {
+            driveFileManager.removeLocalFiles(root: DriveFileManager.lastPicturesRootFile)
+            super.forceRefresh()
+        }
+    }
+
     override static func instantiate(viewModel: FileListViewModel) -> Self {
         let viewController = Storyboard.menu
             .instantiateViewController(withIdentifier: "PhotoListViewController") as! PhotoListViewController

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
@@ -74,6 +74,7 @@ class PhotoListViewModel: FileListViewModel {
 
         let fetchedFiles = driveFileManager.database.fetchResults(ofType: File.self) { lazyCollection in
             lazyCollection
+                .filter("ANY parentLink.id == %@", DriveFileManager.lastPicturesRootFile.id)
                 .filter("extensionType IN %@", [ConvertedType.image.rawValue, ConvertedType.video.rawValue])
                 .filter("ANY supportedBy CONTAINS %@", FileSupportedBy.thumbnail.rawValue)
                 .sorted(by: [SortType.newer.value.sortDescriptor])

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
@@ -73,7 +73,9 @@ class PhotoListViewModel: FileListViewModel {
                    currentDirectory: DriveFileManager.lastPicturesRootFile)
 
         let fetchedFiles = driveFileManager.database.fetchResults(ofType: File.self) { lazyCollection in
-            lazyCollection.filter("extensionType IN %@", [ConvertedType.image.rawValue, ConvertedType.video.rawValue])
+            lazyCollection
+                .filter("extensionType IN %@", [ConvertedType.image.rawValue, ConvertedType.video.rawValue])
+                .filter("ANY supportedBy CONTAINS %@", FileSupportedBy.thumbnail.rawValue)
                 .sorted(by: [SortType.newer.value.sortDescriptor])
         }
 

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewModel.swift
@@ -53,7 +53,10 @@ class PhotoListViewModel: FileListViewModel {
     private static let emptySections = [Section(model: Group(referenceDate: Date(), sortMode: .day), elements: [])]
 
     var sections = emptySections
-    private var moreComing = false
+    private var moreComing: Bool {
+        nextCursor != nil
+    }
+
     private var nextCursor: String?
     private var sortMode: PhotoSortMode = UserDefaults.shared.photoSortMode {
         didSet { sortingChanged() }

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -513,7 +513,9 @@ public final class DriveFileManager {
                 return
             }
 
-            lastPicturesRootInContext.children.removeAll()
+            for child in lastPicturesRootInContext.children {
+                removeFileInDatabase(fileUid: child.uid, cascade: false, writableRealm: writableRealm)
+            }
             writableRealm.add(lastPicturesRootInContext, update: .modified)
         }
     }

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -503,6 +503,21 @@ public final class DriveFileManager {
         }
     }
 
+    /// Remove all children of to a root File with a transaction
+    public func removeLocalFiles(root: File) {
+        try? database.writeTransaction { writableRealm in
+            guard let lastPicturesRootInContext = writableRealm
+                .objects(File.self)
+                .filter("id == %@", DriveFileManager.lastPicturesRootFile.id)
+                .first else {
+                return
+            }
+
+            lastPicturesRootInContext.children.removeAll()
+            writableRealm.add(lastPicturesRootInContext, update: .modified)
+        }
+    }
+
     public func lastModifiedFiles(cursor: String? = nil) async throws -> (files: [File], nextCursor: String?) {
         do {
             let lastModifiedFilesResponse = try await apiFetcher.lastModifiedFiles(drive: drive, cursor: cursor)


### PR DESCRIPTION
~~I could also batch refresh all `File`s on a pull to refresh, but a lot of work for limited impact.~~
Did the pull to refresh thing.