### PR TITLE
fix(UploadQueue): Prevent an enumeration crash.

### DIFF
--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -88,7 +88,7 @@ extension UploadQueue: UploadQueueable {
                 return lazyCollection.filter(uploadFileQuery)
                     .sorted(byKeyPath: "taskCreationDate")
             }
-            let uploadingFileIds = uploadingFiles.map(\.id)
+            let uploadingFileIds = Array(uploadingFiles.map(\.id))
             Log.uploadQueue("rebuildUploadQueueFromObjectsInRealm uploads to restart:\(uploadingFileIds.count)")
 
             let batches = uploadingFileIds.chunks(ofCount: 100)


### PR DESCRIPTION
Prevent a crash by forcing the use of an Array instead of a lazy collection.