### PR TITLE
fix: Prevent a realm crash when saving a file

### DIFF
--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -105,6 +105,8 @@ public final class FileActionsHelper {
 
     #if !ISEXTENSION
     public static func save(file: File, from viewController: UIViewController? = nil, showSuccessSnackBar: Bool = true) {
+        guard !file.isInvalidated else { return }
+
         @InjectService var appNavigable: AppNavigable
         let presenterViewController = viewController != nil
             ? viewController


### PR DESCRIPTION
A deeper refactor could be performed to explicit the use of frozen files in `File actions`.
Right now this will prevent a realm crash when using the `save` action.