### PR TITLE
feat: Photo sync default to wifi only on new installs

### DIFF
--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -75,7 +75,9 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         if let settings = photoUploader.frozenSettings {
             return PhotoSyncSettings(value: settings as Any)
         } else {
-            return PhotoSyncSettings()
+            let syncSetting = PhotoSyncSettings()
+            syncSetting.wifiSync = .onlyWifi
+            return syncSetting
         }
     }()
 


### PR DESCRIPTION
New installs defaults to WIFI only for photo sync.
Migration in unchanged.