### PR TITLE
fix: Set save button loading while the photo sync settings are saving

### DIFF
--- a/kDrive/UI/Controller/Files/Categories/EditCategoryViewController.swift
+++ b/kDrive/UI/Controller/Files/Categories/EditCategoryViewController.swift
@@ -137,7 +137,7 @@ extension EditCategoryViewController: ColorSelectionDelegate {
 // MARK: - Footer button delegate
 
 extension EditCategoryViewController: FooterButtonDelegate {
-    @objc func didClickOnButton(_ sender: AnyObject) {
+    @objc func didClickOnButton(_ sender: IKLargeButton) {
         MatomoUtils.track(eventWithCategory: .categories, name: category != nil ? "update" : "add")
         Task { [proxyFilesToAdd = filesToAdd?.map { $0.proxify() }] in
             do {

--- a/kDrive/UI/Controller/Files/DropBox/ManageDropBoxViewController.swift
+++ b/kDrive/UI/Controller/Files/DropBox/ManageDropBoxViewController.swift
@@ -318,7 +318,7 @@ extension ManageDropBoxViewController: NewFolderSettingsDelegate {
 // MARK: - FooterButtonDelegate
 
 extension ManageDropBoxViewController: FooterButtonDelegate {
-    func didClickOnButton(_ sender: AnyObject) {
+    func didClickOnButton(_ sender: IKLargeButton) {
         let password = getSetting(for: .optionPassword) ? (getValue(for: .optionPassword) as? String) : ""
         let validUntil = getSetting(for: .optionDate) ? (getValue(for: .optionDate) as? Date) : nil
         let limitFileSize: BinaryDisplaySize?

--- a/kDrive/UI/Controller/Files/Rights and Share/InviteUserViewController.swift
+++ b/kDrive/UI/Controller/Files/Rights and Share/InviteUserViewController.swift
@@ -332,7 +332,7 @@ extension InviteUserViewController: RightsSelectionDelegate {
 }
 
 extension InviteUserViewController: FooterButtonDelegate {
-    func didClickOnButton(_ sender: AnyObject) {
+    func didClickOnButton(_ sender: IKLargeButton) {
         MatomoUtils.track(eventWithCategory: .shareAndRights, name: "inviteUser")
         let settings = FileAccessSettings(
             message: message,

--- a/kDrive/UI/Controller/Files/Rights and Share/ShareLinkSettingsViewController.swift
+++ b/kDrive/UI/Controller/Files/Rights and Share/ShareLinkSettingsViewController.swift
@@ -343,7 +343,7 @@ extension ShareLinkSettingsViewController: RightsSelectionDelegate {
 // MARK: - FooterButtonDelegate
 
 extension ShareLinkSettingsViewController: FooterButtonDelegate {
-    func didClickOnButton(_ sender: AnyObject) {
+    func didClickOnButton(_ sender: IKLargeButton) {
         let right: ShareLinkPermission?
         // If we set a new password, set the right to "password"
         if getSetting(for: .optionPassword) && !newPassword {

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+FooterButtonDelegate.swift
@@ -24,7 +24,7 @@ import kDriveResources
 import UIKit
 
 extension SaveFileViewController: FooterButtonDelegate {
-    @objc func didClickOnButton(_ sender: AnyObject) {
+    @objc func didClickOnButton(_ sender: IKLargeButton) {
         guard let selectedDriveFileManager,
               let directory = selectedDirectory else {
             return

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -487,7 +487,7 @@ extension PhotoSyncSettingsViewController: SelectPhotoFormatDelegate {
 // MARK: - Footer button delegate
 
 extension PhotoSyncSettingsViewController: FooterButtonDelegate {
-    func didClickOnButton(_ sender: AnyObject) {
+    func didClickOnButton(_ sender: IKLargeButton) {
         guard freeSpaceService.hasEnoughAvailableSpaceForChunkUpload else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.errorDeviceStorage)
             return

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -488,8 +488,11 @@ extension PhotoSyncSettingsViewController: SelectPhotoFormatDelegate {
 
 extension PhotoSyncSettingsViewController: FooterButtonDelegate {
     func didClickOnButton(_ sender: IKLargeButton) {
+        sender.setLoading(true)
+
         guard freeSpaceService.hasEnoughAvailableSpaceForChunkUpload else {
             UIConstants.showSnackBarIfNeeded(error: DriveError.errorDeviceStorage)
+            sender.setLoading(false)
             return
         }
 
@@ -498,6 +501,7 @@ extension PhotoSyncSettingsViewController: FooterButtonDelegate {
         saveSettings()
         Task { @MainActor in
             self.navigationController?.popViewController(animated: true)
+            sender.setLoading(false)
         }
 
         DispatchQueue.global(qos: .userInitiated).async {

--- a/kDrive/UI/Controller/NewFolder/NewFolderViewController.swift
+++ b/kDrive/UI/Controller/NewFolder/NewFolderViewController.swift
@@ -399,7 +399,7 @@ extension NewFolderViewController: UITableViewDelegate, UITableViewDataSource {
 // MARK: - FooterButtonDelegate
 
 extension NewFolderViewController: FooterButtonDelegate {
-    func didClickOnButton(_ sender: AnyObject) {
+    func didClickOnButton(_ sender: IKLargeButton) {
         let footer = tableView.footerView(forSection: sections.count - 1) as! FooterButtonView
         footer.footerButton.setLoading(true)
         footer.footerButton.layoutIfNeeded()

--- a/kDrive/UI/Controller/Photo/SavePhotoViewController.swift
+++ b/kDrive/UI/Controller/Photo/SavePhotoViewController.swift
@@ -66,7 +66,7 @@ class SavePhotoViewController: SaveFileViewController {
         }
     }
 
-    override func didClickOnButton(_ sender: AnyObject) {
+    override func didClickOnButton(_ sender: IKLargeButton) {
         guard let filename = items.first?.name,
               let selectedDriveFileManager,
               let selectedDirectory else {

--- a/kDrive/UI/Controller/Scan/SaveScanViewController.swift
+++ b/kDrive/UI/Controller/Scan/SaveScanViewController.swift
@@ -70,7 +70,7 @@ final class SaveScanViewController: SaveFileViewController {
         }
     }
 
-    override func didClickOnButton(_ sender: AnyObject) {
+    override func didClickOnButton(_ sender: IKLargeButton) {
         let footer = tableView.footerView(forSection: sections.count - 1) as! FooterButtonView
         footer.footerButton.setLoading(true)
         guard let filename = items.first?.name,

--- a/kDrive/UI/View/Footer view/FooterButtonView.swift
+++ b/kDrive/UI/View/Footer view/FooterButtonView.swift
@@ -20,7 +20,7 @@ import kDriveCore
 import UIKit
 
 protocol FooterButtonDelegate: AnyObject {
-    func didClickOnButton(_ sender: AnyObject)
+    func didClickOnButton(_ sender: IKLargeButton)
 }
 
 class FooterButtonView: UITableViewHeaderFooterView {


### PR DESCRIPTION
Two steps
- Mini refactor to explicit that `FooterButtonDelegate` always callback with a `IKLargeButton`
- Apply the button state in the required view