### PR TITLE
refactor(SaveFileViewController): Split the class

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
@@ -23,8 +23,6 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-// MARK: - FooterButtonDelegate
-
 extension SaveFileViewController: FooterButtonDelegate {
     @objc func didClickOnButton(_ sender: AnyObject) {
         guard let drive = selectedDriveFileManager?.drive,

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectDriveDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectDriveDelegate.swift
@@ -19,8 +19,6 @@
 import Foundation
 import kDriveCore
 
-// MARK: - SelectDriveDelegate
-
 extension SaveFileViewController: SelectDriveDelegate {
     func didSelectDrive(_ drive: Drive) {
         if let selectedDriveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: drive.userId) {

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectDriveDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectDriveDelegate.swift
@@ -1,0 +1,36 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+
+// MARK: - SelectDriveDelegate
+
+extension SaveFileViewController: SelectDriveDelegate {
+    func didSelectDrive(_ drive: Drive) {
+        if let selectedDriveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: drive.userId) {
+            self.selectedDriveFileManager = selectedDriveFileManager
+            selectedDirectory = getBestDirectory()
+            sections = [.fileName, .driveSelection, .directorySelection]
+            if itemProvidersContainHeicPhotos {
+                sections.append(.photoFormatOption)
+            }
+        }
+        updateButton()
+    }
+}

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectFolderDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectFolderDelegate.swift
@@ -19,8 +19,6 @@
 import kDriveCore
 import UIKit
 
-// MARK: - SelectFolderDelegate
-
 extension SaveFileViewController: SelectFolderDelegate {
     func didSelectFolder(_ folder: File) {
         if folder.id == DriveFileManager.constants.rootID {

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectFolderDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectFolderDelegate.swift
@@ -1,0 +1,34 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import kDriveCore
+import UIKit
+
+// MARK: - SelectFolderDelegate
+
+extension SaveFileViewController: SelectFolderDelegate {
+    func didSelectFolder(_ folder: File) {
+        if folder.id == DriveFileManager.constants.rootID {
+            selectedDirectory = selectedDriveFileManager?.getCachedRootFile()
+        } else {
+            selectedDirectory = folder
+        }
+        updateButton()
+        tableView.reloadData()
+    }
+}

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectPhotoFormatDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectPhotoFormatDelegate.swift
@@ -1,0 +1,35 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+
+// MARK: - SelectPhotoFormatDelegate
+
+extension SaveFileViewController: SelectPhotoFormatDelegate {
+    func didSelectPhotoFormat(_ format: PhotoFileFormat) {
+        if userPreferredPhotoFormat != format {
+            userPreferredPhotoFormat = format
+            if itemProviders?.isEmpty == false {
+                setItemProviders()
+            } else {
+                setAssetIdentifiers()
+            }
+        }
+    }
+}

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectPhotoFormatDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+SelectPhotoFormatDelegate.swift
@@ -19,8 +19,6 @@
 import Foundation
 import kDriveCore
 
-// MARK: - SelectPhotoFormatDelegate
-
 extension SaveFileViewController: SelectPhotoFormatDelegate {
     func didSelectPhotoFormat(_ format: PhotoFileFormat) {
         if userPreferredPhotoFormat != format {

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDataSource.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDataSource.swift
@@ -1,0 +1,123 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import kDriveResources
+import UIKit
+
+// MARK: - UITableViewDataSource
+
+extension SaveFileViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        let section = sections[section]
+        if section == .fileName {
+            return items.count
+        } else {
+            return 1
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch sections[indexPath.section] {
+        case .alert:
+            let cell = tableView.dequeueReusableCell(type: AlertTableViewCell.self, for: indexPath)
+            cell.configure(with: .warning, message: KDriveResourcesStrings.Localizable.snackBarUploadError(errorCount))
+            return cell
+        case .fileName:
+            let item = items[indexPath.row]
+            if items.count > 1 {
+                let cell = tableView.dequeueReusableCell(type: UploadTableViewCell.self, for: indexPath)
+                cell.initWithPositionAndShadow(
+                    isFirst: indexPath.row == 0,
+                    isLast: indexPath.row == self.tableView(tableView, numberOfRowsInSection: indexPath.section) - 1
+                )
+                cell.configureWith(importedFile: item)
+                return cell
+            } else {
+                let cell = tableView.dequeueReusableCell(type: FileNameTableViewCell.self, for: indexPath)
+                cell.textField.text = item.name
+                cell.textDidChange = { [weak self] text in
+                    guard let self else { return }
+                    item.name = text ?? KDriveResourcesStrings.Localizable.allUntitledFileName
+                    if let text, !text.isEmpty {
+                        updateButton()
+                    } else {
+                        enableButton = false
+                    }
+                }
+                return cell
+            }
+        case .driveSelection:
+            let cell = tableView.dequeueReusableCell(type: LocationTableViewCell.self, for: indexPath)
+            cell.initWithPositionAndShadow(isFirst: true, isLast: true)
+            cell.configure(with: selectedDriveFileManager?.drive)
+            return cell
+        case .directorySelection:
+            let cell = tableView.dequeueReusableCell(type: LocationTableViewCell.self, for: indexPath)
+            cell.initWithPositionAndShadow(isFirst: true, isLast: true)
+            cell.configure(with: selectedDirectory, drive: selectedDriveFileManager!.drive)
+            return cell
+        case .photoFormatOption:
+            let cell = tableView.dequeueReusableCell(type: PhotoFormatTableViewCell.self, for: indexPath)
+            cell.initWithPositionAndShadow(isFirst: true, isLast: true)
+            cell.configure(with: userPreferredPhotoFormat)
+            return cell
+        case .importing:
+            let cell = tableView.dequeueReusableCell(type: ImportingTableViewCell.self, for: indexPath)
+            cell.importationProgressView.observedProgress = importProgress
+            return cell
+        default:
+            fatalError("Not supported by this datasource")
+        }
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        switch sections[section] {
+        case .fileName:
+            return HomeTitleView.instantiate(title: "")
+        case .driveSelection:
+            return HomeTitleView.instantiate(title: "kDrive")
+        case .directorySelection:
+            return HomeTitleView.instantiate(title: KDriveResourcesStrings.Localizable.allPathTitle)
+        case .photoFormatOption:
+            return HomeTitleView.instantiate(title: KDriveResourcesStrings.Localizable.photoFormatTitle)
+        default:
+            return nil
+        }
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == tableView.numberOfSections - 1 && !importInProgress {
+            return 124
+        }
+        return 32
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if section == tableView.numberOfSections - 1 && !importInProgress {
+            let view = FooterButtonView.instantiate(title: KDriveResourcesStrings.Localizable.buttonSave)
+            view.delegate = self
+            view.footerButton.isEnabled = enableButton
+            return view
+        }
+        return nil
+    }
+}

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDataSource.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDataSource.swift
@@ -19,8 +19,6 @@
 import kDriveResources
 import UIKit
 
-// MARK: - UITableViewDataSource
-
 extension SaveFileViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let section = sections[section]

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
@@ -1,0 +1,69 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2024 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import kDriveCore
+import kDriveResources
+import UIKit
+
+// MARK: - UITableViewDelegate
+
+extension SaveFileViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        switch sections[indexPath.section] {
+        case .fileName:
+            let item = items[indexPath.row]
+            if items.count > 1 {
+                let alert = AlertFieldViewController(
+                    title: KDriveResourcesStrings.Localizable.buttonRename,
+                    placeholder: KDriveResourcesStrings.Localizable.hintInputFileName,
+                    text: item.name,
+                    action: KDriveResourcesStrings.Localizable.buttonSave,
+                    loading: false
+                ) { newName in
+                    item.name = newName
+                    tableView.reloadRows(at: [indexPath], with: .automatic)
+                }
+                alert.textFieldConfiguration = .fileNameConfiguration
+                alert.textFieldConfiguration.selectedRange = item.name
+                    .startIndex ..< (item.name.lastIndex { $0 == "." } ?? item.name.endIndex)
+                present(alert, animated: true)
+            }
+        case .driveSelection:
+            let selectDriveViewController = SelectDriveViewController.instantiate()
+            selectDriveViewController.selectedDrive = selectedDriveFileManager?.drive
+            selectDriveViewController.delegate = self
+            navigationController?.pushViewController(selectDriveViewController, animated: true)
+        case .directorySelection:
+            guard let driveFileManager = selectedDriveFileManager else { return }
+            let selectFolderNavigationController = SelectFolderViewController.instantiateInNavigationController(
+                driveFileManager: driveFileManager,
+                startDirectory: selectedDirectory,
+                delegate: self
+            )
+            present(selectFolderNavigationController, animated: true)
+        case .photoFormatOption:
+            let selectPhotoFormatViewController = SelectPhotoFormatViewController
+                .instantiate(selectedFormat: userPreferredPhotoFormat)
+            selectPhotoFormatViewController.delegate = self
+            navigationController?.pushViewController(selectPhotoFormatViewController, animated: true)
+        default:
+            break
+        }
+    }
+}

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
@@ -20,8 +20,6 @@ import kDriveCore
 import kDriveResources
 import UIKit
 
-// MARK: - UITableViewDelegate
-
 extension SaveFileViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
Split the class for better readability and further development.
Strictly compatible with the current code, does not change anything.
Required by `PublicShare` feature.