### PR TITLE
fix(OnlyOfficeViewController): Fix status bar dark mode in OnlyOffice

### DIFF
--- a/kDrive/Resources/Assets.xcassets/Colors/onlyOfficeBackgroundColor.colorset/Contents.json
+++ b/kDrive/Resources/Assets.xcassets/Colors/onlyOfficeBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x23",
+          "green" : "0x23",
+          "red" : "0x23"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -104,6 +104,7 @@ final class OnlyOfficeViewController: UIViewController {
 
         setupWebView()
 
+        view.backgroundColor = KDriveResourcesAsset.onlyOfficeBackgroundColor.color
         view.addSubview(progressView)
         progressView.progressViewStyle = .bar
         progressView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Prevent the webview to extend on safe areas to fix a glitch in dark mode

Here is a before:
<img width="430" alt="Screenshot 2025-03-31 at 14 32 01" src="https://github.com/user-attachments/assets/3d6d0b77-f395-4ab2-8ac5-0b4aee89a92e" />

And after:
<img width="535" alt="Screenshot 2025-04-02 at 16 33 50" src="https://github.com/user-attachments/assets/e7f17828-3a09-444d-9bde-a874b9a50b49" />
<img width="528" alt="Screenshot 2025-04-02 at 16 33 42" src="https://github.com/user-attachments/assets/2441328a-4c20-4593-a843-e4315fea096c" />

