### PR TITLE
refactor: Resolve common warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules:
  - force_cast
  - cyclomatic_complexity
  - closure_parameter_position
+ - non_optional_string_data_conversion
 opt_in_rules:
  - strong_iboutlet
  - closure_end_indentation

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -8,7 +8,7 @@ import ProjectDescriptionHelpers
 let packageSettings = PackageSettings(
     productTypes: [
         "RealmSwift": .staticLibrary,
-        "Realm": .staticLibrary,
+        "Realm": .staticLibrary
     ]
 )
 
@@ -42,6 +42,6 @@ let package = Package(
         .package(url: "https://github.com/Cocoanetics/Kvitto", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/raspu/Highlightr", .upToNextMajor(from: "2.1.0")),
         .package(url: "https://github.com/bmoliveira/MarkdownKit", .upToNextMajor(from: "1.7.0")),
-        .package(url: "https://github.com/matomo-org/matomo-sdk-ios", .upToNextMajor(from: "7.5.1")),
+        .package(url: "https://github.com/matomo-org/matomo-sdk-ios", .upToNextMajor(from: "7.5.1"))
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/ExtensionTarget.swift
+++ b/Tuist/ProjectDescriptionHelpers/ExtensionTarget.swift
@@ -108,7 +108,7 @@ public extension Target {
                            .external(name: "FloatingPanel"),
                            .external(name: "Lottie"),
                            .external(name: "DropDown"),
-                           .external(name: "HorizonCalendar"),
+                           .external(name: "HorizonCalendar")
                        ],
                        settings: settings)
     }

--- a/kDrive/UI/Controller/DriveUpdateRequiredViewController.swift
+++ b/kDrive/UI/Controller/DriveUpdateRequiredViewController.swift
@@ -67,6 +67,7 @@ class DriveUpdateRequiredViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 

--- a/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
+++ b/kDrive/UI/Controller/Files/Categories/ManageCategoriesViewController.swift
@@ -348,10 +348,9 @@ final class ManageCategoriesViewController: UITableViewController {
 extension ManageCategoriesViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         if let searchText {
-            filteredCategories = categories.filter { $0.localizedName.range(
-                of: searchText,
-                options: [.caseInsensitive, .diacriticInsensitive]
-            ) != nil }
+            filteredCategories = categories.filter {
+                $0.localizedName.range(of: searchText, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+            }
             // Append dummy category to show creation cell if the category doesn't exist yet
             if userCanCreateAndEditCategories && !categories
                 .contains(where: { $0.localizedName.caseInsensitiveCompare(searchText) == .orderedSame }) {

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -381,7 +381,7 @@ extension FileActionsFloatingPanelViewController {
         alert.textFieldConfiguration = .fileNameConfiguration
         if !file.isDirectory {
             alert.textFieldConfiguration.selectedRange = fileName
-                .startIndex ..< (fileName.lastIndex(where: { $0 == "." }) ?? fileName.endIndex)
+                .startIndex ..< (fileName.lastIndex { $0 == "." } ?? fileName.endIndex)
         }
         present(alert, animated: true)
     }
@@ -407,7 +407,7 @@ extension FileActionsFloatingPanelViewController {
         alert.textFieldConfiguration = .fileNameConfiguration
         if !file.isDirectory {
             alert.textFieldConfiguration.selectedRange = file.name
-                .startIndex ..< (file.name.lastIndex(where: { $0 == "." }) ?? file.name.endIndex)
+                .startIndex ..< (file.name.lastIndex { $0 == "." } ?? file.name.endIndex)
         }
         present(alert, animated: true)
     }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -258,7 +258,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         case header, quickActions, actions
     }
 
-    class var sections: [Section] {
+    static var sections: [Section] {
         return Section.allCases
     }
 

--- a/kDrive/UI/Controller/Files/FilePresenter.swift
+++ b/kDrive/UI/Controller/Files/FilePresenter.swift
@@ -36,7 +36,7 @@ final class FilePresenter {
         self.viewController = viewController
     }
 
-    class func presentParent(of file: File, driveFileManager: DriveFileManager, viewController: UIViewController) {
+    static func presentParent(of file: File, driveFileManager: DriveFileManager, viewController: UIViewController) {
         guard let rootViewController = viewController.view.window?.rootViewController as? MainTabViewController else {
             return
         }

--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -33,7 +33,7 @@ final class OnlyOfficeViewController: UIViewController {
 
     private var progressObserver: NSKeyValueObservation?
 
-    class func open(driveFileManager: DriveFileManager, file: File, viewController: UIViewController) {
+    static func open(driveFileManager: DriveFileManager, file: File, viewController: UIViewController) {
         guard file.isOfficeFile else { return }
 
         if let newExtension = file.conversion?.onylofficeExtension {
@@ -88,7 +88,7 @@ final class OnlyOfficeViewController: UIViewController {
         }
     }
 
-    class func instantiate(driveFileManager: DriveFileManager, file: File,
+    static func instantiate(driveFileManager: DriveFileManager, file: File,
                            previewParent: PreviewViewController?) -> OnlyOfficeViewController {
         let onlyOfficeViewController = OnlyOfficeViewController()
         onlyOfficeViewController.driveFileManager = driveFileManager

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -624,7 +624,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
             SceneRestorationValues.Carousel.filesIds.rawValue: allFilesIds,
             SceneRestorationValues.Carousel.currentIndex.rawValue: currentIndexRow,
             SceneRestorationValues.Carousel.normalFolderHierarchy.rawValue: normalFolderHierarchy,
-            SceneRestorationValues.Carousel.presentationOrigin.rawValue: presentationOrigin.rawValue,
+            SceneRestorationValues.Carousel.presentationOrigin.rawValue: presentationOrigin.rawValue
         ]
     }
 }

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -590,7 +590,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
         )
     }
 
-    class func instantiate(
+    static func instantiate(
         files: [File],
         index: Int,
         driveFileManager: DriveFileManager,

--- a/kDrive/UI/Controller/Files/RecentActivityFilesViewController.swift
+++ b/kDrive/UI/Controller/Files/RecentActivityFilesViewController.swift
@@ -67,6 +67,7 @@ class RecentActivityFilesViewController: FileListViewController {
 
         if let user = activity.user {
             var text = user.displayName + " "
+            // swiftlint:disable void_function_in_ternary
             switch activity.action {
             case .fileCreate:
                 text += isDirectory ? KDriveResourcesStrings.Localizable.fileActivityFolderCreate(count) : KDriveResourcesStrings
@@ -84,6 +85,7 @@ class RecentActivityFilesViewController: FileListViewController {
             default:
                 text += KDriveResourcesStrings.Localizable.fileActivityUnknown(count)
             }
+            // swiftlint:enable void_function_in_ternary
 
             headerView.activityLabel.text = text
 

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController.swift
@@ -429,7 +429,7 @@ extension SaveFileViewController: UITableViewDelegate {
                 }
                 alert.textFieldConfiguration = .fileNameConfiguration
                 alert.textFieldConfiguration.selectedRange = item.name
-                    .startIndex ..< (item.name.lastIndex(where: { $0 == "." }) ?? item.name.endIndex)
+                    .startIndex ..< (item.name.lastIndex { $0 == "." } ?? item.name.endIndex)
                 present(alert, animated: true)
             }
         case .driveSelection:

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -120,7 +120,7 @@ final class UploadQueueViewController: UIViewController {
                                        driveId: currentDirectory.driveId)
     }
 
-    class func instantiate() -> UploadQueueViewController {
+    static func instantiate() -> UploadQueueViewController {
         return Storyboard.files
             .instantiateViewController(withIdentifier: "UploadQueueViewController") as! UploadQueueViewController
     }

--- a/kDrive/UI/Controller/Home/HomeViewController.swift
+++ b/kDrive/UI/Controller/Home/HomeViewController.swift
@@ -276,7 +276,7 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
         configuration.boundarySupplementaryItems = [HomeViewController.generateHeaderItem()]
 
-        let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] section, layoutEnvironment in
+        let layout = UICollectionViewCompositionalLayout(sectionProvider: { [weak self] section, _ in
             guard let self else { return nil }
             switch HomeSection.allCases[section] {
             case .top:

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
@@ -199,7 +199,7 @@ final class PhotoListViewController: FileListViewController {
             super.forceRefresh()
         }
     }
-    
+
     override func onFilePresented(_ file: File) {
         #if !ISEXTENSION
         filePresenter.present(for: file,
@@ -209,7 +209,7 @@ final class PhotoListViewController: FileListViewController {
                               presentationOrigin: viewModel.configuration.presentationOrigin)
         #endif
     }
-    
+
     // MARK: - Multiple selection
 
     override func toggleMultipleSelection(_ on: Bool) {

--- a/kDrive/UI/Controller/PreloadingViewController.swift
+++ b/kDrive/UI/Controller/PreloadingViewController.swift
@@ -79,7 +79,7 @@ class PreloadingViewController: UIViewController {
         view.addSubview(progressView)
         NSLayoutConstraint.activate([
             progressView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            progressView.topAnchor.constraint(equalTo: driveImageView.bottomAnchor, constant: 16),
+            progressView.topAnchor.constraint(equalTo: driveImageView.bottomAnchor, constant: 16)
         ])
 
         view.addSubview(splashscreenInfomaniakImageView)

--- a/kDrive/UI/Controller/PreloadingViewController.swift
+++ b/kDrive/UI/Controller/PreloadingViewController.swift
@@ -93,7 +93,7 @@ class PreloadingViewController: UIViewController {
     func preloadAccountAndDrives() {
         Task {
             do {
-                let _ = try await accountManager.updateUser(for: currentAccount, registerToken: true)
+                _ = try await accountManager.updateUser(for: currentAccount, registerToken: true)
                 _ = try accountManager.getFirstAvailableDriveFileManager(for: currentAccount.userId)
 
                 if let currentDriveFileManager = self.accountManager.currentDriveFileManager {

--- a/kDrive/UI/Controller/Scan/SaveScanViewController.swift
+++ b/kDrive/UI/Controller/Scan/SaveScanViewController.swift
@@ -98,7 +98,7 @@ final class SaveScanViewController: SaveFileViewController {
         }
     }
 
-    override class func instantiate(driveFileManager: DriveFileManager?) -> SaveScanViewController {
+    override static func instantiate(driveFileManager: DriveFileManager?) -> SaveScanViewController {
         let viewController = Storyboard.scan
             .instantiateViewController(withIdentifier: "SaveScanViewController") as! SaveScanViewController
         viewController.selectedDriveFileManager = driveFileManager

--- a/kDrive/UI/View/Files/FileDetail/FileDetailActivitySeparatorTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/FileDetailActivitySeparatorTableViewCell.swift
@@ -25,17 +25,6 @@ class FileDetailActivitySeparatorTableViewCell: UITableViewCell {
     @IBOutlet var dateLabel: UILabel!
     @IBOutlet var bottomSeparator: UIView!
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
     override func prepareForReuse() {
         super.prepareForReuse()
         topSeparator.isHidden = false

--- a/kDrive/UI/View/Files/FileDetail/FileInformation/FileInformationCreationTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/FileInformation/FileInformationCreationTableViewCell.swift
@@ -21,8 +21,4 @@ import UIKit
 class FileInformationCreationTableViewCell: UITableViewCell {
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var creationLabel: UILabel!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
 }

--- a/kDrive/UI/View/Files/FileDetail/FileInformation/FileInformationSizeTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/FileInformation/FileInformationSizeTableViewCell.swift
@@ -21,8 +21,4 @@ import UIKit
 class FileInformationSizeTableViewCell: UITableViewCell {
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var sizeLabel: UILabel!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
 }

--- a/kDrive/UI/View/Files/FileDetail/InfoTableViewCell.swift
+++ b/kDrive/UI/View/Files/FileDetail/InfoTableViewCell.swift
@@ -21,10 +21,6 @@ import UIKit
 class InfoTableViewCell: UITableViewCell {
     var actionHandler: ((UIButton) -> Void)?
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
-
     @IBAction func buttonPressed(_ sender: UIButton) {
         actionHandler?(sender)
     }

--- a/kDrive/UI/View/Files/SaveFile/DriveSwitchTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/DriveSwitchTableViewCell.swift
@@ -28,9 +28,9 @@ class DriveSwitchTableViewCell: InsetTableViewCell {
         static let switchDrive = Style(height: 72)
     }
 
-    @IBOutlet weak var heightConstraint: NSLayoutConstraint!
-    @IBOutlet weak var driveImageView: UIImageView!
-    @IBOutlet weak var selectDriveImageView: UIImageView!
+    @IBOutlet var heightConstraint: NSLayoutConstraint!
+    @IBOutlet var driveImageView: UIImageView!
+    @IBOutlet var selectDriveImageView: UIImageView!
     var style: Style = .home {
         didSet {
             heightConstraint.constant = style.height

--- a/kDrive/UI/View/Files/SaveFile/FileNameTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/FileNameTableViewCell.swift
@@ -53,8 +53,7 @@ class FileNameTableViewCell: UITableViewCell, UITextFieldDelegate {
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
         guard let fileName = textField.text else { return }
-        textFieldConfiguration.selectedRange = fileName
-            .startIndex ..< (fileName.lastIndex(where: { $0 == "." }) ?? fileName.endIndex)
+        textFieldConfiguration.selectedRange = fileName.startIndex ..< (fileName.lastIndex { $0 == "." } ?? fileName.endIndex)
         textFieldConfiguration.selectText(in: textField)
     }
 

--- a/kDrive/UI/View/Files/SaveFile/FileNameTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/FileNameTableViewCell.swift
@@ -22,7 +22,7 @@ import MaterialOutlinedTextField
 import UIKit
 
 class FileNameTableViewCell: UITableViewCell, UITextFieldDelegate {
-    @IBOutlet weak var textField: MaterialOutlinedTextField!
+    @IBOutlet var textField: MaterialOutlinedTextField!
     var textDidChange: ((String?) -> Void)?
     var textDidEndEditing: ((String?) -> Void)?
 

--- a/kDrive/UI/View/Files/SaveFile/ImportingTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/ImportingTableViewCell.swift
@@ -19,5 +19,5 @@
 import UIKit
 
 class ImportingTableViewCell: UITableViewCell {
-    @IBOutlet weak var importationProgressView: UIProgressView!
+    @IBOutlet var importationProgressView: UIProgressView!
 }

--- a/kDrive/UI/View/Files/SaveFile/LocationTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/LocationTableViewCell.swift
@@ -22,7 +22,7 @@ import kDriveResources
 import UIKit
 
 class LocationTableViewCell: InsetTableViewCell {
-    @IBOutlet weak var logoImage: UIImageView!
+    @IBOutlet var logoImage: UIImageView!
 
     func configure(with drive: Drive?) {
         logoImage.image = KDriveResourcesAsset.drive.image

--- a/kDrive/UI/View/Files/SaveFile/ScanTypeTableViewCell.swift
+++ b/kDrive/UI/View/Files/SaveFile/ScanTypeTableViewCell.swift
@@ -22,7 +22,7 @@ import UIKit
 import VisionKit
 
 class ScanTypeTableViewCell: UITableViewCell {
-    @IBOutlet weak var segmentedControl: IKSegmentedControl!
+    @IBOutlet var segmentedControl: IKSegmentedControl!
 
     var didSelectIndex: ((Int) -> Void)?
 

--- a/kDrive/UI/View/Files/Search/BasicTitleCollectionReusableView.swift
+++ b/kDrive/UI/View/Files/Search/BasicTitleCollectionReusableView.swift
@@ -19,5 +19,5 @@
 import UIKit
 
 class BasicTitleCollectionReusableView: UICollectionReusableView {
-    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet var titleLabel: UILabel!
 }

--- a/kDrive/UI/View/Files/Search/RecentSearchCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Search/RecentSearchCollectionViewCell.swift
@@ -21,9 +21,9 @@ import kDriveCore
 import UIKit
 
 class RecentSearchCollectionViewCell: UICollectionViewCell {
-    @IBOutlet weak var contentInsetView: UIView!
-    @IBOutlet weak var highlightedView: UIView!
-    @IBOutlet weak var recentSearchTitle: IKLabel!
+    @IBOutlet var contentInsetView: UIView!
+    @IBOutlet var highlightedView: UIView!
+    @IBOutlet var recentSearchTitle: IKLabel!
     var removeButtonHandler: ((UIButton) -> Void)?
 
     override var isHighlighted: Bool {

--- a/kDrive/UI/View/Files/Search/SearchFilterCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Search/SearchFilterCollectionViewCell.swift
@@ -26,9 +26,9 @@ protocol SearchFilterCellDelegate: AnyObject {
 }
 
 class SearchFilterCollectionViewCell: UICollectionViewCell {
-    @IBOutlet weak var iconImageView: UIImageView!
-    @IBOutlet weak var titleLabel: IKLabel!
-    @IBOutlet weak var removeButton: UIButton!
+    @IBOutlet var iconImageView: UIImageView!
+    @IBOutlet var titleLabel: IKLabel!
+    @IBOutlet var removeButton: UIButton!
 
     weak var delegate: SearchFilterCellDelegate?
 

--- a/kDrive/UI/View/Generic/SelectionTableViewCell.swift
+++ b/kDrive/UI/View/Generic/SelectionTableViewCell.swift
@@ -23,14 +23,6 @@ import UIKit
 class SelectionTableViewCell: InsetTableViewCell {
     @IBOutlet var label: UILabel!
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-    }
-
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 

--- a/kDrive/UI/View/Menu/DriveTitleTableViewCell.swift
+++ b/kDrive/UI/View/Menu/DriveTitleTableViewCell.swift
@@ -19,15 +19,4 @@
 import InfomaniakCoreUI
 import UIKit
 
-class DriveTitleTableViewCell: InsetTableViewCell {
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-}
+class DriveTitleTableViewCell: InsetTableViewCell {}

--- a/kDrive/UI/View/Menu/Parameters/AboutDetailTableViewCell.swift
+++ b/kDrive/UI/View/Menu/Parameters/AboutDetailTableViewCell.swift
@@ -21,9 +21,4 @@ import UIKit
 
 class AboutDetailTableViewCell: InsetTableViewCell {
     @IBOutlet var detailLabel: UILabel!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
 }

--- a/kDrive/UI/View/Menu/Parameters/ParameterAboutTableViewCell.swift
+++ b/kDrive/UI/View/Menu/Parameters/ParameterAboutTableViewCell.swift
@@ -19,9 +19,4 @@
 import InfomaniakCoreUI
 import UIKit
 
-class ParameterAboutTableViewCell: InsetTableViewCell {
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-}
+class ParameterAboutTableViewCell: InsetTableViewCell {}

--- a/kDrive/UI/View/Menu/SwitchUser/NoAccountTableViewCell.swift
+++ b/kDrive/UI/View/Menu/SwitchUser/NoAccountTableViewCell.swift
@@ -18,15 +18,4 @@
 
 import UIKit
 
-class NoAccountTableViewCell: UITableViewCell {
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-}
+class NoAccountTableViewCell: UITableViewCell {}

--- a/kDrive/UI/View/NewFolder/NewFolderLocationCollectionViewCell.swift
+++ b/kDrive/UI/View/NewFolder/NewFolderLocationCollectionViewCell.swift
@@ -22,9 +22,4 @@ class NewFolderLocationCollectionViewCell: UICollectionViewCell {
     @IBOutlet var accessoryImage: UIImageView!
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var chevronImage: UIImageView!
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
 }

--- a/kDrive/UI/View/NewFolder/NewFolderSettingsTitleTableViewCell.swift
+++ b/kDrive/UI/View/NewFolder/NewFolderSettingsTitleTableViewCell.swift
@@ -19,15 +19,4 @@
 import InfomaniakCoreUI
 import UIKit
 
-class NewFolderSettingsTitleTableViewCell: InsetTableViewCell {
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-}
+class NewFolderSettingsTitleTableViewCell: InsetTableViewCell {}

--- a/kDriveAPITests/kDriveCore/DriveApiTests.swift
+++ b/kDriveAPITests/kDriveCore/DriveApiTests.swift
@@ -37,13 +37,13 @@ final class DriveApiTests: XCTestCase {
     private let proxyDrive = ProxyDrive(id: Env.driveId)
     private let isFreeDrive = false
 
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .realApp)
     }
 
-    override class func tearDown() {
+    override static func tearDown() {
         let group = DispatchGroup()
         group.enter()
         Task {

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManagerConstants.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManagerConstants.swift
@@ -196,7 +196,7 @@ public class DriveFileManagerConstants {
 
         // Migration for APIV3
         if oldSchemaVersion < 20 {
-            migration.enumerateObjects(ofType: UploadFile.className()) { oldObject, newObject in
+            migration.enumerateObjects(ofType: UploadFile.className()) { _, newObject in
                 guard let newObject else {
                     return
                 }

--- a/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
+++ b/kDriveCore/Data/Cache/DriveInfosManager/DriveInfosManager.swift
@@ -113,7 +113,7 @@ public final class DriveInfosManager: DriveInfosManagerQueryable {
         ]
     )
 
-    private class func removeDanglingObjects(ofType type: RLMObjectBase.Type, migration: Migration, ids: Set<String>) {
+    private static func removeDanglingObjects(ofType type: RLMObjectBase.Type, migration: Migration, ids: Set<String>) {
         migration.enumerateObjects(ofType: type.className()) { oldObject, newObject in
             guard let newObject, let objectId = oldObject?["objectId"] as? String else { return }
             if !ids.contains(objectId) {

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Query.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Query.swift
@@ -1,4 +1,3 @@
-//
 /*
  Infomaniak kDrive - iOS App
  Copyright (C) 2023 Infomaniak Network SA

--- a/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
+++ b/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
@@ -158,7 +158,7 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
             PHAssetResourceManager.default().requestData(for: bestResource,
                                                          options: options) { data in
                 hasher.update(data)
-            } completionHandler: { error in
+            } completionHandler: { _ in
                 hasher.finalize()
                 group.leave()
             }

--- a/kDriveCore/Utils/Sentry/ApiToken+Sentry.swift
+++ b/kDriveCore/Utils/Sentry/ApiToken+Sentry.swift
@@ -41,7 +41,7 @@ public extension ApiToken {
             "User id": userId,
             "Expiration date": expirationDate?.timeIntervalSince1970 ?? "infinite",
             "Access Token": truncatedAccessToken,
-            "Refresh Token": truncatedRefreshToken,
+            "Refresh Token": truncatedRefreshToken
         ]
     }
 }

--- a/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
+++ b/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
@@ -212,11 +212,13 @@ final class DirectoryEnumerator: NSObject, NSFileProviderEnumerator {
                     parentDirectory.lastCursor = response.cursor
                 }
 
-                observer.didUpdate(updatedItems.map { $0.toFileProviderItem(
-                    parent: nil,
-                    drive: driveFileManager.drive,
-                    domain: domain
-                ) })
+                observer.didUpdate(updatedItems.map {
+                    $0.toFileProviderItem(
+                        parent: nil,
+                        drive: driveFileManager.drive,
+                        domain: domain
+                    )
+                })
                 observer.didDeleteItems(withIdentifiers: deletedItems)
 
                 guard let newLastCursor = response.cursor,

--- a/kDriveFileProvider/Enumerators/RootEnumerator.swift
+++ b/kDriveFileProvider/Enumerators/RootEnumerator.swift
@@ -94,11 +94,13 @@ class RootEnumerator: NSObject, NSFileProviderEnumerator {
                 let (files, nextCursor) = try await self.fetchRoot(page: page)
                 observer.didEnumerate(files
                     .filter { $0.visibility == .isPrivateSpace || $0.visibility == .isTeamSpace }
-                    .map { $0.toFileProviderItem(
-                        parent: .rootContainer,
-                        drive: driveFileManager.drive,
-                        domain: domain
-                    ) })
+                    .map {
+                        $0.toFileProviderItem(
+                            parent: .rootContainer,
+                            drive: driveFileManager.drive,
+                            domain: domain
+                        )
+                    })
 
                 // there should never be more cursors but still implement next page logic just in case
                 if let nextCursor {
@@ -167,11 +169,13 @@ class RootEnumerator: NSObject, NSFileProviderEnumerator {
                 let deletedIds = childIdsAfterUpdate.subtracting(childIdsBeforeUpdate)
 
                 let updatedFiles = liveParentDirectory.children + [liveParentDirectory]
-                observer.didUpdate(updatedFiles.map { $0.toFileProviderItem(
-                    parent: .rootContainer,
-                    drive: driveFileManager.drive,
-                    domain: domain
-                ) })
+                observer.didUpdate(updatedFiles.map {
+                    $0.toFileProviderItem(
+                        parent: .rootContainer,
+                        drive: driveFileManager.drive,
+                        domain: domain
+                    )
+                })
                 observer.didDeleteItems(withIdentifiers: deletedIds.map { NSFileProviderItemIdentifier($0) })
                 observer.finishEnumeratingChanges(
                     upTo: syncAnchor,

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -401,7 +401,7 @@ final class FileProviderExtension: NSFileProviderExtension {
 
         // Observe queue for upload completion
         var observationToken: ObservationToken?
-        observationToken = uploadQueueObservable.observeFileUploaded(self, fileId: uploadFile.id) { uploadedFile, _ in
+        observationToken = uploadQueueObservable.observeFileUploaded(self, fileId: uploadFile.id) { _, _ in
             observationToken?.cancel()
             observationToken = nil
 

--- a/kDriveFileProvider/NSFileProviderPage+Extension.swift
+++ b/kDriveFileProvider/NSFileProviderPage+Extension.swift
@@ -1,4 +1,3 @@
-//
 /*
  Infomaniak kDrive - iOS App
  Copyright (C) 2023 Infomaniak Network SA

--- a/kDriveFileProvider/NSFileProviderSyncAnchor+Extension.swift
+++ b/kDriveFileProvider/NSFileProviderSyncAnchor+Extension.swift
@@ -1,4 +1,3 @@
-//
 /*
  Infomaniak kDrive - iOS App
  Copyright (C) 2023 Infomaniak Network SA

--- a/kDriveTests/StateRestoration/UTSceneRestorationMetadata.swift
+++ b/kDriveTests/StateRestoration/UTSceneRestorationMetadata.swift
@@ -27,7 +27,7 @@ import XCTest
 final class UTSceneRestorationMetadata: XCTestCase {
     static var driveFileManager: DriveFileManager!
 
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/ITChunkProvider.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/ITChunkProvider.swift
@@ -21,7 +21,7 @@ import XCTest
 
 /// Integration Tests of the ChunkProvider
 final class ITChunkProvider: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/ITRangeProvider.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/ITRangeProvider.swift
@@ -21,7 +21,7 @@ import XCTest
 
 /// Integration Tests of the RangeProvider
 final class ITRangeProvider: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/ITRangeProviderGuts.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/ITRangeProviderGuts.swift
@@ -21,7 +21,7 @@ import XCTest
 
 /// Integration Tests of the RangeProviderGuts
 final class ITRangeProviderGuts: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/UTChunkProvider.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/UTChunkProvider.swift
@@ -22,7 +22,7 @@ import XCTest
 
 /// Unit Tests of the ChunkProvider
 final class UTChunkProvider: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/UTRangeProvider.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/UTRangeProvider.swift
@@ -21,7 +21,7 @@ import XCTest
 
 /// Unit Tests of the RangeProvider
 final class UTRangeProvider: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)

--- a/kDriveTests/kDriveCore/UploadChunks/UTRangeProviderGuts.swift
+++ b/kDriveTests/kDriveCore/UploadChunks/UTRangeProviderGuts.swift
@@ -22,7 +22,7 @@ import XCTest
 
 /// Unit tests of the RangeProviderGuts
 final class UTRangeProviderGuts: XCTestCase {
-    override class func setUp() {
+    override static func setUp() {
         super.setUp()
         MockingHelper.clearRegisteredTypes()
         MockingHelper.registerConcreteTypes(configuration: .minimal)


### PR DESCRIPTION
The following warnings were addressed:
- unused_closure_parameter
- void_function_in_ternary
- unused_closure_parameter
- redundant_discardable_let
- overridden_super_call
- trailing_whitespace
- closure_end_indentation
- trailing_closure
- strong_iboutlet
- trailing_comma
- unneeded_override
- static_over_final_class