### PR TITLE
fix: Realm accessed from the wrong thread

### DIFF
--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -215,13 +215,14 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
 
     func observeFileUpdated() {
         driveFileManager?.observeFileUpdated(self, fileId: nil) { [weak self] file in
-            guard let self,
-                  self.currentFile.id == file.id else {
-                return
-            }
-
-            self.currentFile = file
             Task { @MainActor in
+                guard let self,
+                      self.currentFile.id == file.id else {
+                    return
+                }
+
+                self.currentFile = file
+
                 self.collectionView.endEditing(true)
                 self.collectionView.reloadItems(at: [self.currentIndex])
             }


### PR DESCRIPTION
Sentry id KDRIVE-IOS-9PM