### PR TITLE
fix: Crash on force unwrap

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
@@ -42,7 +42,7 @@ class SelectFolderViewModel: ConcreteFileListViewModel {
     }
 }
 
-class SelectFolderViewController: FileListViewController {
+final class SelectFolderViewController: FileListViewController {
     lazy var selectFolderButton: IKLargeButton = {
         let button = IKLargeButton(frame: .zero)
         button.setTitle(KDriveResourcesStrings.Localizable.buttonValid, for: .normal)

--- a/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
@@ -204,19 +204,23 @@ class SelectFolderViewController: FileListViewController {
     // MARK: - Collection view delegate
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let selectedFile = viewModel.getFile(at: indexPath)!
-        if selectedFile.isDirectory {
-            let destinationViewController = SelectFolderViewController(
-                viewModel: SelectFolderViewModel(
-                    driveFileManager: viewModel.driveFileManager,
-                    currentDirectory: selectedFile
-                ),
-                disabledDirectoriesSelection: disabledDirectoriesSelection,
-                fileToMove: fileToMove,
-                delegate: delegate,
-                selectHandler: selectHandler
-            )
-            navigationController?.pushViewController(destinationViewController, animated: true)
+        guard let navigationController,
+              let selectedFile = viewModel.getFile(at: indexPath),
+              selectedFile.isDirectory else {
+            return
         }
+
+        let destinationViewController = SelectFolderViewController(
+            viewModel: SelectFolderViewModel(
+                driveFileManager: viewModel.driveFileManager,
+                currentDirectory: selectedFile
+            ),
+            disabledDirectoriesSelection: disabledDirectoriesSelection,
+            fileToMove: fileToMove,
+            delegate: delegate,
+            selectHandler: selectHandler
+        )
+
+        navigationController.pushViewController(destinationViewController, animated: true)
     }
 }

--- a/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
@@ -194,8 +194,9 @@ final class SelectFolderViewController: FileListViewController {
     // MARK: - Collection view data source
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let file = viewModel.getFile(at: indexPath)!
+        let file = displayedFiles[indexPath.row]
         let cell = super.collectionView(collectionView, cellForItemAt: indexPath) as! FileCollectionViewCell
+
         cell.setEnabled(file.isDirectory && file.id != fileToMove)
         cell.moreButton.isHidden = true
         return cell
@@ -204,8 +205,8 @@ final class SelectFolderViewController: FileListViewController {
     // MARK: - Collection view delegate
 
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let selectedFile = displayedFiles[indexPath.row]
         guard let navigationController,
-              let selectedFile = viewModel.getFile(at: indexPath),
               selectedFile.isDirectory else {
             return
         }


### PR DESCRIPTION
Using inherited property `displayedFiles` to make sure we have a data source that reflects the view to prevent a crash