### PR TITLE
fix: Background refresh can freeze uploads in foreground

### DIFF
--- a/kDriveCore/Services/BackgroundTasksService.swift
+++ b/kDriveCore/Services/BackgroundTasksService.swift
@@ -77,9 +77,17 @@ struct BackgroundTasksService: BackgroundTasksServiceable {
 
         task.expirationHandler = {
             Log.backgroundTaskScheduling("Task \(identifier) EXPIRED", level: .error)
+            defer {
+                task.setTaskCompleted(success: false)
+            }
+
+            if UIApplication.shared.applicationState != .background {
+                Log.backgroundTaskScheduling("Task \(identifier) EXPIRED not in BACKGROUND", level: .error)
+                return
+            }
+
             uploadService.suspendAllOperations()
             uploadService.rescheduleRunningOperations()
-            task.setTaskCompleted(success: false)
         }
     }
 

--- a/kDriveCore/Services/BackgroundTasksService.swift
+++ b/kDriveCore/Services/BackgroundTasksService.swift
@@ -64,6 +64,12 @@ struct BackgroundTasksService: BackgroundTasksServiceable {
     public func buildBackgroundTask(_ task: BGTask, identifier: String) {
         scheduleBackgroundRefresh()
 
+        if UIApplication.shared.applicationState != .background {
+            Log.backgroundTaskScheduling("Task \(identifier) only active in BACKGROUND")
+            task.setTaskCompleted(success: true)
+            return
+        }
+
         handleBackgroundRefresh { _ in
             Log.backgroundTaskScheduling("Task \(identifier) completed with SUCCESS")
             task.setTaskCompleted(success: true)


### PR DESCRIPTION
### Abstract

I found a bug where the `background upload` feature can trigger while the app is running in the foreground. 
This tends to be while the app is running long photo sync uploads.

When the `background upload` is _then_ asked by the system to suspend, the uploads are frozen without the ability to restart without killing the app.

This PR simply reschedule the background task later, and exit gracefully.