### PR TITLE
fix: Correctly display changes in files header

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -320,10 +320,8 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
 
     private func updateListStyle(_ listStyle: ListStyle) {
         headerView?.listOrGridButton.setImage(listStyle.icon, for: .normal)
-        UIView.transition(with: collectionView, duration: 0.25, options: .transitionCrossDissolve) {
-            self.collectionView.reloadData()
-            self.setSelectedCells()
-        }
+        collectionView.reloadItems(at: collectionView.indexPathsForVisibleItems)
+        setSelectedCells()
     }
 
     private func present(_ viewController: UIViewController, presentationType: ControllerPresentationType, animated: Bool) {

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -259,6 +259,10 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         // We need recompute the size of the header cell right after the batch update so it reflects its state properly.
         // State of the header cell can be updated during a diff update of the collection view.
         collectionView.reloadItems(at: [IndexPath(row: 0, section: 0)])
+
+        if let headerView {
+            setUpHeaderView(headerView, isEmptyViewHidden: viewModel.isShowingEmptyView)
+        }
     }
 
     private func bindUploadCardViewModel() {


### PR DESCRIPTION
This PR resolves two issues with the header:
1. The title didn't update correctly after a sorting change. This is because of the recent PR to fix the empty view before this PR we were relying on the display empty view logic to update the header which wasn't a good idea. We are now updating the title after the file collection changes as before.
2. The grid or list icon button wasn't updating correctly this is probably because of changes in the collectionView layout on iOS 18. I updated the code to do something more in line with the collectionView apis.