### PR TITLE
fix(FileProviderExtension): Resolve correct DI type

### DIFF
--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -54,7 +54,7 @@ extension DriveFileManager {
 
 final class FileProviderExtension: NSFileProviderExtension {
     @LazyInjectService var driveInfosManager: DriveInfosManager
-    @LazyInjectService var uploadService: UploadService
+    @LazyInjectService var uploadService: UploadServiceable
     @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
 
     /// Making sure the DI is registered at a very early stage of the app launch.


### PR DESCRIPTION
`UploadService` no longer exists within DI, we must use `UploadServiceable`
Somehow this one was missed in a recent refactor.