### PR TITLE
fix(DriveFileManager): Fix pagination for public share

### DIFF
--- a/kDrive/UI/Controller/Menu/Share/PublicShareViewModel.swift
+++ b/kDrive/UI/Controller/Menu/Share/PublicShareViewModel.swift
@@ -77,6 +77,7 @@ final class PublicShareViewModel: InMemoryFileListViewModel {
 
         let (_, nextCursor) = try await driveFileManager.publicShareFiles(rootProxy: rootProxy,
                                                                           publicShareProxy: publicShareProxy,
+                                                                          cursor: cursor,
                                                                           publicShareApiFetcher: publicShareApiFetcher)
         endRefreshing()
         if let nextCursor {

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -447,7 +447,8 @@ public final class DriveFileManager {
                             let mySharedFiles = try await publicShareApiFetcher.shareLinkFileChildren(
                                 rootFolderId: rootProxy.id,
                                 publicShareProxy: publicShareProxy,
-                                sortType: sortType
+                                sortType: sortType,
+                                cursor: cursor
                             )
                             return mySharedFiles
                         },


### PR DESCRIPTION
With the fixed `ios-core`, passing the cursor wehre needed fixed the public shares not been able to _load more_

Feature PR https://github.com/Infomaniak/ios-kDrive/pull/1306