### PR TITLE
fix(DriveFileManager): In some specific case realm crash 

### DIFF
--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+Listing.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+Listing.swift
@@ -61,6 +61,11 @@ public extension DriveFileManager {
                 writableRealm: writableRealm
             )
 
+            // post `handleActions` managedParent may be invalidated in current context
+            guard !managedParent.isInvalidated else {
+                return
+            }
+
             managedParent.lastCursor = nextCursor
             managedParent.versionCode = DriveFileManager.constants.currentVersionCode
             managedParent.fullyDownloaded = !hasMore


### PR DESCRIPTION
Try to modify a deleted realm object within the same transaction was crashing in some specific case.