### PR TITLE
fix(LaunchPanelsController): No restoration if in data is invalid

### DIFF
--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -610,6 +610,11 @@ public struct AppRouter: AppNavigable {
         navigationController: UINavigationController,
         animated: Bool
     ) {
+        guard index <= frozenFiles.count else {
+            Log.sceneDelegate("unable to presentPreviewViewController, invalid data", level: .error)
+            return
+        }
+
         let previewViewController = PreviewViewController.instantiate(files: frozenFiles,
                                                                       index: index,
                                                                       driveFileManager: driveFileManager,

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -584,11 +584,17 @@ class PreviewViewController: UIViewController, PreviewContentCellDelegate, Scene
     // MARK: - State restoration
 
     var currentSceneMetadata: [AnyHashable: Any] {
-        [
+        let allFilesIds = previewFiles.map(\.id)
+        let currentIndexRow = currentIndex.row
+        guard currentIndexRow <= allFilesIds.count else {
+            return [:]
+        }
+
+        return [
             SceneRestorationKeys.lastViewController.rawValue: SceneRestorationScreens.PreviewViewController.rawValue,
             SceneRestorationValues.driveId.rawValue: driveFileManager.drive.id,
-            SceneRestorationValues.Carousel.filesIds.rawValue: previewFiles.map(\.id),
-            SceneRestorationValues.Carousel.currentIndex.rawValue: currentIndex.row,
+            SceneRestorationValues.Carousel.filesIds.rawValue: allFilesIds,
+            SceneRestorationValues.Carousel.currentIndex.rawValue: currentIndexRow,
             SceneRestorationValues.Carousel.normalFolderHierarchy.rawValue: normalFolderHierarchy,
             SceneRestorationValues.Carousel.fromActivities.rawValue: fromActivities
         ]


### PR DESCRIPTION
Make sure it does not try to restore or save its state if data is invalid.

In some conditions, incorrect restoration data could be stored, resulting in a crash.