### PR TITLE
fix: Prevent two audio player to run at once

### DIFF
--- a/kDrive/UI/View/Files/Preview/AudioCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/AudioCollectionViewCell.swift
@@ -78,11 +78,12 @@ final class AudioCollectionViewCell: PreviewCollectionViewCell {
     }
 
     override func configureWith(file: File) {
-        assert(file.isFrozen, "file should be frozen for safe async work in the player")
+        // file should be safe for async work in the player
+        let frozenFile = file.freezeIfNeeded()
 
         Task {
             setUpPlayButtons()
-            await singleTrackPlayer.setup(with: file)
+            await singleTrackPlayer.setup(with: frozenFile)
             setControls(enabled: true)
             setupObservation()
         }

--- a/kDriveCore/AudioPlayer/MediaPlayerOrchestrator.swift
+++ b/kDriveCore/AudioPlayer/MediaPlayerOrchestrator.swift
@@ -30,7 +30,7 @@ public final class MediaPlayerOrchestrator {
         }
 
         guard let lastUsedPlayer,
-              lastUsedPlayer != playable,
+              !(lastUsedPlayer === playable),
               lastUsedPlayer.playerState == .playing else {
             return
         }

--- a/kDriveCore/AudioPlayer/MediaPlayerOrchestrator.swift
+++ b/kDriveCore/AudioPlayer/MediaPlayerOrchestrator.swift
@@ -1,0 +1,40 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+/// A simple service to orchestrate between all the possibly existing media player objects in the app
+public final class MediaPlayerOrchestrator {
+    private weak var lastUsedPlayer: SingleTrackPlayer?
+
+    public init() {}
+
+    public func newPlaybackStarted(playable: SingleTrackPlayer) {
+        defer {
+            lastUsedPlayer = playable
+        }
+
+        guard let lastUsedPlayer,
+              lastUsedPlayer != playable,
+              lastUsedPlayer.playerState == .playing else {
+            return
+        }
+
+        lastUsedPlayer.pause()
+    }
+}

--- a/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
+++ b/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
@@ -96,8 +96,7 @@ public final class SingleTrackPlayer {
         playableFileName = playableFile.name
 
         if !playableFile.isLocalVersionOlderThanRemote {
-            let url = playableFile.localUrl
-            player = AVPlayer(url: url)
+            player = AVPlayer(url: playableFile.localUrl)
             setUpObservers()
         } else if let token = driveFileManager.apiFetcher.currentToken {
             driveFileManager.apiFetcher.performAuthenticatedRequest(token: token) { token, _ in
@@ -210,13 +209,16 @@ public final class SingleTrackPlayer {
     // MARK: - Observation
 
     private func setUpObservers() {
+        defer {
+            setUpRemoteControlEvents()
+        }
+
         interruptionObserver = NotificationCenter.default.addObserver(forName: AVAudioSession.interruptionNotification,
                                                                       object: AVAudioSession.sharedInstance(),
                                                                       queue: .main) { [weak self] notification in
             self?.handleAudioSessionInterruption(notification: notification)
         }
         startPlaybackObservationIfNeeded()
-        setUpRemoteControlEvents()
 
         guard let player else {
             return
@@ -269,7 +271,7 @@ public final class SingleTrackPlayer {
     }
 
     public func stopPlaybackObservation() {
-        guard let timeObserver = timeObserver else {
+        guard let timeObserver else {
             return
         }
 

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -155,6 +155,9 @@ public enum FactoryService {
             },
             Factory(type: DriveInfosManager.self) { _, _ in
                 DriveInfosManager()
+            },
+            Factory(type: MediaPlayerOrchestrator.self) { _, _ in
+                MediaPlayerOrchestrator()
             }
         ]
         return services


### PR DESCRIPTION
#### Fix:

https://github.com/Infomaniak/ios-kDrive/issues/1011

#### How to test:

comment `singleTrackPlayer.pause()` in `didEndDisplaying()`
