### PR TITLE
chore: Release build 5.3.0-b1

### DIFF
--- a/TestFlight/WhatToTest.en-GB.txt
+++ b/TestFlight/WhatToTest.en-GB.txt
@@ -1,0 +1,3 @@
+- Single file public sharing
+- Matomo and Sentry opt-out settings
+- Stability improvements and bug fixes

--- a/TestFlight/WhatToTest.fr-FR.txt
+++ b/TestFlight/WhatToTest.fr-FR.txt
@@ -1,0 +1,3 @@
+- Partage public d'un fichier
+- Paramètres consentement Matomo et Sentry
+- Améliorations de la stabilité et corrections de bugs


### PR DESCRIPTION
Version in Tuist config is already bumped to `5.3.0`