### PR TITLE
fix: Close button works in share extension in SaveFileViewController

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
@@ -299,6 +299,9 @@ class SaveFileViewController: UIViewController {
     @IBAction func close(_ sender: Any) {
         importProgress?.cancel()
         dismiss(animated: true)
+        if let extensionContext {
+            extensionContext.completeRequest(returningItems: nil, completionHandler: nil)
+        }
     }
 }
 


### PR DESCRIPTION
The action of the button circled in red now works

<img width="392" alt="Screenshot 2024-08-22 at 14 18 21" src="https://github.com/user-attachments/assets/cd6f691a-42c8-431e-97f4-f7a6ae5485c3">
