### PR TITLE
fix: Drive restoration to the correct one

### DIFF
--- a/kDrive/AppRestorationService.swift
+++ b/kDrive/AppRestorationService.swift
@@ -21,20 +21,6 @@ import InfomaniakDI
 import kDriveCore
 import UIKit
 
-/// Something that centralize the App Restoration logic
-public protocol AppRestorationServiceable {
-    /// Is restoration enabled
-    var shouldRestoreApplicationState: Bool { get }
-
-    /// Should save the scene sate
-    var shouldSaveApplicationState: Bool { get }
-
-    /// Saves a restoration version, for forward compatibility
-    func saveRestorationVersion()
-
-    func reloadAppUI(for driveId: Int, userId: Int) async
-}
-
 public final class AppRestorationService: AppRestorationServiceable {
     @LazyInjectService var appNavigable: AppNavigable
 

--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -606,7 +606,7 @@ public struct AppRouter: AppNavigable {
             return
         }
 
-        let driveFileManager = try accountManager.getFirstAvailableDriveFileManager(for: account.userId)
+        let driveFileManager = try await accountManager.getBestAvailableDriveFileManager(for: account)
         let drive = driveFileManager.drive
         accountManager.setCurrentDriveForCurrentAccount(for: drive.id, userId: drive.userId)
         showMainViewController(driveFileManager: driveFileManager, selectedIndex: nil)

--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -187,6 +187,12 @@ public struct AppRouter: AppNavigable {
                 return
             }
 
+            guard let previousDriveId = sceneUserInfo[SceneRestorationValues.driveId.rawValue] as? Int,
+                  previousDriveId == driveFileManager.drive.id else {
+                Log.sceneDelegate("driveId do not match for restore :\(sceneUserInfo)", level: .error)
+                return
+            }
+
             let selectedIndex = tabBarViewController.selectedIndex
             let viewControllers = tabBarViewController.viewControllers
             guard let rootNavigationController = viewControllers?[safe: selectedIndex] as? UINavigationController else {

--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -59,7 +59,7 @@ public struct AppRouter: AppNavigable {
         return window
     }
 
-    @MainActor var sceneUserInfo: [AnyHashable: Any]? {
+    @MainActor public var sceneUserInfo: [AnyHashable: Any]? {
         guard let scene = window?.windowScene,
               let userInfo = scene.userActivity?.userInfo else {
             return nil

--- a/kDrive/UI/Controller/Menu/SwitchUserViewController.swift
+++ b/kDrive/UI/Controller/Menu/SwitchUserViewController.swift
@@ -86,12 +86,14 @@ class SwitchUserViewController: UIViewController {
 
     private func switchToConnectedAccount(_ account: Account) {
         do {
-            let driveFileManager = try accountManager.getFirstAvailableDriveFileManager(for: account.userId)
-            MatomoUtils.track(eventWithCategory: .account, name: "switch")
-            MatomoUtils.connectUser()
+            Task { @MainActor in
+                let driveFileManager = try await accountManager.getBestAvailableDriveFileManager(for: account)
+                MatomoUtils.track(eventWithCategory: .account, name: "switch")
+                MatomoUtils.connectUser()
 
-            accountManager.switchAccount(newAccount: account)
-            appNavigable.showMainViewController(driveFileManager: driveFileManager, selectedIndex: nil)
+                accountManager.switchAccount(newAccount: account)
+                appNavigable.showMainViewController(driveFileManager: driveFileManager, selectedIndex: nil)
+            }
         } catch DriveError.NoDriveError.noDrive {
             let driveErrorNavigationViewController = DriveErrorViewController.instantiateInNavigationController(
                 errorType: .noDrive,

--- a/kDrive/UI/Controller/PreloadingViewController.swift
+++ b/kDrive/UI/Controller/PreloadingViewController.swift
@@ -94,7 +94,7 @@ class PreloadingViewController: UIViewController {
         Task {
             do {
                 _ = try await accountManager.updateUser(for: currentAccount, registerToken: true)
-                _ = try accountManager.getFirstAvailableDriveFileManager(for: currentAccount.userId)
+                _ = try await accountManager.getBestAvailableDriveFileManager(for: currentAccount)
 
                 if let currentDriveFileManager = self.accountManager.currentDriveFileManager {
                     let state = RootViewControllerState.mainViewController(driveFileManager: currentDriveFileManager)

--- a/kDriveCore/Data/Cache/AccountManager.swift
+++ b/kDriveCore/Data/Cache/AccountManager.swift
@@ -338,6 +338,13 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
     }
 
     private func bestAvailableDrive(from drives: [Drive], account: Account) async throws -> Drive {
+        if appRestorationService.shouldRestoreApplicationState,
+           let sceneUserInfo = await router.sceneUserInfo,
+           let previousDriveId = sceneUserInfo[SceneRestorationValues.driveId.rawValue] as? Int,
+           let restoredDrive = drives.first(where: { $0.id == previousDriveId && $0.isDriveUser && !$0.inMaintenance }) {
+            return restoredDrive
+        }
+
         guard let mainDrive = drives.first(where: { $0.isDriveUser && !$0.inMaintenance }) else {
             removeAccount(toDeleteAccount: account)
             throw drives.first?.isInTechnicalMaintenance == true ?

--- a/kDriveCore/Services/AppRestorationServiceable.swift
+++ b/kDriveCore/Services/AppRestorationServiceable.swift
@@ -1,0 +1,33 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+/// Something that centralize the App Restoration logic
+public protocol AppRestorationServiceable {
+    /// Is restoration enabled
+    var shouldRestoreApplicationState: Bool { get }
+
+    /// Should save the scene sate
+    var shouldSaveApplicationState: Bool { get }
+
+    /// Saves a restoration version, for forward compatibility
+    func saveRestorationVersion()
+
+    func reloadAppUI(for driveId: Int, userId: Int) async
+}

--- a/kDriveCore/Utils/AppNavigable.swift
+++ b/kDriveCore/Utils/AppNavigable.swift
@@ -188,6 +188,10 @@ public protocol RouterActionable {
     func refreshCacheScanLibraryAndUpload(preload: Bool, isSwitching: Bool) async
 }
 
+public protocol SceneRoutable {
+    @MainActor var sceneUserInfo: [AnyHashable: Any]? { get }
+}
+
 /// Something that can navigate within the kDrive app
 public typealias AppNavigable = AppExtensionRoutable
     & Routable
@@ -195,4 +199,5 @@ public typealias AppNavigable = AppExtensionRoutable
     & RouterAppNavigable
     & RouterFileNavigable
     & RouterRootNavigable
+    & SceneRoutable
     & TopmostViewControllerFetchable

--- a/kDriveCore/Utils/InExtensionRouter.swift
+++ b/kDriveCore/Utils/InExtensionRouter.swift
@@ -111,4 +111,6 @@ public struct InExtensionRouter: AppNavigable {
     public func updateTheme() {}
 
     public var topMostViewController: UIViewController?
+
+    @MainActor public var sceneUserInfo: [AnyHashable: Any]? { return nil }
 }

--- a/kDriveTests/kDrive/Launch/MockAccountManager.swift
+++ b/kDriveTests/kDrive/Launch/MockAccountManager.swift
@@ -49,7 +49,7 @@ class MockAccountManager: AccountManageable, RefreshTokenDelegate {
 
     func getDriveFileManager(for driveId: Int, userId: Int) -> DriveFileManager? { currentDriveFileManager }
 
-    func getFirstAvailableDriveFileManager(for userId: Int) throws -> DriveFileManager { fatalError("Not implemented") }
+    func getBestAvailableDriveFileManager(for account: Account) async throws -> DriveFileManager { fatalError("Not implemented") }
 
     func getApiFetcher(for userId: Int, token: ApiToken) -> DriveApiFetcher { fatalError("Not implemented") }
 


### PR DESCRIPTION
TODO: Use currentDriveId

- Restoration in not performed if Drive mismatch.
- If restoration data available, we select the last used drive.