### PR TITLE
fix(DownloadAuthenticatedOperation): Remove invalid assertion in debug

### DIFF
--- a/kDriveCore/Data/DownloadQueue/DownloadOperation/DownloadAuthenticatedOperation.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadOperation/DownloadAuthenticatedOperation.swift
@@ -253,11 +253,6 @@ public class DownloadAuthenticatedOperation: DownloadOperation, DownloadFileOper
             return
         }
 
-        assert(
-            file.isDownloaded,
-            "Expecting to be downloaded at the end of the downloadOperation error:\(String(describing: error))"
-        )
-
         try? uploadsDatabase.writeTransaction { writableRealm in
             guard let task = writableRealm.objects(DownloadTask.self)
                 .filter("sessionUrl = %@", sessionUrl.absoluteString)


### PR DESCRIPTION
The assertion in invalid, when the download task is __cancelled__ we do not have a file at the end of the download.
It erroneously triggers with debug builds