### PR TITLE
fix(PhotoLibraryUploader): Early photo upload start.

### DIFF
--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -48,13 +48,14 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     @LazyInjectService var appNavigable: AppNavigable
     @LazyInjectService var backgroundDownloadSessionManager: BackgroundDownloadSessionManager
     @LazyInjectService var backgroundUploadSessionManager: BackgroundUploadSessionManager
+    @LazyInjectService var appContextService: AppContextServiceable
 
     // MARK: - UIApplicationDelegate
 
     func application(_ application: UIApplication,
                      willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         Logging.initLogging()
-        Log.appDelegate("Application starting in foreground ? \(UIApplication.shared.applicationState != .background)")
+        Log.appDelegate("Application starting in foreground ? \(appContextService.mainAppIsForeground)")
 
         ImageCache.default.memoryStorage.config.totalCostLimit = Constants.ImageCache.memorySizeLimit
         // Must define a limit, unlimited otherwise

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -23,6 +23,8 @@ import Photos
 import RealmSwift
 
 public extension PhotoLibraryUploader {
+    private static let batchSize = 99
+
     @discardableResult
     func scheduleNewPicturesForUpload() -> Int {
         Log.photoLibraryUploader("scheduleNewPicturesForUpload")
@@ -176,7 +178,7 @@ public extension PhotoLibraryUploader {
                 writableRealm.add(uploadFile, update: .modified)
 
                 // Batching writes
-                if idx < assetsFetchResult.count - 1 && idx % 99 == 0 {
+                if idx < assetsFetchResult.count - 1 && idx % Self.batchSize == 0 {
                     Log.photoLibraryUploader("Commit assets batch up to :\(idx)")
                     if let creationDate = asset.creationDate {
                         updateLastSyncDate(creationDate, writableRealm: writableRealm)
@@ -186,7 +188,7 @@ public extension PhotoLibraryUploader {
                     try? writableRealm.commitWrite()
 
                     // Start the upload queue early once we have files to upload
-                    if idx < 100 {
+                    if idx <= Self.batchSize {
                         earlyStartUploadQueue()
                     }
 

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -203,13 +203,16 @@ public extension PhotoLibraryUploader {
     }
 
     private func earlyStartUploadQueue() {
-        @InjectService var appContextService: AppContextServiceable
-        guard !appContextService.isExtension else {
-            return
-        }
+        Task {
+            // We do not start the upload in background mode or in extension
+            @InjectService var appContextService: AppContextServiceable
+            guard await appContextService.mainAppIsForeground else {
+                return
+            }
 
-        @InjectService var uploadQueue: UploadQueue
-        uploadQueue.rebuildUploadQueueFromObjectsInRealm()
+            @InjectService var uploadQueue: UploadQueue
+            uploadQueue.rebuildUploadQueueFromObjectsInRealm()
+        }
     }
 
     private func getPhotoLibraryName(

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -184,6 +184,12 @@ public extension PhotoLibraryUploader {
 
                     // Commit write every 100 assets if it's not the last
                     try? writableRealm.commitWrite()
+
+                    // Start the upload queue early once we have files to upload
+                    if idx < 100 {
+                        earlyStartUploadQueue()
+                    }
+
                     writableRealm.beginWrite()
                 }
             }
@@ -192,6 +198,16 @@ public extension PhotoLibraryUploader {
         guard !expiringActivity.shouldTerminate else {
             throw ErrorDomain.importCancelledBySystem
         }
+    }
+
+    private func earlyStartUploadQueue() {
+        @InjectService var appContextService: AppContextServiceable
+        guard !appContextService.isExtension else {
+            return
+        }
+
+        @InjectService var uploadQueue: UploadQueue
+        uploadQueue.rebuildUploadQueueFromObjectsInRealm()
     }
 
     private func getPhotoLibraryName(

--- a/kDriveCore/Services/AppContextService.swift
+++ b/kDriveCore/Services/AppContextService.swift
@@ -16,7 +16,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Foundation
+import UIKit
 
 /// All the ways some code can be executed within the __kDrive__ project
 public enum DriveAppContext: String {
@@ -43,6 +43,9 @@ public protocol AppContextServiceable {
 
     /// Shorthand to check if we are within the main app or any extension
     var isExtension: Bool { get }
+
+    /// True if the main app is rendering in front of the user
+    @MainActor var mainAppIsForeground: Bool { get }
 }
 
 public struct AppContextService: AppContextServiceable {
@@ -54,6 +57,13 @@ public struct AppContextService: AppContextServiceable {
         }
 
         return false
+    }
+
+    @MainActor public var mainAppIsForeground: Bool {
+        guard !isExtension else {
+            return false
+        }
+        return UIApplication.shared.applicationState == .active
     }
 
     public init(context: DriveAppContext) {

--- a/kDriveCore/Utils/NotificationsHelper.swift
+++ b/kDriveCore/Utils/NotificationsHelper.swift
@@ -221,14 +221,12 @@ public struct NotificationsHelper: NotificationsHelpable {
                 return
             }
 
-            let isInBackground = appContextService.isExtension || UIApplication.shared.applicationState != .active
-
-            if isInBackground {
+            if appContextService.mainAppIsForeground {
+                UIConstants.showSnackBar(message: notification.body, duration: .lengthLong, action: action)
+            } else {
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
                 let request = UNNotificationRequest(identifier: id, content: notification, trigger: trigger)
                 try? await UNUserNotificationCenter.current().add(request)
-            } else {
-                UIConstants.showSnackBar(message: notification.body, duration: .lengthLong, action: action)
             }
         }
     }


### PR DESCRIPTION
Start the upload during a photo sync after the scan of the first batch of pictures.
Strictly limited to foreground app operations.