### PR TITLE
fix: Realm crash on invalidated object in File action sheet

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -457,7 +457,7 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
             floatingPanelViewController.layout = fileFloatingPanelLayout(files: files)
 
             if let file = files.first {
-                fileInformationsViewController.setFile(file, driveFileManager: driveFileManager)
+                fileInformationsViewController.setFile(from: file.uid, driveFileManager: driveFileManager)
             }
 
             floatingPanelViewController.set(contentViewController: fileInformationsViewController)

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -369,7 +369,7 @@ class FileListViewModel: SelectDelegate {
             switch action {
             case .share:
                 MatomoUtils.track(eventWithCategory: .fileListFileAction, name: "swipeShareAndRights")
-                let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, file: file)
+                let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: file)
                 onPresentViewController?(.push, shareVC, true)
             case .delete:
                 MatomoUtils.track(eventWithCategory: .fileListFileAction, name: "swipePutInTrash")

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -369,7 +369,11 @@ class FileListViewModel: SelectDelegate {
             switch action {
             case .share:
                 MatomoUtils.track(eventWithCategory: .fileListFileAction, name: "swipeShareAndRights")
-                let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: file)
+                guard let liveFile = file.thaw() else {
+                    UIConstants.showSnackBarIfNeeded(error: DriveError.fileNotFound)
+                    return
+                }
+                let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: liveFile)
                 onPresentViewController?(.push, shareVC, true)
             case .delete:
                 MatomoUtils.track(eventWithCategory: .fileListFileAction, name: "swipePutInTrash")

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -74,47 +74,49 @@ extension FileActionsFloatingPanelViewController {
             return
         }
 
-        actions = (frozenFile.isDirectory ? FloatingPanelAction.folderListActions : FloatingPanelAction.listActions).filter { action in
-            switch action {
-            case .openWith:
-                return frozenFile.capabilities.canWrite
-            case .edit:
-                return frozenFile.isOfficeFile && frozenFile.capabilities.canWrite
-            case .manageCategories:
-                return driveFileManager.drive.categoryRights.canPutOnFile && !frozenFile.isDisabled
-            case .favorite:
-                return frozenFile.capabilities.canUseFavorite
-            case .convertToDropbox:
-                return frozenFile.capabilities.canBecomeDropbox
-            case .manageDropbox:
-                return frozenFile.isDropbox
-            case .upsaleColor:
-                return frozenFile.isDirectory && driveFileManager.drive.isFreePack
-            case .folderColor:
-                return frozenFile.capabilities.canColor
-            case .seeFolder:
-                return !normalFolderHierarchy && (frozenFile.parent != nil || frozenFile.parentId != 0)
-            case .offline:
-                return !sharedWithMe && presentationOrigin != .photoList
-            case .download:
-                return frozenFile.capabilities.canRead
-            case .move:
-                return frozenFile.capabilities.canMove && !sharedWithMe
-            case .duplicate:
-                return !sharedWithMe && frozenFile.capabilities.canRead && frozenFile.visibility != .isSharedSpace && frozenFile
-                    .visibility != .isTeamSpace
-            case .rename:
-                return frozenFile.capabilities.canRename && !sharedWithMe && !frozenFile.isImporting
-            case .delete:
-                return frozenFile.capabilities.canDelete && !frozenFile.isImporting
-            case .leaveShare:
-                return frozenFile.capabilities.canLeave
-            case .cancelImport:
-                return frozenFile.isImporting
-            default:
-                return true
+        actions = (frozenFile.isDirectory ? FloatingPanelAction.folderListActions : FloatingPanelAction.listActions)
+            .filter { action in
+                switch action {
+                case .openWith:
+                    return frozenFile.capabilities.canWrite
+                case .edit:
+                    return frozenFile.isOfficeFile && frozenFile.capabilities.canWrite
+                case .manageCategories:
+                    return driveFileManager.drive.categoryRights.canPutOnFile && !frozenFile.isDisabled
+                case .favorite:
+                    return frozenFile.capabilities.canUseFavorite
+                case .convertToDropbox:
+                    return frozenFile.capabilities.canBecomeDropbox
+                case .manageDropbox:
+                    return frozenFile.isDropbox
+                case .upsaleColor:
+                    return frozenFile.isDirectory && driveFileManager.drive.isFreePack
+                case .folderColor:
+                    return frozenFile.capabilities.canColor
+                case .seeFolder:
+                    return !normalFolderHierarchy && (frozenFile.parent != nil || frozenFile.parentId != 0)
+                case .offline:
+                    return !sharedWithMe && presentationOrigin != .photoList
+                case .download:
+                    return frozenFile.capabilities.canRead
+                case .move:
+                    return frozenFile.capabilities.canMove && !sharedWithMe
+                case .duplicate:
+                    return !sharedWithMe && frozenFile.capabilities.canRead && frozenFile
+                        .visibility != .isSharedSpace && frozenFile
+                        .visibility != .isTeamSpace
+                case .rename:
+                    return frozenFile.capabilities.canRename && !sharedWithMe && !frozenFile.isImporting
+                case .delete:
+                    return frozenFile.capabilities.canDelete && !frozenFile.isImporting
+                case .leaveShare:
+                    return frozenFile.capabilities.canLeave
+                case .cancelImport:
+                    return frozenFile.isImporting
+                default:
+                    return true
+                }
             }
-        }
     }
 
     // MARK: Handling
@@ -432,7 +434,10 @@ extension FileActionsFloatingPanelViewController {
         let alert = AlertFieldViewController(title: KDriveResourcesStrings.Localizable.buttonRename,
                                              placeholder: placeholder, text: frozenFile.name,
                                              action: KDriveResourcesStrings.Localizable.buttonSave,
-                                             loading: true) { [proxyFile = frozenFile.proxify(), filename = frozenFile.name] newName in
+                                             loading: true) { [
+            proxyFile = frozenFile.proxify(),
+            filename = frozenFile.name
+        ] newName in
             guard newName != filename else { return }
             do {
                 _ = try await self.driveFileManager.rename(file: proxyFile, newName: newName)

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -259,7 +259,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func manageCategoriesAction() {
         FileActionsHelper.manageCategories(
-            frozenFiles: [frozenFile.freezeIfNeeded()],
+            frozenFiles: [frozenFile],
             driveFileManager: driveFileManager,
             from: self,
             presentingParent: presentingViewController

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -348,12 +348,16 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func offlineAction(at indexPath: IndexPath) {
-        FileActionsHelper.offline(files: [frozenFile], driveFileManager: driveFileManager, filesNotAvailable: nil) { _, error in
-            if let error {
+        FileActionsHelper
+            .offline(files: [frozenFile], driveFileManager: driveFileManager, filesNotAvailable: nil) { updatedFile, error in
+                guard let error else {
+                    self.refreshFile()
+                    self.collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])
+                    return
+                }
+
                 UIConstants.showSnackBarIfNeeded(error: error)
             }
-        }
-        collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])
     }
 
     private func downloadAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -208,7 +208,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func shareAndRightsAction() {
         guard let liveFile = frozenFile.thaw() else {
-            UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
+            UIConstants.showSnackBarIfNeeded(error: DriveError.fileNotFound)
             return
         }
         let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: liveFile)

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -207,7 +207,11 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func shareAndRightsAction() {
-        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, file: frozenFile)
+        guard let liveFile = frozenFile.thaw() else {
+            UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
+            return
+        }
+        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: liveFile)
         presentingParent?.navigationController?.pushViewController(shareVC, animated: true)
         dismiss(animated: true)
     }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -349,7 +349,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func offlineAction(at indexPath: IndexPath) {
         FileActionsHelper
-            .offline(files: [frozenFile], driveFileManager: driveFileManager, filesNotAvailable: nil) { updatedFile, error in
+            .offline(files: [frozenFile], driveFileManager: driveFileManager, filesNotAvailable: nil) { _, error in
                 guard let error else {
                     self.refreshFile()
                     self.collectionView.reloadItems(at: [IndexPath(item: 0, section: 0), indexPath])

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -38,7 +38,7 @@ extension FileActionsFloatingPanelViewController {
 
         if driveFileManager.isPublicShare {
             quickActions = []
-        } else if file.isDirectory {
+        } else if frozenFile.isDirectory {
             quickActions = FloatingPanelAction.folderQuickActions
         } else {
             quickActions = FloatingPanelAction.quickActions
@@ -47,15 +47,15 @@ extension FileActionsFloatingPanelViewController {
         for action in quickActions {
             switch action {
             case .shareAndRights:
-                if !file.capabilities.canShare || offline {
+                if !frozenFile.capabilities.canShare || offline {
                     action.isEnabled = false
                 }
             case .shareLink:
-                if (!file.capabilities.canBecomeSharelink || offline) && !file.hasSharelink && !file.isDropbox {
+                if (!frozenFile.capabilities.canBecomeSharelink || offline) && !frozenFile.hasSharelink && !frozenFile.isDropbox {
                     action.isEnabled = false
                 }
             case .add:
-                if !file.capabilities.canCreateFile || !file.capabilities.canCreateDirectory {
+                if !frozenFile.capabilities.canCreateFile || !frozenFile.capabilities.canCreateDirectory {
                     action.isEnabled = false
                 }
             default:
@@ -66,7 +66,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func setupActions() {
         guard !driveFileManager.isPublicShare else {
-            if file.isDirectory {
+            if frozenFile.isDirectory {
                 actions = FloatingPanelAction.publicShareFolderActions
             } else {
                 actions = FloatingPanelAction.publicShareActions
@@ -74,43 +74,43 @@ extension FileActionsFloatingPanelViewController {
             return
         }
 
-        actions = (file.isDirectory ? FloatingPanelAction.folderListActions : FloatingPanelAction.listActions).filter { action in
+        actions = (frozenFile.isDirectory ? FloatingPanelAction.folderListActions : FloatingPanelAction.listActions).filter { action in
             switch action {
             case .openWith:
-                return file.capabilities.canWrite
+                return frozenFile.capabilities.canWrite
             case .edit:
-                return file.isOfficeFile && file.capabilities.canWrite
+                return frozenFile.isOfficeFile && frozenFile.capabilities.canWrite
             case .manageCategories:
-                return driveFileManager.drive.categoryRights.canPutOnFile && !file.isDisabled
+                return driveFileManager.drive.categoryRights.canPutOnFile && !frozenFile.isDisabled
             case .favorite:
-                return file.capabilities.canUseFavorite
+                return frozenFile.capabilities.canUseFavorite
             case .convertToDropbox:
-                return file.capabilities.canBecomeDropbox
+                return frozenFile.capabilities.canBecomeDropbox
             case .manageDropbox:
-                return file.isDropbox
+                return frozenFile.isDropbox
             case .upsaleColor:
-                return file.isDirectory && driveFileManager.drive.isFreePack
+                return frozenFile.isDirectory && driveFileManager.drive.isFreePack
             case .folderColor:
-                return file.capabilities.canColor
+                return frozenFile.capabilities.canColor
             case .seeFolder:
-                return !normalFolderHierarchy && (file.parent != nil || file.parentId != 0)
+                return !normalFolderHierarchy && (frozenFile.parent != nil || frozenFile.parentId != 0)
             case .offline:
                 return !sharedWithMe && presentationOrigin != .photoList
             case .download:
-                return file.capabilities.canRead
+                return frozenFile.capabilities.canRead
             case .move:
-                return file.capabilities.canMove && !sharedWithMe
+                return frozenFile.capabilities.canMove && !sharedWithMe
             case .duplicate:
-                return !sharedWithMe && file.capabilities.canRead && file.visibility != .isSharedSpace && file
+                return !sharedWithMe && frozenFile.capabilities.canRead && frozenFile.visibility != .isSharedSpace && frozenFile
                     .visibility != .isTeamSpace
             case .rename:
-                return file.capabilities.canRename && !sharedWithMe && !file.isImporting
+                return frozenFile.capabilities.canRename && !sharedWithMe && !frozenFile.isImporting
             case .delete:
-                return file.capabilities.canDelete && !file.isImporting
+                return frozenFile.capabilities.canDelete && !frozenFile.isImporting
             case .leaveShare:
-                return file.capabilities.canLeave
+                return frozenFile.capabilities.canLeave
             case .cancelImport:
-                return file.isImporting
+                return frozenFile.isImporting
             default:
                 return true
             }
@@ -134,7 +134,7 @@ extension FileActionsFloatingPanelViewController {
         case .openWith:
             openWithAction(action, at: indexPath)
         case .edit:
-            OnlyOfficeViewController.open(driveFileManager: driveFileManager, file: file, viewController: self)
+            OnlyOfficeViewController.open(driveFileManager: driveFileManager, file: frozenFile, viewController: self)
         case .manageCategories:
             manageCategoriesAction()
         case .favorite:
@@ -173,7 +173,7 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func informationsAction() {
-        let fileDetailViewController = FileDetailViewController.instantiate(driveFileManager: driveFileManager, file: file)
+        let fileDetailViewController = FileDetailViewController.instantiate(driveFileManager: driveFileManager, file: frozenFile)
         presentingParent?.navigationController?.pushViewController(fileDetailViewController, animated: true)
         dismiss(animated: true)
     }
@@ -181,7 +181,7 @@ extension FileActionsFloatingPanelViewController {
     private func addAction() {
         let floatingPanelViewController = AdaptiveDriveFloatingPanelController()
         let fileInformationsViewController = PlusButtonFloatingPanelViewController(driveFileManager: driveFileManager,
-                                                                                   folder: file,
+                                                                                   folder: frozenFile,
                                                                                    presentedFromPlusButton: false)
         floatingPanelViewController.isRemovalInteractionEnabled = true
         floatingPanelViewController.delegate = fileInformationsViewController
@@ -194,7 +194,7 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func sendCopyAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
-        if file.isMostRecentDownloaded {
+        if frozenFile.isMostRecentDownloaded {
             presentShareSheet(from: indexPath)
         } else {
             downloadFile(action: action,
@@ -205,22 +205,22 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func shareAndRightsAction() {
-        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, file: file)
+        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, file: frozenFile)
         presentingParent?.navigationController?.pushViewController(shareVC, animated: true)
         dismiss(animated: true)
     }
 
     private func shareLinkAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
-        if let link = file.dropbox?.url {
+        if let link = frozenFile.dropbox?.url {
             // Copy share link
             copyShareLinkToPasteboard(from: indexPath, link: link)
-        } else if let link = file.sharelink?.url {
+        } else if let link = frozenFile.sharelink?.url {
             // Copy share link
             copyShareLinkToPasteboard(from: indexPath, link: link)
         } else {
             // Create share link
             setLoading(true, action: action, at: indexPath)
-            Task { [proxyFile = file.proxify()] in
+            Task { [proxyFile = frozenFile.proxify()] in
                 do {
                     let shareLink = try await driveFileManager.createShareLink(for: proxyFile)
                     setLoading(false, action: action, at: indexPath)
@@ -245,19 +245,19 @@ extension FileActionsFloatingPanelViewController {
 
     private func openWithAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
         let view = collectionView.cellForItem(at: indexPath)?.frame ?? .zero
-        if file.isMostRecentDownloaded {
-            FileActionsHelper.instance.openWith(file: file, from: view, in: collectionView, delegate: self)
+        if frozenFile.isMostRecentDownloaded {
+            FileActionsHelper.instance.openWith(file: frozenFile, from: view, in: collectionView, delegate: self)
         } else {
             downloadFile(action: action, indexPath: indexPath) { [weak self] in
                 guard let self else { return }
-                FileActionsHelper.instance.openWith(file: file, from: view, in: collectionView, delegate: self)
+                FileActionsHelper.instance.openWith(file: frozenFile, from: view, in: collectionView, delegate: self)
             }
         }
     }
 
     private func manageCategoriesAction() {
         FileActionsHelper.manageCategories(
-            frozenFiles: [file.freezeIfNeeded()],
+            frozenFiles: [frozenFile.freezeIfNeeded()],
             driveFileManager: driveFileManager,
             from: self,
             presentingParent: presentingViewController
@@ -267,7 +267,7 @@ extension FileActionsFloatingPanelViewController {
     private func manageFavoriteAction() {
         Task {
             do {
-                let isFavored = try await FileActionsHelper.favorite(files: [file], driveFileManager: driveFileManager)
+                let isFavored = try await FileActionsHelper.favorite(files: [frozenFile], driveFileManager: driveFileManager)
                 if isFavored {
                     UIConstants
                         .showSnackBar(message: KDriveResourcesStrings.Localizable.fileListAddFavoritesConfirmationSnackbar(1))
@@ -283,7 +283,7 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func convertToDropboxAction() {
-        guard file.capabilities.canBecomeDropbox else {
+        guard frozenFile.capabilities.canBecomeDropbox else {
             let driveFloatingPanelController = DropBoxFloatingPanelViewController.instantiatePanel()
             let floatingPanelViewController = driveFloatingPanelController
                 .contentViewController as? DropBoxFloatingPanelViewController
@@ -308,7 +308,7 @@ extension FileActionsFloatingPanelViewController {
         let viewController = ManageDropBoxViewController.instantiate(
             driveFileManager: driveFileManager,
             convertingFolder: true,
-            folder: file
+            folder: frozenFile
         )
 
         presentingParent?.navigationController?.pushViewController(viewController, animated: true)
@@ -316,7 +316,7 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func manageDropboxAction() {
-        let viewController = ManageDropBoxViewController.instantiate(driveFileManager: driveFileManager, folder: file)
+        let viewController = ManageDropBoxViewController.instantiate(driveFileManager: driveFileManager, folder: frozenFile)
         presentingParent?.navigationController?.pushViewController(viewController, animated: true)
         dismiss(animated: true)
     }
@@ -327,7 +327,7 @@ extension FileActionsFloatingPanelViewController {
 
     private func folderColorAction() {
         FileActionsHelper.folderColor(
-            files: [file],
+            files: [frozenFile],
             driveFileManager: driveFileManager,
             from: self,
             presentingParent: presentingParent
@@ -341,12 +341,12 @@ extension FileActionsFloatingPanelViewController {
 
     private func seeFolderAction() {
         guard let viewController = presentingParent else { return }
-        FilePresenter.presentParent(of: file, driveFileManager: driveFileManager, viewController: viewController)
+        FilePresenter.presentParent(of: frozenFile, driveFileManager: driveFileManager, viewController: viewController)
         dismiss(animated: true)
     }
 
     private func offlineAction(at indexPath: IndexPath) {
-        FileActionsHelper.offline(files: [file], driveFileManager: driveFileManager, filesNotAvailable: nil) { _, error in
+        FileActionsHelper.offline(files: [frozenFile], driveFileManager: driveFileManager, filesNotAvailable: nil) { _, error in
             if let error {
                 UIConstants.showSnackBarIfNeeded(error: error)
             }
@@ -355,9 +355,9 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func downloadAction(_ action: FloatingPanelAction, at indexPath: IndexPath) {
-        if file.isMostRecentDownloaded {
-            FileActionsHelper.save(file: file, from: self)
-        } else if let operation = downloadQueue.operation(for: file.id) {
+        if frozenFile.isMostRecentDownloaded {
+            FileActionsHelper.save(file: frozenFile, from: self)
+        } else if let operation = downloadQueue.operation(for: frozenFile.id) {
             // Download is already scheduled, ask to cancel
             let alert = AlertTextViewController(
                 title: KDriveResourcesStrings.Localizable.cancelDownloadTitle,
@@ -369,9 +369,9 @@ extension FileActionsFloatingPanelViewController {
             }
             present(alert, animated: true)
         } else {
-            downloadFile(action: action, indexPath: indexPath) { [weak self, file] in
-                guard let file else { return }
-                FileActionsHelper.save(file: file, from: self)
+            downloadFile(action: action, indexPath: indexPath) { [weak self, frozenFile] in
+                guard let frozenFile else { return }
+                FileActionsHelper.save(file: frozenFile, from: self)
             }
         }
     }
@@ -379,12 +379,12 @@ extension FileActionsFloatingPanelViewController {
     private func moveAction() {
         let selectFolderNavigationController = SelectFolderViewController.instantiateInNavigationController(
             driveFileManager: driveFileManager,
-            startDirectory: file.parent?.freeze(),
-            fileToMove: file.id,
-            disabledDirectoriesSelection: [file.parent ?? driveFileManager.getCachedRootFile()]
+            startDirectory: frozenFile.parent?.freeze(),
+            fileToMove: frozenFile.id,
+            disabledDirectoriesSelection: [frozenFile.parent ?? driveFileManager.getCachedRootFile()]
         ) { [weak self] selectedFolder in
             guard let self else { return }
-            FileActionsHelper.instance.move(file: file, to: selectedFolder, driveFileManager: driveFileManager) { success in
+            FileActionsHelper.instance.move(file: frozenFile, to: selectedFolder, driveFileManager: driveFileManager) { success in
                 // Close preview
                 if success,
                    self.presentingParent is PreviewViewController {
@@ -396,16 +396,16 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func duplicateAction() {
-        guard file.isManagedByRealm else {
+        guard frozenFile.isManagedByRealm else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
             return
         }
-        let fileName = file.name
+        let fileName = frozenFile.name
         let alert = AlertFieldViewController(title: KDriveResourcesStrings.Localizable.buttonDuplicate,
                                              placeholder: KDriveResourcesStrings.Localizable.fileInfoInputDuplicateFile,
                                              text: fileName,
                                              action: KDriveResourcesStrings.Localizable.buttonCopy,
-                                             loading: true) { [proxyFile = file.proxify()] duplicateName in
+                                             loading: true) { [proxyFile = frozenFile.proxify()] duplicateName in
             do {
                 _ = try await self.driveFileManager.duplicate(file: proxyFile, duplicateName: duplicateName)
                 UIConstants
@@ -415,7 +415,7 @@ extension FileActionsFloatingPanelViewController {
             }
         }
         alert.textFieldConfiguration = .fileNameConfiguration
-        if !file.isDirectory {
+        if !frozenFile.isDirectory {
             alert.textFieldConfiguration.selectedRange = fileName
                 .startIndex ..< (fileName.lastIndex { $0 == "." } ?? fileName.endIndex)
         }
@@ -423,16 +423,16 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func renameAction() {
-        guard file.isManagedByRealm else {
+        guard frozenFile.isManagedByRealm else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
             return
         }
-        let placeholder = file.isDirectory ? KDriveResourcesStrings.Localizable.hintInputDirName : KDriveResourcesStrings
+        let placeholder = frozenFile.isDirectory ? KDriveResourcesStrings.Localizable.hintInputDirName : KDriveResourcesStrings
             .Localizable.hintInputFileName
         let alert = AlertFieldViewController(title: KDriveResourcesStrings.Localizable.buttonRename,
-                                             placeholder: placeholder, text: file.name,
+                                             placeholder: placeholder, text: frozenFile.name,
                                              action: KDriveResourcesStrings.Localizable.buttonSave,
-                                             loading: true) { [proxyFile = file.proxify(), filename = file.name] newName in
+                                             loading: true) { [proxyFile = frozenFile.proxify(), filename = frozenFile.name] newName in
             guard newName != filename else { return }
             do {
                 _ = try await self.driveFileManager.rename(file: proxyFile, newName: newName)
@@ -441,30 +441,30 @@ extension FileActionsFloatingPanelViewController {
             }
         }
         alert.textFieldConfiguration = .fileNameConfiguration
-        if !file.isDirectory {
-            alert.textFieldConfiguration.selectedRange = file.name
-                .startIndex ..< (file.name.lastIndex { $0 == "." } ?? file.name.endIndex)
+        if !frozenFile.isDirectory {
+            alert.textFieldConfiguration.selectedRange = frozenFile.name
+                .startIndex ..< (frozenFile.name.lastIndex { $0 == "." } ?? frozenFile.name.endIndex)
         }
         present(alert, animated: true)
     }
 
     private func deleteAction() {
-        guard file.isManagedByRealm else {
+        guard frozenFile.isManagedByRealm else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
             return
         }
         let attrString = NSMutableAttributedString(
-            string: KDriveResourcesStrings.Localizable.modalMoveTrashDescription(file.name),
-            boldText: file.name
+            string: KDriveResourcesStrings.Localizable.modalMoveTrashDescription(frozenFile.name),
+            boldText: frozenFile.name
         )
         let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.modalMoveTrashTitle,
                                             message: attrString,
                                             action: KDriveResourcesStrings.Localizable.buttonMove,
                                             destructive: true,
                                             loading: true) { [
-            proxyFile = file.proxify(),
-            filename = file.name,
-            proxyParent = file.parent?.proxify()
+            proxyFile = frozenFile.proxify(),
+            filename = frozenFile.name,
+            proxyParent = frozenFile.parent?.proxify()
         ] in
             do {
                 let response = try await self.driveFileManager.delete(file: proxyFile)
@@ -495,18 +495,18 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func leaveShareAction() {
-        guard file.isManagedByRealm else {
+        guard frozenFile.isManagedByRealm else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.unknownError)
             return
         }
         let attrString = NSMutableAttributedString(
-            string: KDriveResourcesStrings.Localizable.modalLeaveShareDescription(file.name),
-            boldText: file.name
+            string: KDriveResourcesStrings.Localizable.modalLeaveShareDescription(frozenFile.name),
+            boldText: frozenFile.name
         )
         let alert = AlertTextViewController(title: KDriveResourcesStrings.Localizable.modalLeaveShareTitle,
                                             message: attrString,
                                             action: KDriveResourcesStrings.Localizable.buttonLeaveShare,
-                                            loading: true) { [proxyFile = file.proxify()] in
+                                            loading: true) { [proxyFile = frozenFile.proxify()] in
             do {
                 _ = try await self.driveFileManager.delete(file: proxyFile)
                 UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.snackbarLeaveShareConfirmation)
@@ -520,7 +520,7 @@ extension FileActionsFloatingPanelViewController {
     }
 
     private func cancelImportAction() {
-        guard let importId = file.externalImport?.id else { return }
+        guard let importId = frozenFile.externalImport?.id else { return }
         Task {
             do {
                 _ = try await driveFileManager.apiFetcher.cancelImport(drive: driveFileManager.drive, id: importId)
@@ -548,7 +548,7 @@ extension FileActionsFloatingPanelViewController {
         PublicShareAction().addToMyDrive(
             publicShareProxy: publicShareProxy,
             currentUserDriveFileManager: currentUserDriveFileManager,
-            selectedItemsIds: [file.id],
+            selectedItemsIds: [frozenFile.id],
             exceptItemIds: [],
             onPresentViewController: { saveNavigationViewController, animated in
                 self.present(saveNavigationViewController, animated: animated, completion: nil)

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -128,7 +128,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     // MARK: - Private methods
 
     private func refreshFile() {
-        guard let freshFrozenFile = driveFileManager.database.fetchObject(ofType: File.self, forPrimaryKey: self.fileUid)?.freeze()
+        guard let freshFrozenFile = driveFileManager.database.fetchObject(ofType: File.self, forPrimaryKey: fileUid)?.freeze()
         else {
             dismiss(animated: true)
             return

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -180,7 +180,9 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     func setLoading(_ isLoading: Bool, action: FloatingPanelAction, at indexPath: IndexPath) {
         action.isLoading = isLoading
         Task { @MainActor [weak self] in
-            self?.collectionView.reloadItems(at: [indexPath])
+            guard let self else { return }
+            self.refreshFile()
+            self.collectionView.reloadItems(at: [indexPath])
         }
     }
 

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -29,8 +29,9 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     @LazyInjectService var router: AppNavigable
     @LazyInjectService var downloadQueue: DownloadQueueable
 
-    var driveFileManager: DriveFileManager!
-    var file: File!
+    private(set) var driveFileManager: DriveFileManager!
+    private(set) var file: File!
+
     var normalFolderHierarchy = true
     var presentationOrigin = PresentationOrigin.fileList
     weak var presentingParent: UIViewController?
@@ -120,7 +121,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
                 }
             }
         }
-        // Reload
+
         reload(animated: false)
     }
 

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -204,11 +204,11 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
                 self?.downloadAction = nil
                 self?.setLoading(true, action: action, at: indexPath)
                 Task { @MainActor in
-                    if error == nil {
-                        completion()
-                    } else {
+                    guard error == nil else {
                         UIConstants.showSnackBarIfNeeded(error: DriveError.downloadFailed)
+                        return
                     }
+                    completion()
                 }
             }
 

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -93,7 +93,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     }
 
     func setFile(_ newFile: File, driveFileManager: DriveFileManager) {
-        guard newFile.isInvalidated == false else {
+        guard !newFile.isInvalidated else {
             dismiss(animated: true)
             return
         }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -89,14 +89,17 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
 
         ReachabilityListener.instance.observeNetworkChange(self) { [weak self] _ in
             Task { @MainActor in
-                guard self?.frozenFile != nil else { return }
-                self?.frozenFile.realm?.refresh()
-                if self?.frozenFile.isInvalidated == true {
-                    // File has been removed
-                    self?.dismiss(animated: true)
-                } else {
-                    self?.reload(animated: true)
+                guard let self, self.frozenFile != nil else {
+                    return
                 }
+
+                let freshFile = self.freshFrozenFile
+                guard !freshFile.isInvalidated else {
+                    self.dismiss(animated: true)
+                    return
+                }
+
+                self.reload(animated: true)
             }
         }
     }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -119,9 +119,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         reload(animated: false)
     }
 
-    // MARK: - Private methods
-
-    private func refreshFile() {
+    func refreshFile() {
         guard let freshFrozenFile = driveFileManager.database.fetchObject(ofType: File.self, forPrimaryKey: fileUid)?.freeze()
         else {
             dismiss(animated: true)
@@ -129,6 +127,8 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         }
         frozenFile = freshFrozenFile
     }
+
+    // MARK: - Private methods
 
     private static func createLayout() -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout { section, _ in

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -164,6 +164,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         setupContent()
         if animated {
             UIView.transition(with: collectionView, duration: 0.35, options: .transitionCrossDissolve) {
+                self.refreshFile()
                 self.collectionView.reloadData()
             }
         } else {
@@ -175,7 +176,6 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         action.isLoading = isLoading
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.refreshFile()
             self.collectionView.reloadItems(at: [indexPath])
         }
     }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -111,14 +111,8 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         fileObserver?.cancel()
         fileObserver = driveFileManager.observeFileUpdated(self, fileId: frozenFile.id) { [weak self] freshFile in
             guard let self else { return }
-            assert(freshFile.isFrozen, "Realm should notify with a frozen file")
-            self.frozenFile = freshFile
             Task { @MainActor in
-                if freshFile.isInvalidated {
-                    self.dismiss(animated: true)
-                } else {
-                    self.reload(animated: true)
-                }
+                self.reload(animated: true)
             }
         }
 

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -115,10 +115,10 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         frozenFile = newFile
         fileObserver?.cancel()
         fileObserver = driveFileManager.observeFileUpdated(self, fileId: frozenFile.id) { [weak self] freshFile in
+            guard let self else { return }
+            assert(freshFile.isFrozen, "Realm should notify with a frozen file")
+            self.frozenFile = freshFile
             Task { @MainActor in
-                guard let self else { return }
-                assert(freshFile.isFrozen, "Realm should notify with a frozen file")
-                self.frozenFile = freshFile
                 if freshFile.isInvalidated {
                     self.dismiss(animated: true)
                 } else {

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -32,6 +32,15 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     private(set) var driveFileManager: DriveFileManager!
     private(set) var frozenFile: File!
 
+    var freshFrozenFile: File {
+        guard let freshFrozenFile = frozenFile.thaw()?.freeze() else {
+            return frozenFile
+        }
+
+        frozenFile = freshFrozenFile
+        return frozenFile.freeze()
+    }
+
     var normalFolderHierarchy = true
     var presentationOrigin = PresentationOrigin.fileList
     weak var presentingParent: UIViewController?
@@ -253,20 +262,20 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         switch Self.sections[indexPath.section] {
         case .header:
             let cell = collectionView.dequeueReusableCell(type: FileCollectionViewCell.self, for: indexPath)
-            cell.configureWith(driveFileManager: driveFileManager, file: frozenFile)
+            cell.configureWith(driveFileManager: driveFileManager, file: freshFrozenFile)
             cell.moreButton.isHidden = true
             return cell
         case .quickActions:
             let cell = collectionView.dequeueReusableCell(type: FloatingPanelQuickActionCollectionViewCell.self, for: indexPath)
             let action = quickActions[indexPath.item]
-            cell.configure(with: action, file: frozenFile)
+            cell.configure(with: action, file: freshFrozenFile)
             return cell
         case .actions:
             let cell = collectionView.dequeueReusableCell(type: FloatingPanelActionCollectionViewCell.self, for: indexPath)
             let action = actions[indexPath.item]
             cell.configure(
                 with: action,
-                file: frozenFile,
+                file: freshFrozenFile,
                 showProgress: downloadAction == action,
                 driveFileManager: driveFileManager,
                 currentPackId: packId

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -109,7 +109,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         frozenFile = freshFrozenFile
 
         fileObserver?.cancel()
-        fileObserver = driveFileManager.observeFileUpdated(self, fileId: frozenFile.id) { [weak self] freshFile in
+        fileObserver = driveFileManager.observeFileUpdated(self, fileId: frozenFile.id) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
                 self.reload(animated: true)

--- a/kDrive/UI/Controller/Files/FileDetailViewController.swift
+++ b/kDrive/UI/Controller/Files/FileDetailViewController.swift
@@ -839,7 +839,7 @@ extension FileDetailViewController: FileDetailDelegate {
 
 extension FileDetailViewController: FileUsersDelegate {
     func shareButtonTapped() {
-        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, file: file)
+        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: file)
         navigationController?.pushViewController(shareVC, animated: true)
     }
 }

--- a/kDrive/UI/Controller/Files/FileDetailViewController.swift
+++ b/kDrive/UI/Controller/Files/FileDetailViewController.swift
@@ -839,7 +839,11 @@ extension FileDetailViewController: FileDetailDelegate {
 
 extension FileDetailViewController: FileUsersDelegate {
     func shareButtonTapped() {
-        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: file)
+        guard let liveFile = file.thaw() else {
+            UIConstants.showSnackBarIfNeeded(error: DriveError.fileNotFound)
+            return
+        }
+        let shareVC = ShareAndRightsViewController.instantiate(driveFileManager: driveFileManager, liveFile: liveFile)
         navigationController?.pushViewController(shareVC, animated: true)
     }
 }

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -229,7 +229,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
     }
 
     private func updateFileForCurrentIndex() {
-        fileInformationsViewController.setFile(currentFile, driveFileManager: driveFileManager)
+        fileInformationsViewController.setFile(from: currentFile.uid, driveFileManager: driveFileManager)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/kDrive/UI/Controller/Files/Rights and Share/ShareAndRightsViewController.swift
+++ b/kDrive/UI/Controller/Files/Rights and Share/ShareAndRightsViewController.swift
@@ -139,11 +139,12 @@ class ShareAndRightsViewController: UIViewController {
         _ = navigationController?.popViewController(animated: true)
     }
 
-    class func instantiate(driveFileManager: DriveFileManager, file: File) -> ShareAndRightsViewController {
+    class func instantiate(driveFileManager: DriveFileManager, liveFile: File) -> ShareAndRightsViewController {
+        assert(!liveFile.isFrozen && liveFile.realm != nil, "we expect a live object here for this class to work properly")
         let viewController = Storyboard.files
             .instantiateViewController(withIdentifier: "ShareAndRightsViewController") as! ShareAndRightsViewController
         viewController.driveFileManager = driveFileManager
-        viewController.file = file
+        viewController.file = liveFile
         return viewController
     }
 }

--- a/kDrive/UI/Controller/NewFolder/NewFolderViewController.swift
+++ b/kDrive/UI/Controller/NewFolder/NewFolderViewController.swift
@@ -424,7 +424,7 @@ extension NewFolderViewController: FooterButtonDelegate {
                     if toShare {
                         let shareVC = ShareAndRightsViewController.instantiate(
                             driveFileManager: self.driveFileManager,
-                            file: directory
+                            liveFile: directory
                         )
                         self.folderCreated = true
                         self.navigationController?.pushViewController(shareVC, animated: true)
@@ -445,7 +445,7 @@ extension NewFolderViewController: FooterButtonDelegate {
                     if !forAllUser {
                         let shareVC = ShareAndRightsViewController.instantiate(
                             driveFileManager: self.driveFileManager,
-                            file: directory
+                            liveFile: directory
                         )
                         self.folderCreated = true
                         self.navigationController?.pushViewController(shareVC, animated: true)
@@ -487,7 +487,7 @@ extension NewFolderViewController: FooterButtonDelegate {
                     if !onlyForMe {
                         let shareVC = ShareAndRightsViewController.instantiate(
                             driveFileManager: self.driveFileManager,
-                            file: directory
+                            liveFile: directory
                         )
                         self.folderCreated = true
                         self.dropBoxUrl = directory.dropbox?.url ?? ""

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
@@ -55,6 +55,7 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
         super.prepareForReuse()
         observationToken?.cancel()
         observationToken = nil
+        setProgress(nil)
         switchView.setOn(false, animated: false)
         switchView.isHidden = true
         chipContainerView.subviews.forEach { $0.removeFromSuperview() }

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
@@ -53,9 +53,11 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        observationToken?.cancel()
+        observationToken = nil
+        switchView.setOn(false, animated: false)
         switchView.isHidden = true
         chipContainerView.subviews.forEach { $0.removeFromSuperview() }
-        observationToken?.cancel()
     }
 
     func configure(with action: FloatingPanelAction,

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
@@ -84,12 +84,11 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
         case .convertToDropbox:
             guard currentPackId == .myKSuite, driveFileManager.drive.dropboxQuotaExceeded else { return }
             configureChip()
+        case .download:
+            guard let file else { return }
+            observeProgress(showProgress, file: file)
         default:
             break
-        }
-
-        if let file {
-            observeProgress(showProgress, file: file)
         }
     }
 
@@ -153,10 +152,12 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
            !downloadOperation.isCancelled,
            !fileExists {
             switchView.setOn(true, animated: true)
+            observeProgress(true, file: file)
         } else if file.isAvailableOffline, fileExists {
             switchView.setOn(true, animated: false)
         } else {
             switchView.setOn(false, animated: true)
+            observeProgress(false, file: file)
         }
 
         if file.isAvailableOffline, fileExists {

--- a/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FloatingPanel/FloatingPanelActionCollectionViewCell.swift
@@ -164,6 +164,7 @@ class FloatingPanelActionCollectionViewCell: UICollectionViewCell {
 
     func observeProgress(_ showProgress: Bool, file: File) {
         observationToken?.cancel()
+        observationToken = nil
         setProgress(showProgress ? -1 : nil)
         if showProgress {
             observationToken = downloadQueue.observeFileDownloadProgress(self, fileId: file.id) { _, progress in

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -1353,7 +1353,7 @@ public final class DriveFileManager {
             writableFile.isAvailableOffline = false
         }
 
-        downloadQueue.operation(for: fileId)?.cancel()
+        downloadQueue.cancelFileOperation(for: fileId)
     }
 
     public func setLocalRecentActivities(detachedActivities: [FileActivity]) async {


### PR DESCRIPTION
- Reworked `FileActionsFloatingPanelViewController` to function with frozen objects instead of live ones internally.
  - Reworked `setFile()` function to work consistently given any input realm object in any state.
    - Previously, given an entry point, the behaviour could be dissimilar.
- Fix an issue with an invalidated `live` object, since it works with frozen objects internally now.
- In production, it is relatively easy to glitch the "available offline" function. This is now way more robust.
