### PR TITLE
fix(DirectoryEnumerator): Remove deleted items from updated items

### DIFF
--- a/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
+++ b/kDriveFileProvider/Enumerators/DirectoryEnumerator.swift
@@ -206,6 +206,7 @@ final class DirectoryEnumerator: NSObject, NSFileProviderEnumerator {
                         }
 
                         deletedItems.append(NSFileProviderItemIdentifier(existingDeletedFile.id))
+                        updatedItems.removeAll { $0.id == existingDeletedFile.id }
                         writableRealm.delete(existingDeletedFile)
                     }
 


### PR DESCRIPTION
fix for KDRIVE-IOS-BWQ

If in the same action result the user has updated and deleted a file (eg. rename then delete). The fileprovider would crash because the updated file was invalidated. 

This PR removes the file from the updatedItems if its also in the deletedItems