### PR TITLE
fix: Cache cleanup fix

### DIFF
--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -24,7 +24,6 @@ import kDriveResources
 import Kingfisher
 import UIKit
 
-
 final class StorageTableViewController: UITableViewController {
     private enum Section: CaseIterable {
         case header, directories, files

--- a/kDrive/UI/Controller/Menu/StorageTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/StorageTableViewController.swift
@@ -24,6 +24,7 @@ import kDriveResources
 import Kingfisher
 import UIKit
 
+
 final class StorageTableViewController: UITableViewController {
     private enum Section: CaseIterable {
         case header, directories, files
@@ -111,13 +112,9 @@ final class StorageTableViewController: UITableViewController {
             self.tableView.reloadData()
         }
 
-        // Check old size calculation and new one, send a sentry.
         Task {
-            let legacySize = cacheDirectories.reduce(0) { $0 + $1.size }
-
             let metadata = [
                 "usedSize": usedSize,
-                "legacySize": legacySize,
                 "appSize": appSize,
                 "appGroupSize": appGroupSize
             ]

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -98,7 +98,7 @@ extension UploadOperation {
 
         // Write buffer
         let chunkName = chunkName(number: number, fileId: uploadFileId, hash: hash)
-        let chunkPath = tempChunkFolder.appendingPathExtension(chunkName)
+        let chunkPath = tempChunkFolder.appendingPathComponent(chunkName)
         try buffer.write(to: chunkPath, options: [.atomic])
         Log.uploadOperation("wrote chunk:\(chunkPath) ufid:\(uploadFileId)")
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -93,7 +93,7 @@ extension UploadOperation {
                     sessionToken: String,
                     hash: String) throws -> URL {
         // Store chunks at the root of NSTemporaryDirectory
-        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+        let tempRoot = FileManager.default.temporaryDirectory
         let chunkName = chunkName(number: number, fileId: uploadFileId, sessionToken: sessionToken, hash: hash)
         let chunkPath = tempRoot.appendingPathComponent(chunkName)
 

--- a/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/UploadQueue/Operation/UploadOperation.swift
@@ -388,13 +388,15 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 assertionFailure("unable to lookup chunk task id, ufid:\(self.uploadFileId)")
             }
 
-            // Some cleanup if we have the chance
+            // Cleanup chunks in storage
             if let path = chunkTask.path {
                 let url = URL(fileURLWithPath: path, isDirectory: false)
                 let chunkNumber = chunkTask.chunkNumber
-                DispatchQueue.global(qos: .background).async {
-                    Log.uploadOperation("cleanup chunk:\(chunkNumber) ufid:\(self.uploadFileId)")
-                    try? self.fileManager.removeItem(at: url)
+                Log.uploadOperation("cleanup chunk:\(chunkNumber) ufid:\(self.uploadFileId)")
+                do {
+                    try self.fileManager.removeItem(at: url)
+                } catch {
+                    Log.uploadOperation("failed to clean chunk \(error) ufid:\(self.uploadFileId)", level: .error)
                 }
             }
         } notFound: {

--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -20,6 +20,7 @@ import Algorithms
 import CocoaLumberjackSwift
 import Foundation
 import InfomaniakCore
+import InfomaniakDI
 import RealmSwift
 
 // MARK: - Publish
@@ -74,6 +75,10 @@ extension UploadQueue: UploadQueueable {
     public func rebuildUploadQueueFromObjectsInRealm(_ caller: StaticString = #function) {
         Log.uploadQueue("rebuildUploadQueueFromObjectsInRealm caller:\(caller)")
         concurrentQueue.sync {
+            // Clean cache if necessary before we try to restart the uploads.
+            @InjectService var freeSpaceService: FreeSpaceService
+            freeSpaceService.cleanCacheIfAlmostFull()
+
             guard let uploadFileQuery else {
                 Log.uploadQueue("\(#function) disabled in \(appContextService.context.rawValue)", level: .error)
                 return

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -185,7 +185,7 @@ public struct FreeSpaceService {
         }
 
         // Only clean if reaching the minimum space required for upload
-        guard freeSpaceInTemporaryDirectory < minimalSpaceRequiredForChunkUpload * 2 else {
+        guard freeSpaceInTemporaryDirectory < minimalSpaceRequiredForChunkUpload * 4 else {
             return
         }
 

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -174,8 +174,10 @@ public struct FreeSpaceService {
         }
     }
 
-    /// On devices with low free space, we clear the temporaryDirectory on exit
-    private func cleanCacheIfAlmostFull() {
+    /// On devices with low free space, we clear the temporaryDirectory
+    /// 
+    /// Safe to call before rebuilding the upload queue
+    public func cleanCacheIfAlmostFull() {
         let freeSpaceInTemporaryDirectory: Int64
         do {
             freeSpaceInTemporaryDirectory = try freeSpace(url: Self.temporaryDirectoryURL)

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -175,7 +175,7 @@ public struct FreeSpaceService {
     }
 
     /// On devices with low free space, we clear the temporaryDirectory
-    /// 
+    ///
     /// Safe to call before rebuilding the upload queue
     public func cleanCacheIfAlmostFull() {
         let freeSpaceInTemporaryDirectory: Int64


### PR DESCRIPTION
- Each chunk is now cleaned right away after a successful upload. In some heavy system load conditions, the clean-up was not performed.
- The clean-up of the cache folder is triggered earlier on
- The cleanup is not only done when the app closes, but now also before we try to rebuild the upload queue