### PR TITLE
fix(DirectoryEnumerator): Fetch object by UID with an actual UID

### DIFF
--- a/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
+++ b/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
@@ -201,7 +201,7 @@ final class DirectoryEnumerator: NSObject, NSFileProviderEnumerator {
                     }
 
                     for deletedChild in deletedFiles {
-                        guard let existingDeletedFile: File = writableRealm.getObject(id: deletedChild.id) else {
+                        guard let existingDeletedFile: File = writableRealm.getObject(id: deletedChild.uid) else {
                             continue
                         }
 


### PR DESCRIPTION
Fetch was done with an ID of type Int where an UID of type String was expected as the primary key.