### PR TITLE
fix(SingleTrackPlayer): Fix observation crash

### DIFF
--- a/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
+++ b/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
@@ -99,6 +99,7 @@ public final class SingleTrackPlayer: Pausable {
     /// Async as may take up some time
     public func setup(with playableFile: File) async { // TODO: use abstract type
         if !playableFile.isLocalVersionOlderThanRemote {
+            removeAllObservers()
             let asset = AVAsset(url: playableFile.localUrl)
             player = AVPlayer(url: playableFile.localUrl)
             setUpObservers()


### PR DESCRIPTION
Make sure to reset any observation before we recreate an `AVPlayer` to prevent a crash