### PR TITLE
fix: Prevent photo library from duplicating items in the upload queue

### DIFF
--- a/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -74,7 +74,7 @@ extension UploadQueue: UploadQueueable {
 
     public func rebuildUploadQueueFromObjectsInRealm(_ caller: StaticString = #function) {
         Log.uploadQueue("rebuildUploadQueueFromObjectsInRealm caller:\(caller)")
-        concurrentQueue.sync {
+        serialQueue.sync {
             // Clean cache if necessary before we try to restart the uploads.
             @InjectService var freeSpaceService: FreeSpaceService
             freeSpaceService.cleanCacheIfAlmostFull()

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader+Scan.swift
@@ -65,8 +65,6 @@ public extension PhotoLibraryUploader {
                     Log.photoLibraryUploader("addImageAssetsToUploadQueue error:\(error)", level: .error)
                 }
             }
-
-            Log.photoLibraryUploader("scheduleNewPicturesForUpload FINISHED")
         }
 
         return newAssetsCount
@@ -78,7 +76,6 @@ public extension PhotoLibraryUploader {
         if let settings = writableRealm.objects(PhotoSyncSettings.self).first,
            !settings.isInvalidated {
             settings.lastSync = date
-            Log.photoLibraryUploader("updateLastSyncDate: \(date)")
         }
     }
 

--- a/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/UploadQueue/Servicies/PhotoLibraryUploader.swift
@@ -29,6 +29,16 @@ public final class PhotoLibraryUploader {
     @LazyInjectService var uploadQueue: UploadQueue
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
 
+    let serialQueue: DispatchQueue = {
+        @LazyInjectService var appContextService: AppContextServiceable
+        let autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = appContextService.isExtension ? .workItem : .inherit
+
+        return DispatchQueue(
+            label: "com.infomaniak.drive.photo-library",
+            autoreleaseFrequency: autoreleaseFrequency
+        )
+    }()
+
     /// Threshold value to trigger cleaning of photo roll if enabled
     static let removeAssetsCountThreshold = 10
 


### PR DESCRIPTION
When we re-scan the photo library, we do not exclude what is already in queue.
Therefore, we can end up with multiple uploads of the same file in upload queue.

This PR aims at solving this issue by checking if the hash of the file is queued.
Also, some preventive steps were taken to prevent collisions during the scan of the photo library.

Needed by the 4G feature https://github.com/Infomaniak/ios-kDrive/pull/1440