### PR TITLE
fix(PhotoSync): Do not start if not enough free space available

### DIFF
--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -528,7 +528,7 @@ extension PhotoSyncSettingsViewController: SelectPhotoFormatDelegate {
 
 extension PhotoSyncSettingsViewController: FooterButtonDelegate {
     func didClickOnButton(_ sender: AnyObject) {
-        guard freeSpaceService.isEnoughAvailableSpaceForChunkUpload else {
+        guard freeSpaceService.hasEnoughAvailableSpaceForChunkUpload else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.errorDeviceStorage)
             return
         }

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -29,6 +29,7 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) private var uploadsDatabase: Transactionable
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var freeSpaceService: FreeSpaceService
 
     private enum PhotoSyncSection {
         case syncSwitch
@@ -527,6 +528,11 @@ extension PhotoSyncSettingsViewController: SelectPhotoFormatDelegate {
 
 extension PhotoSyncSettingsViewController: FooterButtonDelegate {
     func didClickOnButton(_ sender: AnyObject) {
+        guard freeSpaceService.isEnoughAvailableSpaceForChunkUpload else {
+            UIConstants.showSnackBarIfNeeded(error: DriveError.errorDeviceStorage)
+            return
+        }
+
         MatomoUtils.trackPhotoSync(isEnabled: photoSyncEnabled, with: newSyncSettings)
 
         DispatchQueue.global(qos: .userInitiated).async {

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -55,17 +55,23 @@ public struct FreeSpaceService {
         return requiredSpace
     }
 
-    public func checkEnoughAvailableSpaceForChunkUpload() throws {
+    public var isEnoughAvailableSpaceForChunkUpload: Bool {
         let freeSpaceInTemporaryDirectory: Int64
         do {
             freeSpaceInTemporaryDirectory = try freeSpace(url: Self.temporaryDirectoryURL)
         } catch {
             Log.uploadOperation("unable to read available space \(error)", level: .error)
-            return
+            return true
         }
 
-        // Throw if not enough space
         guard freeSpaceInTemporaryDirectory > minimalSpaceRequiredForChunkUpload else {
+            return false
+        }
+        return true
+    }
+
+    public func checkEnoughAvailableSpaceForChunkUpload() throws {
+        guard isEnoughAvailableSpaceForChunkUpload else {
             throw StorageIssues.notEnoughSpace
         }
     }

--- a/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/FreeSpace/FreeSpaceService.swift
@@ -55,7 +55,7 @@ public struct FreeSpaceService {
         return requiredSpace
     }
 
-    public var isEnoughAvailableSpaceForChunkUpload: Bool {
+    public var hasEnoughAvailableSpaceForChunkUpload: Bool {
         let freeSpaceInTemporaryDirectory: Int64
         do {
             freeSpaceInTemporaryDirectory = try freeSpace(url: Self.temporaryDirectoryURL)
@@ -71,7 +71,7 @@ public struct FreeSpaceService {
     }
 
     public func checkEnoughAvailableSpaceForChunkUpload() throws {
-        guard isEnoughAvailableSpaceForChunkUpload else {
+        guard hasEnoughAvailableSpaceForChunkUpload else {
             throw StorageIssues.notEnoughSpace
         }
     }


### PR DESCRIPTION
Here is what it looks like in the rare event of not enough space before we try to launch a sync.

This is important for iCloud users, as we will be unable to fetch iCloud assets if there is no sufficient space on the device.

<img width="505" alt="Screenshot 2025-01-16 at 18 38 45" src="https://github.com/user-attachments/assets/9b8f2026-97a3-4e15-b448-89184591373a" />
