### PR TITLE
fix: ManageCategoriesViewController now uses frozen files to prevent a crash

### DIFF
--- a/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
+++ b/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
@@ -189,17 +189,21 @@ final class ManageCategoriesViewController: UITableViewController {
         for file in files {
             driveFileManager.observeFileUpdated(self, fileId: file.id) { newFile in
                 Task { @MainActor [weak self] in
+                    guard let self = self else {
+                        return
+                    }
+
                     guard !newFile.isInvalidated else {
-                        if self?.presentingViewController != nil && viewControllersCount < 2 {
-                            self?.closeButtonPressed()
+                        if self.presentingViewController != nil && viewControllersCount < 2 {
+                            self.closeButtonPressed()
                         } else {
-                            self?.navigationController?.popViewController(animated: true)
+                            self.navigationController?.popViewController(animated: true)
                         }
                         return
                     }
                     // Update list of files with new file
-                    self?.files?.removeAll { $0.id == file.id }
-                    self?.files?.append(newFile)
+                    self.files?.removeAll { $0.id == file.id }
+                    self.files?.append(newFile)
                 }
             }
         }

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -572,7 +572,7 @@ class FileListViewController: UIViewController, UICollectionViewDataSource, Swip
     func onFilePresented(_ file: File) {
         #if !ISEXTENSION
         filePresenter.present(for: file,
-                              files: viewModel.getAllFiles(),
+                              files: viewModel.getAllFrozenFiles(),
                               driveFileManager: viewModel.driveFileManager,
                               normalFolderHierarchy: viewModel.configuration.normalFolderHierarchy,
                               fromActivities: viewModel.configuration.fromActivities)

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -432,7 +432,7 @@ class FileListViewModel: SelectDelegate {
         return file.freezeIfNeeded()
     }
 
-    func getAllFiles() -> [File] {
+    func getAllFrozenFiles() -> [File] {
         return Array(files.freeze())
     }
 

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -234,7 +234,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func manageCategoriesAction() {
         FileActionsHelper.manageCategories(
-            files: [file],
+            frozenFiles: [file.freezeIfNeeded()],
             driveFileManager: driveFileManager,
             from: self,
             presentingParent: presentingViewController

--- a/kDrive/UI/Controller/Files/FileDetailViewController.swift
+++ b/kDrive/UI/Controller/Files/FileDetailViewController.swift
@@ -677,7 +677,7 @@ extension FileDetailViewController: UITableViewDelegate, UITableViewDataSource {
         }
         if currentTab == .informations && fileInformationRows[indexPath.row] == .categories && canManageCategories {
             let manageCategoriesViewController = ManageCategoriesViewController.instantiate(
-                files: [file],
+                frozenFiles: [file.freezeIfNeeded()],
                 driveFileManager: driveFileManager
             )
             navigationController?.pushViewController(manageCategoriesViewController, animated: true)

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController+Actions.swift
@@ -81,7 +81,8 @@ extension MultipleSelectionFloatingPanelViewController {
     }
 
     private func manageCategoriesAction(group: DispatchGroup) {
-        FileActionsHelper.manageCategories(files: files,
+        let frozenFiles = files.map { $0.freezeIfNeeded() }
+        FileActionsHelper.manageCategories(frozenFiles: frozenFiles,
                                            driveFileManager: driveFileManager,
                                            from: self,
                                            group: group,

--- a/kDrive/UI/Controller/Files/RecentActivityFilesViewController.swift
+++ b/kDrive/UI/Controller/Files/RecentActivityFilesViewController.swift
@@ -97,7 +97,7 @@ class RecentActivityFilesViewController: FileListViewController {
         if file.isDirectory {
             let managedFile = driveFileManager.getManagedFile(from: file.detached())
             filePresenter.present(for: managedFile,
-                                  files: viewModel.getAllFiles(),
+                                  files: viewModel.getAllFrozenFiles(),
                                   driveFileManager: viewModel.driveFileManager,
                                   normalFolderHierarchy: viewModel.configuration.normalFolderHierarchy,
                                   fromActivities: viewModel.configuration.fromActivities)

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -417,11 +417,11 @@ public final class FileActionsHelper {
         return areFavored
     }
 
-    public static func manageCategories(files: [File], driveFileManager: DriveFileManager, from viewController: UIViewController,
+    public static func manageCategories(frozenFiles: [File], driveFileManager: DriveFileManager, from viewController: UIViewController,
                                         group: DispatchGroup? = nil, presentingParent: UIViewController?) {
         group?.enter()
         let navigationManageCategoriesViewController = ManageCategoriesViewController.instantiateInNavigationController(
-            files: files,
+            frozenFiles: frozenFiles,
             driveFileManager: driveFileManager
         )
         let manageCategoriesViewController = (navigationManageCategoriesViewController


### PR DESCRIPTION
A realm crash was in ManageCategoriesViewController. This class was tracking some live objects that can get invalidated.
Now it tracks frozen objects. And I made it explicit in the naming of init methods.