### PR TITLE
fix: Invalidated live object crash DiffKit while diffing

### DIFF
--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -104,8 +104,9 @@ final class UploadTableViewCell: InsetTableViewCell {
         }
     }
 
-    func configureWith(uploadFile: UploadFile, progress: CGFloat?) {
-        guard !uploadFile.isInvalidated else {
+    func configureWith(frozenUploadFile: UploadFile, progress: CGFloat?) {
+        assert(frozenUploadFile.isFrozen, "Expected a frozen upload file")
+        guard let uploadFile = frozenUploadFile.thaw() else {
             return
         }
 


### PR DESCRIPTION
### Abstract 

When cancelling an upload, the app crashes.

`DiffKit` accesses an invalidated object and crashes.
The `UploadQueueViewController` now tracks a list of frozen files.
The cell was updated to use frozen files as input.
The use of frozen or live file was explicited