### PR TITLE
fix: Do not apply last modified date if not downloaded

### DIFF
--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+Listing.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+Listing.swift
@@ -142,7 +142,6 @@ public extension DriveFileManager {
                 if fileUid != directory.uid {
                     directory.children.insert(actionFile)
                 }
-                actionFile.applyLastModifiedDateToLocalFile()
 
             default:
                 break


### PR DESCRIPTION
Applying the new revised at date without redownloading the file was wrong.
This could lead to issues where the local cache would believe that it had the latest version but in fact had still the old one with new date applied. 