### PR TITLE
fix(MultiSelectActions): A selection of files (and folders) no longer show a change color option

### DIFF
--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -206,6 +206,10 @@ public class FloatingPanelAction: Equatable {
     }
 
     static var multipleSelectionActions: [FloatingPanelAction] {
+        return [manageCategories, favorite, offline, download, move, duplicate].map { $0.reset() }
+    }
+
+    static var multipleSelectionActionsOnlyFolders: [FloatingPanelAction] {
         return [manageCategories, favorite, folderColor, offline, download, move, duplicate].map { $0.reset() }
     }
 

--- a/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/MultipleSelectionFloatingPanelViewController.swift
@@ -73,7 +73,11 @@ final class MultipleSelectionFloatingPanelViewController: UICollectionViewContro
                 actions.removeAll { $0 == .download }
             }
         } else {
-            actions = FloatingPanelAction.multipleSelectionActions
+            if files.contains { !$0.isDirectory } {
+                actions = FloatingPanelAction.multipleSelectionActions
+            } else {
+                actions = FloatingPanelAction.multipleSelectionActionsOnlyFolders
+            }
         }
     }
 


### PR DESCRIPTION
Change folder color action is only availlable if _only_ folders are selected.