### PR TITLE
fix: Use a native swift sort to prevent a crash in Drive

### DIFF
--- a/kDriveCore/Data/Models/Drive/Drive.swift
+++ b/kDriveCore/Data/Models/Drive/Drive.swift
@@ -183,14 +183,11 @@ public final class Drive: Object, Codable {
             return []
         }
 
-        let fileCategoriesIds: [Int]
-        if file.isManagedByRealm {
-            fileCategoriesIds = Array(file.categories.sorted(by: \.addedAt, ascending: true)).map(\.categoryId)
-        } else {
-            // File is not managed by Realm: cannot use the `.sorted(by:)` method :(
-            fileCategoriesIds = file.categories.sorted { $0.addedAt.compare($1.addedAt) == .orderedAscending }.map(\.categoryId)
-        }
-        let filteredCategories = categories.filter(NSPredicate(format: "id IN %@", fileCategoriesIds))
+        // If File is not managed by Realm: cannot use the `.sorted(by:)` method :(
+        // Also the Realm sort can crash if managed by realm
+        let fileCategoriesIds = file.categories.sorted { $0.addedAt.compare($1.addedAt) == .orderedAscending }.map(\.categoryId)
+        let filteredCategories = categories.filter("id IN %@", fileCategoriesIds)
+
         // Sort the categories
         return fileCategoriesIds.compactMap { id in filteredCategories.first { $0.id == id } }
     }


### PR DESCRIPTION
Fix an appstoreconnect crash.

Substitute a Realm sort for a standard swift sort that existed already in the code.