### PR TITLE
fix: Remove and int overflow crash

### DIFF
--- a/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
+++ b/kDriveCore/Utils/Sentry/SentryDebug+Upload.swift
@@ -108,7 +108,7 @@ extension SentryDebug {
 
     static func capturePHAssetResourceManagerError(
         _ error: Error,
-        requestId: Int32 = Int32(NSNotFound),
+        requestId: Int32 = INT32_MAX,
         function: StaticString = #function
     ) {
         let extra: [String: AnyHashable] = [


### PR DESCRIPTION
Casting NSNotFound (a large Int64 on 64bit arch, 32 in 32bit mode) into Int32 was crashing.
This removes the need for a NSNotFound, and still has a meaningful value that is not zero when not set.