### PR TITLE
fix(FileListViewController): Prevent realm crash in FileList

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -619,11 +619,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         }
 
         let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath) as! FileCollectionViewCell
-
         let file = displayedFiles[indexPath.row]
-        guard !file.isInvalidated else {
-            return cell
-        }
 
         cell.initStyle(isFirst: file.isFirstInList, isLast: file.isLastInList)
         cell.configureWith(

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -619,7 +619,11 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         }
 
         let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath) as! FileCollectionViewCell
+
         let file = displayedFiles[indexPath.row]
+        guard !file.isInvalidated else {
+            return cell
+        }
 
         cell.initStyle(isFirst: file.isFirstInList, isLast: file.isLastInList)
         cell.configureWith(

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -73,7 +73,10 @@ public final class DriveFileManager {
     }
 
     public let realmConfiguration: Realm.Configuration
+
+    // TODO: Fetch a drive with a computed property instead of tracking a Realm object
     public private(set) var drive: Drive
+
     public let apiFetcher: DriveApiFetcher
 
     private var didUpdateFileObservers = [UUID: (File) -> Void]()

--- a/kDriveCore/Data/Models/Drive/Drive.swift
+++ b/kDriveCore/Data/Models/Drive/Drive.swift
@@ -179,6 +179,10 @@ public final class Drive: Object, Codable {
     }
 
     public func categories(for file: File) -> [Category] {
+        guard !isInvalidated else {
+            return []
+        }
+
         let fileCategoriesIds: [Int]
         if file.isManagedByRealm {
             fileCategoriesIds = Array(file.categories.sorted(by: \.addedAt, ascending: true)).map(\.categoryId)


### PR DESCRIPTION
[edited] In some rare occurrence, the Drive object is invalidated and the `categories(for:` function breaks.
This is a workaround for that.