### PR TITLE
fix: Prevent NSInternalInconsistencyException when reloading header

### DIFF
--- a/kDrive/UI/Controller/Home/RootMenuHeaderView.swift
+++ b/kDrive/UI/Controller/Home/RootMenuHeaderView.swift
@@ -124,7 +124,7 @@ class RootMenuHeaderView: UICollectionReusableView {
         guard let collectionView else { return }
         UIView.transition(with: collectionView, duration: 0.25, options: .transitionCrossDissolve) {
             let sectionHeaderContext = UICollectionViewLayoutInvalidationContext()
-            sectionHeaderContext.invalidateDecorationElements(
+            sectionHeaderContext.invalidateSupplementaryElements(
                 ofKind: RootMenuHeaderView.kind.rawValue,
                 at: [IndexPath(item: 0, section: 0)]
             )


### PR DESCRIPTION
HomeView was crashing when showing UploadCell on some iOS versions. For some reason, `UICollectionViewLayoutInvalidationContext` is very hard and buggy to use. Switching from `invalidateDecorationElements` to `invalidateSupplementaryElements` seems to work without any side effect.
Fix for sentry short ids:
- KDRIVE-IOS-9Q7
- KDRIVE-IOS-8KX