### PR TITLE
fix: OnlyOffice theme is the correct OS theme when editing a document

### DIFF
--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -138,18 +138,10 @@ final class OnlyOfficeViewController: UIViewController {
         }
     }
 
-    private func clearWebViewCache() {
+    private func clearWebViewLocalStorage() {
         let websiteDataStore = WKWebsiteDataStore.default()
-
-        let dataTypes: Set<String> = [
-            WKWebsiteDataTypeDiskCache,
-            WKWebsiteDataTypeMemoryCache,
-            WKWebsiteDataTypeCookies,
-            WKWebsiteDataTypeLocalStorage,
-            WKWebsiteDataTypeSessionStorage
-        ]
-
-        websiteDataStore.removeData(ofTypes: dataTypes, modifiedSince: Date(timeIntervalSince1970: 0)) { }
+        websiteDataStore.removeData(ofTypes: [WKWebsiteDataTypeLocalStorage],
+                                    modifiedSince: Date(timeIntervalSince1970: 0)) {}
     }
 
     private func setupWebView() {
@@ -170,7 +162,7 @@ final class OnlyOfficeViewController: UIViewController {
         webConfiguration.defaultWebpagePreferences.preferredContentMode = .mobile
 
         // Clean web cache force to apply the current OS theme to OnlyOffice
-        clearWebViewCache()
+        clearWebViewLocalStorage()
 
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
         webView.scrollView.isScrollEnabled = false

--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -138,6 +138,20 @@ final class OnlyOfficeViewController: UIViewController {
         }
     }
 
+    private func clearWebViewCache() {
+        let websiteDataStore = WKWebsiteDataStore.default()
+
+        let dataTypes: Set<String> = [
+            WKWebsiteDataTypeDiskCache,
+            WKWebsiteDataTypeMemoryCache,
+            WKWebsiteDataTypeCookies,
+            WKWebsiteDataTypeLocalStorage,
+            WKWebsiteDataTypeSessionStorage
+        ]
+
+        websiteDataStore.removeData(ofTypes: dataTypes, modifiedSince: Date(timeIntervalSince1970: 0)) { }
+    }
+
     private func setupWebView() {
         /*
          With iOS 16.1, WKWebView cannot handle SharedWorkers
@@ -151,8 +165,13 @@ final class OnlyOfficeViewController: UIViewController {
             forMainFrameOnly: false
         )
         webConfiguration.userContentController.addUserScript(dropSharedWorkersScript)
+
         // Force mobile mode for better usage on iPadOS
         webConfiguration.defaultWebpagePreferences.preferredContentMode = .mobile
+
+        // Clean web cache force to apply the current OS theme to OnlyOffice
+        clearWebViewCache()
+
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
         webView.scrollView.isScrollEnabled = false
         webView.uiDelegate = self


### PR DESCRIPTION
Had to clear the cache when creating a webView to force the correct theme color to be applied.