### PR TITLE
fix: Correctly select elements in gallery

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -265,6 +265,10 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         }
     }
 
+    func getDisplayedFile(at indexPath: IndexPath) -> File? {
+        return displayedFiles[safe: indexPath.item]
+    }
+
     private func bindUploadCardViewModel() {
         viewModel.uploadViewModel?.$uploadCount.receiveOnMain(store: &bindStore) { [weak self] uploadCount in
             self?.updateUploadCard(uploadCount: uploadCount)
@@ -457,7 +461,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
             // Necessary for events to trigger in the right order
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                if let file = displayedFiles[safe: indexPath.item] {
+                if let file = getDisplayedFile(at: indexPath) {
                     multipleSelectionViewModel.didSelectFile(file, at: indexPath)
                 }
             }
@@ -583,7 +587,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
                  */
                 let scrollPosition: UICollectionView.ScrollPosition = viewIfLoaded?.window != nil ? .centeredVertically : []
                 for i in 0 ..< viewModel.files.count {
-                    guard let file = displayedFiles[safe: i],
+                    guard let file = getDisplayedFile(at: IndexPath(item: i, section: 0)),
                           multipleSelectionViewModel.selectedItems.contains(file) else {
                         continue
                     }
@@ -658,7 +662,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         forItemAt indexPath: IndexPath
     ) {
         if viewModel.multipleSelectionViewModel?.isSelectAllModeEnabled == true,
-           let file = displayedFiles[safe: indexPath.item],
+           let file = getDisplayedFile(at: indexPath),
            viewModel.multipleSelectionViewModel?.exceptItemIds.contains(file.id) != true {
             collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
         }
@@ -670,7 +674,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if viewModel.multipleSelectionViewModel?.isMultipleSelectionEnabled == true {
-            guard let file = displayedFiles[safe: indexPath.item] else { return }
+            guard let file = getDisplayedFile(at: indexPath) else { return }
             viewModel.multipleSelectionViewModel?.didSelectFile(file, at: indexPath)
         } else {
             viewModel.didSelectFile(at: indexPath)
@@ -679,7 +683,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
 
     override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard viewModel.multipleSelectionViewModel?.isMultipleSelectionEnabled == true,
-              let file = displayedFiles[safe: indexPath.item] else {
+              let file = getDisplayedFile(at: indexPath) else {
             return
         }
         viewModel.multipleSelectionViewModel?.didDeselectFile(file, at: indexPath)
@@ -846,7 +850,7 @@ extension FileListViewController: UICollectionViewDragDelegate {
     func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession,
                         at indexPath: IndexPath) -> [UIDragItem] {
         if let draggableViewModel = viewModel.draggableFileListViewModel,
-           let draggedFile = displayedFiles[safe: indexPath.item] {
+           let draggedFile = getDisplayedFile(at: indexPath) {
             return draggableViewModel.dragItems(for: draggedFile, in: collectionView, at: indexPath, with: session)
         } else {
             return []
@@ -869,7 +873,7 @@ extension FileListViewController: UICollectionViewDropDelegate {
     ) -> UICollectionViewDropProposal {
         if let droppableViewModel = viewModel.droppableFileListViewModel,
            let destinationIndexPath {
-            let file = displayedFiles[safe: destinationIndexPath.item]
+            let file = getDisplayedFile(at: destinationIndexPath)
             return droppableViewModel.updateDropSession(
                 session,
                 in: collectionView,
@@ -887,7 +891,7 @@ extension FileListViewController: UICollectionViewDropDelegate {
 
             if let indexPath = coordinator.destinationIndexPath,
                indexPath.item < viewModel.files.count,
-               let file = displayedFiles[safe: indexPath.item],
+               let file = getDisplayedFile(at: indexPath),
                file.isDirectory && file.capabilities.canUpload {
                 destinationDirectory = file
             }

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
@@ -101,6 +101,10 @@ final class PhotoListViewController: FileListViewController {
         bindPhotoListViewModel()
     }
 
+    override func getDisplayedFile(at indexPath: IndexPath) -> File? {
+        return displayedSections[safe: indexPath.section]?.elements[indexPath.item]
+    }
+
     private func bindPhotoListViewModel() {
         photoListViewModel.$sections.receiveOnMain(store: &bindStore) { [weak self] newContent in
             self?.reloadCollectionViewWith(sections: newContent)
@@ -291,7 +295,7 @@ final class PhotoListViewController: FileListViewController {
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(type: HomeLastPicCollectionViewCell.self, for: indexPath)
-        guard let file = displayedSections[safe: indexPath.section]?.elements[indexPath.row] else {
+        guard let file = getDisplayedFile(at: indexPath) else {
             return cell
         }
 

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -742,7 +742,6 @@ public final class DriveFileManager {
 
                 deleteOrphanFiles(
                     root: DriveFileManager.homeRootFile,
-                    DriveFileManager.lastPicturesRootFile,
                     DriveFileManager.lastModificationsRootFile,
                     DriveFileManager.searchFilesRootFile,
                     writableRealm: writableRealm


### PR DESCRIPTION
`FileListViewController` uses `displayedFiles` which is an array because there are no sections. 
`PhotoListViewController` extends `FileListViewController` but has a different datasource implementation with one section per month. This creates a mixup of indexes on selection.

This PR adds a `getDisplayedFile(at indexPath:IndexPath)` that can be overridden by subclasses for custom behaviour 