### PR TITLE
fix(OrphanFiles): Added a sentry

### DIFF
--- a/kDrive/UI/Controller/Files/Upload/UploadQueueFoldersViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueFoldersViewController.swift
@@ -108,7 +108,8 @@ final class UploadQueueFoldersViewController: UITableViewController {
             let driveId = tuple.driveId
 
             guard let driveFileManager = accountManager.getDriveFileManager(for: driveId, userId: userId) else {
-                Log.fileList("Unable to fetch a linked driveFileManager for driveId:\(driveId) userId:\(userId)", level: .error)
+                let metadata = ["parentId": "\(parentId)", "driveId": "\(driveId)", "userId": "\(userId)"]
+                Log.fileList("Unable to fetch a driveFileManager to display a file", metadata: metadata, level: .error)
                 return nil
             }
 

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -185,7 +185,8 @@ public enum FactoryService {
                 (loggerFactory, "FileProvider"),
                 (loggerFactory, "DriveInfosManager"),
                 (loggerFactory, "SceneDelegate"),
-                (loggerFactory, "SyncedAuthenticator")
+                (loggerFactory, "SyncedAuthenticator"),
+                (loggerFactory, "FileList")
             ]
             return services
         } else {

--- a/kDriveCore/Utils/AbstractLog+Category.swift
+++ b/kDriveCore/Utils/AbstractLog+Category.swift
@@ -217,6 +217,35 @@ public enum Log {
               tag: tag)
     }
 
+    /// shorthand for ABLog, with "FileList" category
+    public static func fileList(_ message: @autoclosure () -> Any,
+                                metadata: [String: String] = [:],
+                                level: AbstractLogLevel = .debug,
+                                context: Int = 0,
+                                file: StaticString = #file,
+                                function: StaticString = #function,
+                                line: UInt = #line,
+                                tag: Any? = nil) {
+        let category = "FileList"
+        let messageString = "\(message())"
+        var metadata = metadata
+        metadata["message"] = messageString
+
+        if level == .error {
+            // Add a breadcrumb only for .errors only
+            SentryDebug.loggerBreadcrumb(caller: "\(function)", metadata: metadata)
+        }
+
+        ABLog(messageString,
+              category: category,
+              level: level,
+              context: context,
+              file: file,
+              function: function,
+              line: line,
+              tag: tag)
+    }
+
     /// Shorthand for ABLog, with "DriveInfosManager" category.
     ///
     /// Sentry tracking enabled when level == .error


### PR DESCRIPTION
This PR only adds some logs if a rare orphan  `uploadFile` exists.
Will be done in a further PR: Remove orphan files in the background, as the root folder no longer exists.