### PR TITLE
fix: Allow null activity type offline

### DIFF
--- a/kDriveCore/Data/Models/PartialListingResult.swift
+++ b/kDriveCore/Data/Models/PartialListingResult.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 @frozen public struct PartialFileActivity: Codable {
-    let lastAction: FileActivityType
+    let lastAction: FileActivityType?
     let fileId: Int
     let lastActionAt: Int?
     let file: File?


### PR DESCRIPTION
`lastAction` could be null if older than X months