### PR TITLE
chore: Bump swift-concurrency to 1.0.0

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -284,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/swift-concurrency",
       "state" : {
-        "revision" : "55fe7541cbfcfb4b73e7836b390e2c566a9ba910",
-        "version" : "0.0.6"
+        "revision" : "97ae7c9b998a43812d3f57ae106cb447a853bf3b",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "13.1.0")),
         .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "7.0.1")),
         .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "0.0.4")),
+        .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-version-checker", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/Infomaniak/LocalizeKit", .upToNextMajor(from: "1.0.2")),
         .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.52.0")),


### PR DESCRIPTION
Library bump, given the unit tests on the library I'm confident it will work smoothly.