### PR TITLE
fix: Correct empty view display logic

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -340,7 +340,7 @@ class FileListViewModel: SelectDelegate {
         isLoading = false
         isRefreshing = false
         currentDirectory = getRefreshedCurrentDirectory()
-        isShowingEmptyView = currentDirectory.children.isEmpty && currentDirectory.fullyDownloaded
+        isShowingEmptyView = shouldShowEmptyView()
     }
 
     func loadActivities() async throws {


### PR DESCRIPTION
Pull to refresh no longer display empty view on offline folder when non empty