### PR TITLE
fix: Reduce upload memory footprint when app is not active

### DIFF
--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/UploadParallelismOrchestrator.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/UploadParallelismOrchestrator.swift
@@ -35,7 +35,7 @@ public final class UploadParallelismOrchestrator {
 
     private var availableParallelism: Int {
         guard let uploadParallelismHeuristic else {
-            return ParallelismDefaults.reducedParallelism
+            return ParallelismDefaults.reduced
         }
         return uploadParallelismHeuristic.currentParallelism
     }

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -88,7 +88,7 @@ public final class WorkloadParallelismHeuristic {
         }
     }
 
-    private func computeParallelism() {
+    private func computeParallelism() async {
         let processInfo = ProcessInfo.processInfo
 
         // If the device is too hot we cool down now
@@ -111,7 +111,7 @@ public final class WorkloadParallelismHeuristic {
         }
 
         // In state .background or .inactive, to reduce memory footprint, we reduce drastically parallelism
-        guard UIApplication.shared.applicationState == .active else {
+        guard await appIsActive else {
             currentParallelism = ParallelismDefaults.reducedParallelism
             return
         }
@@ -122,6 +122,10 @@ public final class WorkloadParallelismHeuristic {
         // Beginning with .serious state, we start reducing the load on the system
         guard thermalState != .serious else {
             currentParallelism = max(ParallelismDefaults.reducedParallelism, parallelism / 2)
+            return
+        }
+
+        guard !Task.isCancelled else {
             return
         }
 

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -22,11 +22,11 @@ import InfomaniakDI
 import UIKit
 
 public enum ParallelismDefaults {
-    static let highParallelism = 6
+    static let high = 6
 
-    static let mediumParallelism = 4
+    static let medium = 4
 
-    static let reducedParallelism = 2
+    static let reduced = 2
 
     static let serial = 1
 }
@@ -136,25 +136,25 @@ public final class WorkloadParallelismHeuristic {
         // If the device is too hot we cool down now
         let thermalState = processInfo.thermalState
         guard thermalState != .critical else {
-            currentParallelism = ParallelismDefaults.reducedParallelism
+            currentParallelism = ParallelismDefaults.reduced
             return
         }
 
         // In low power mode, we reduce parallelism
         guard !processInfo.isLowPowerModeEnabled else {
-            currentParallelism = ParallelismDefaults.reducedParallelism
+            currentParallelism = ParallelismDefaults.reduced
             return
         }
 
         // In extension, to reduce memory footprint, we reduce drastically parallelism
         guard !appContextService.isExtension else {
-            currentParallelism = ParallelismDefaults.reducedParallelism
+            currentParallelism = ParallelismDefaults.reduced
             return
         }
 
         // In state .background or .inactive, to reduce memory footprint, we reduce drastically parallelism
         guard await appIsActive else {
-            currentParallelism = ParallelismDefaults.reducedParallelism
+            currentParallelism = ParallelismDefaults.reduced
             return
         }
 
@@ -163,7 +163,7 @@ public final class WorkloadParallelismHeuristic {
 
         // Beginning with .serious state, we start reducing the load on the system
         guard thermalState != .serious else {
-            currentParallelism = max(ParallelismDefaults.reducedParallelism, parallelism / 2)
+            currentParallelism = max(ParallelismDefaults.reduced, parallelism / 2)
             return
         }
 

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -82,10 +82,18 @@ public final class WorkloadParallelismHeuristic {
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.NSProcessInfoPowerStateDidChange, object: nil)
     }
 
-    @objc private func computeParallelismInQueue() {
-        serialEventQueue.async {
-            self.computeParallelism()
+    @objc private func computeParallelismInTask() {
+        computeTask?.cancel()
+
+        let computeParallelismTask = Task {
+            await computeParallelism()
         }
+
+        computeTask = computeParallelismTask
+    }
+
+    @MainActor private var appIsActive: Bool {
+        UIApplication.shared.applicationState == .active
     }
 
     private func computeParallelism() async {

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -45,6 +45,8 @@ public protocol ParallelismHeuristicDelegate: AnyObject {
 public final class WorkloadParallelismHeuristic {
     @LazyInjectService private var appContextService: AppContextServiceable
 
+    private weak var delegate: ParallelismHeuristicDelegate?
+
     private var computeTask: Task<Void, Never>?
 
     private let serialEventQueue = DispatchQueue(
@@ -52,11 +54,8 @@ public final class WorkloadParallelismHeuristic {
         qos: .default
     )
 
-    private weak var delegate: ParallelismHeuristicDelegate?
-
     init(delegate: ParallelismHeuristicDelegate) {
         self.delegate = delegate
-
         setupObservation()
     }
 
@@ -159,7 +158,8 @@ public final class WorkloadParallelismHeuristic {
         }
 
         // Scaling with the number of activeProcessor to a point
-        let parallelism = min(6, max(4, processInfo.activeProcessorCount))
+        let parallelism = min(ParallelismDefaults.high,
+                              max(ParallelismDefaults.medium, processInfo.activeProcessorCount))
 
         // Beginning with .serious state, we start reducing the load on the system
         guard thermalState != .serious else {

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -110,6 +110,12 @@ public final class WorkloadParallelismHeuristic {
             return
         }
 
+        // In state .background or .inactive, to reduce memory footprint, we reduce drastically parallelism
+        guard UIApplication.shared.applicationState == .active else {
+            currentParallelism = ParallelismDefaults.reducedParallelism
+            return
+        }
+
         // Scaling with the number of activeProcessor to a point
         let parallelism = min(6, max(4, processInfo.activeProcessorCount))
 

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -110,8 +110,8 @@ public final class WorkloadParallelismHeuristic {
             return
         }
 
-        // Scaling with the number of activeProcessor
-        let parallelism = max(4, processInfo.activeProcessorCount)
+        // Scaling with the number of activeProcessor to a point
+        let parallelism = min(6, max(4, processInfo.activeProcessorCount))
 
         // Beginning with .serious state, we start reducing the load on the system
         guard thermalState != .serious else {

--- a/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/Parallelism/WorkloadParallelismHeuristic.swift
@@ -174,9 +174,19 @@ public final class WorkloadParallelismHeuristic {
         currentParallelism = parallelism
     }
 
-    public private(set) var currentParallelism = ParallelismDefaults.reducedParallelism {
+    private var _currentParallelism = ParallelismDefaults.serial {
         didSet {
-            delegate?.parallelismShouldChange(value: currentParallelism)
+            delegate?.parallelismShouldChange(value: _currentParallelism)
+        }
+    }
+
+    public private(set) var currentParallelism: Int {
+        get {
+            _currentParallelism
+        }
+        set {
+            guard _currentParallelism != newValue else { return }
+            _currentParallelism = newValue
         }
     }
 }


### PR DESCRIPTION
### Abstract

When the app is in `background` or `innactive` the limit for memory usage is lower.
In order to stay alive, it is best to reduce uploads on these states.
I now track app state in order to modulate upload parallelism, and prevent app from crashing.