### PR TITLE
chore: Bump DI to the version using an internal lock

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d562be816b65a40ccdfacce3199217a51c2fce53f7b38fed313ad01c0491986d",
+  "originHash" : "8803f52338c38731360cdb6ae5f6ad0ea9163a55ce5bbdb85bc98223b0bccc77",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-dependency-injection",
       "state" : {
-        "revision" : "f7724f3237f6e2b36fbfabacb88f2658e1e7281e",
-        "version" : "2.0.3"
+        "revision" : "86f3b77f71547b7778d2819d4d1c2d77847f2069",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "18.5.1")),
         .package(url: "https://github.com/Infomaniak/ios-features", .upToNextMajor(from: "1.0.4")),
         .package(url: "https://github.com/Infomaniak/ios-login", .upToNextMajor(from: "7.2.0")),
-        .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.3")),
+        .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.4")),
         .package(url: "https://github.com/Infomaniak/swift-concurrency", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Infomaniak/ios-version-checker", .upToNextMajor(from: "10.0.0")),
         .package(url: "https://github.com/Infomaniak/LocalizeKit", .upToNextMajor(from: "1.0.2")),


### PR DESCRIPTION
Having a discrete PR for this is a good reference point to track if any issue and/or performance improvements from the Lock based DI.
