### PR TITLE
fix(PhotoLibraryUploader): Hard fail when unable to fetch an iCloud asset

### DIFF
--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -137,6 +137,7 @@ public extension PhotoLibraryUploader {
                 } catch {
                     // Error thrown while hashing a resource, we stop ASAP.
                     Log.photoLibraryUploader("Error while hashing:\(error) asset: \(asset.localIdentifier)", level: .error)
+                    writableRealm.cancelWrite()
                     stop.pointee = true
                     return
                 }


### PR DESCRIPTION
Was skipping any unreachable asset.

Now the scan will fail, and stop. The app will retry to scan later.

Another PR will set up more remote instrumentalisation in the code to help with this


https://github.com/Infomaniak/ios-kDrive/pull/1383