### PR TITLE
fix: Pass correct activities for FileDetailsView

### DIFF
--- a/kDriveCore/Data/Api/DriveApiFetcher.swift
+++ b/kDriveCore/Data/Api/DriveApiFetcher.swift
@@ -317,7 +317,7 @@ public class DriveApiFetcher: ApiFetcher {
             URLQueryItem(name: "depth", value: "children"),
             URLQueryItem(name: "from_date", value: "\(Int(date.timeIntervalSince1970))")
         ]
-        queryItems.append(contentsOf: FileActivityType.fileActivities.map { URLQueryItem(name: "actions[]", value: $0.rawValue) })
+        queryItems.append(contentsOf: FileActivityType.displayedFileActivities.map { URLQueryItem(name: "actions[]", value: $0.rawValue) })
         let endpoint = Endpoint.fileActivities(file: file)
             .appending(path: "", queryItems: queryItems)
             .cursored(cursor)

--- a/kDriveCore/Data/Models/FileActivity.swift
+++ b/kDriveCore/Data/Models/FileActivity.swift
@@ -61,14 +61,15 @@ public enum FileActivityType: String, Codable, CaseIterable {
     case fileColorUpdate = "file_color_update"
     case fileColorDelete = "file_color_delete"
 
-    public static let fileActivities: [FileActivityType] = [
+    public static let displayedFileActivities: [FileActivityType] = [
         .fileCreate,
         .fileRename,
         .fileMoveIn,
         .fileMoveOut,
         .fileTrash,
-        .fileTrashInherited,
+        // .fileTrashInherited, FIXME: waiting for API fix
         .fileRestore,
+        // .fileRestoreInherited, FIXME: waiting for API fix
         .fileDelete,
         .fileUpdate,
         .fileCategorize,
@@ -88,8 +89,6 @@ public enum FileActivityType: String, Codable, CaseIterable {
         .fileColorUpdate,
         .fileColorDelete
     ]
-
-    public static let displayedFileActivities: [FileActivityType] = FileActivityType.allCases
 }
 
 public class FileActivity: Object, Decodable {


### PR DESCRIPTION
This PR addresses two issues in the FileActivityDetails:
- We only want to display a subset of the activities in the file details view. 
- Some of the activities we asked for were also invalid.
