### PR TITLE
fix(FilePresenter): Function presentParent works again

### DIFF
--- a/kDrive/UI/Controller/Files/FilePresenter.swift
+++ b/kDrive/UI/Controller/Files/FilePresenter.swift
@@ -53,7 +53,7 @@ final class FilePresenter {
 
             navigationController.popToRootViewController(animated: false)
 
-            guard let fileListViewController = navigationController.topViewController as? FileListViewController else {
+            guard let fileListViewController = navigationController.topViewController else {
                 return
             }
 


### PR DESCRIPTION
Some navigation code that (I suspect) broke with the APIV3 migration was the culprit.

Fixes https://github.com/Infomaniak/ios-kDrive/issues/1335