### PR TITLE
fix: Text preview of large or corrupted files crashes

### DIFF
--- a/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
@@ -25,12 +25,15 @@ import UIKit
 
 /// Something to read a file outside of the main actor
 struct CodePreviewWorker {
+    /// The JS text preview library will blow up in memory usage if the input is larger
+    static let textFilePreviewCap = 512_000
+
     func readDataToStringInferEncoding(localUrl: URL) async throws -> String {
         let rawData = try Data(contentsOf: localUrl, options: .alwaysMapped)
 
         let dataToDeserialize: Data
-        if rawData.count > 512_000 {
-            dataToDeserialize = rawData.prefix(512_000)
+        if rawData.count > Self.textFilePreviewCap {
+            dataToDeserialize = rawData.prefix(Self.textFilePreviewCap)
         } else {
             dataToDeserialize = rawData
         }

--- a/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
@@ -27,14 +27,25 @@ import UIKit
 struct CodePreviewWorker {
     func readDataToStringInferEncoding(localUrl: URL) async throws -> String {
         let data = try Data(contentsOf: localUrl, options: .alwaysMapped)
-        var maybeString: NSString?
 
-        NSString.stringEncoding(for: data, convertedString: &maybeString, usedLossyConversion: nil)
-        guard let maybeString else {
-            throw DriveError.unknownError
+        let encodings: [String.Encoding] = [
+            .utf8,
+            .utf16,
+            .utf16BigEndian,
+            .utf16LittleEndian,
+            .ascii,
+            .iso2022JP
+        ]
+
+        for encoding in encodings {
+            guard let deserializedString = String(data: data, encoding: encoding) else {
+                continue
+            }
+
+            return deserializedString
         }
 
-        return maybeString as String
+        throw DriveError.unknownError
     }
 }
 

--- a/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/CodePreviewCollectionViewCell.swift
@@ -26,7 +26,14 @@ import UIKit
 /// Something to read a file outside of the main actor
 struct CodePreviewWorker {
     func readDataToStringInferEncoding(localUrl: URL) async throws -> String {
-        let data = try Data(contentsOf: localUrl, options: .alwaysMapped)
+        let rawData = try Data(contentsOf: localUrl, options: .alwaysMapped)
+
+        let dataToDeserialize: Data
+        if rawData.count > 512_000 {
+            dataToDeserialize = rawData.prefix(512_000)
+        } else {
+            dataToDeserialize = rawData
+        }
 
         let encodings: [String.Encoding] = [
             .utf8,
@@ -38,7 +45,7 @@ struct CodePreviewWorker {
         ]
 
         for encoding in encodings {
-            guard let deserializedString = String(data: data, encoding: encoding) else {
+            guard let deserializedString = String(data: dataToDeserialize, encoding: encoding) else {
                 continue
             }
 


### PR DESCRIPTION
### Abstract

Large text files will crash the app for memory over usage, and corrupted files never complete.

I managed to Swiftify the current code, reduce drastically memory usage. 
But I still had an issue with the JS preview library. So I capped the max size to be previewed.