### PR TITLE
feat: Add RequestContextIdAdaptor to ApiFetcher

### DIFF
--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -30,7 +30,7 @@ public extension ApiFetcher {
         self.init()
         createAuthenticatedSession(token,
                                    authenticator: SyncedAuthenticator(refreshTokenDelegate: delegate),
-                                   additionalAdapters: [UserAgentAdapter()])
+                                   additionalAdapters: [RequestContextIdAdaptor(), UserAgentAdapter()])
     }
 }
 


### PR DESCRIPTION
Already added since a long time on Mail. I think we forgot to add it on Drive.