### PR TITLE
fix(PhotoSync): Skip iCloud asset on iCloud critical error

### DIFF
--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -135,10 +135,8 @@ public extension PhotoLibraryUploader {
                 do {
                     bestResourceSHA256 = try asset.bestResourceSHA256
                 } catch {
-                    // Error thrown while hashing a resource, we stop ASAP.
+                    // Error thrown while hashing a resource, we skip the asset.
                     Log.photoLibraryUploader("Error while hashing:\(error) asset: \(asset.localIdentifier)", level: .error)
-                    writableRealm.cancelWrite()
-                    stop.pointee = true
                     return
                 }
 

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -137,6 +137,7 @@ public extension PhotoLibraryUploader {
                 } catch {
                     // Error thrown while hashing a resource, we stop ASAP.
                     Log.photoLibraryUploader("Error while hashing:\(error) asset: \(asset.localIdentifier)", level: .error)
+                    writableRealm.cancelWrite()
                     stop.pointee = true
                     return
                 }

--- a/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
+++ b/kDriveCore/Utils/PHAsset/PHAssetIdentifier.swift
@@ -155,8 +155,8 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
 
             group.enter()
             var resourceManagerError: Error?
-            PHAssetResourceManager.default().requestData(for: bestResource,
-                                                         options: options) { data in
+            let requestId = PHAssetResourceManager.default().requestData(for: bestResource,
+                                                                         options: options) { data in
                 hasher.update(data)
             } completionHandler: { error in
                 if let error {
@@ -174,7 +174,7 @@ struct PHAssetIdentifier: PHAssetIdentifiable {
 
             // PHAssetResourceManager errors, possibly fetching an asset on iCloud failed
             if let resourceManagerError {
-                SentryDebug.capturePHAssetResourceManagerError(resourceManagerError)
+                SentryDebug.capturePHAssetResourceManagerError(resourceManagerError, requestId: requestId)
                 throw resourceManagerError
             }
 

--- a/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
@@ -111,13 +111,14 @@ extension SentryDebug {
         requestId: Int32 = Int32(NSNotFound),
         function: StaticString = #function
     ) {
-        let context: [String: AnyHashable] = [
+        let extra: [String: AnyHashable] = [
+            "group": ErrorNames.assetResourceManagerError,
             "requestId": requestId,
             "func": "\(function)",
-            "error": "\(error)",
             "localizedError": error.localizedDescription
         ]
-        SentryDebug.capture(message: ErrorNames.assetResourceManagerError, context: context, level: .error)
+
+        SentryDebug.capture(error: error, extras: extra)
     }
 
     // MARK: - Upload notifications

--- a/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
@@ -106,13 +106,18 @@ extension SentryDebug {
         SentryDebug.capture(message: EventNames.uploadCompletedSuccess, extras: metadata)
     }
 
-    static func capturePHAssetResourceManagerError(_ error: Error, function: StaticString = #function) {
-        let metadata: [String: Any] = [
-            "func": function,
-            "error": error,
+    static func capturePHAssetResourceManagerError(
+        _ error: Error,
+        requestId: Int32 = Int32(NSNotFound),
+        function: StaticString = #function
+    ) {
+        let context: [String: AnyHashable] = [
+            "requestId": requestId,
+            "func": "\(function)",
+            "error": "\(error)",
             "localizedError": error.localizedDescription
         ]
-        SentryDebug.capture(message: ErrorNames.assetResourceManagerError, context: metadata, level: .error)
+        SentryDebug.capture(message: ErrorNames.assetResourceManagerError, context: context, level: .error)
     }
 
     // MARK: - Upload notifications


### PR DESCRIPTION
- PhotoSync will skip an iCloud asset if Apple's API is in error. The scan will continue.
- Small changes on `Sentry` related code for better tracking of the issue.