### PR TITLE
refactor: Removed photo scan batching

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -339,9 +339,12 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
     }
 
     private func bindUploadCardViewModel() {
-        viewModel.uploadViewModel?.$uploadCount.receiveOnMain(store: &bindStore) { [weak self] uploadCount in
-            self?.updateUploadCard(uploadCount: uploadCount)
-        }
+        viewModel.uploadViewModel?.$uploadCount
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] uploadCount in
+                self?.updateUploadCard(uploadCount: uploadCount)
+            }
+            .store(in: &bindStore)
     }
 
     private func bindMultipleSelectionViewModel() {

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -72,7 +72,7 @@ final class UploadQueueViewController: UIViewController {
         ReachabilityListener.instance.observeNetworkChange(self) { [weak self] _ in
             Task { @MainActor in
                 guard let self else { return }
-                self?.reloadCollectionView(with: nil)
+                self.reloadCollectionView(with: self.frozenUploadingFiles)
             }
         }
     }
@@ -92,7 +92,7 @@ final class UploadQueueViewController: UIViewController {
             case .change(let object, _):
                 guard let syncSettings = object as? PhotoSyncSettings else { return }
                 self.isWifiOnly = syncSettings.isWifiOnly
-                reloadCollectionView(with: nil)
+                reloadCollectionView(with: self.frozenUploadingFiles)
             case .error(let error):
                 DDLogError("[Realm Observation] Error sync settings \(error)")
             case .deleted:

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -96,7 +96,7 @@ public extension PhotoLibraryUploader {
             var burstIdentifier: String?
             var burstCount = 0
 
-            assetsFetchResult.enumerateObjects { [self] asset, idx, stop in
+            assetsFetchResult.enumerateObjects { [self] asset, _, stop in
                 guard !expiringActivity.shouldTerminate else {
                     Log.photoLibraryUploader("system is asking to terminate")
                     stop.pointee = true


### PR DESCRIPTION
#### Abstract

Hashing media assets during photo sync scan can take a long time.
This is performed inside a batched DB transaction. 
This locks the DB in write for the time of a batch of 100 files.
Any write operation on this realm somewhere else will be locking.
Eg. If a user tries to edit sync settings during a batch scan, it can lock the main queue, to a point where the OS will kill the app.

#### Solution
Here I remove completely the DB write batching for the photo sync.
`UploadFile`s are added one by one.

I just make sure the UI correctly `throttle` display and refresh of the views. 
Most screens were already ready for this.
Upload progress is tracked by cell, so it is unchanged by added `throttle` operations
Diffkit calls are unchanged in lists, `throttle` is applied beforehand.

CPU usage is mostly unchanged during scan and uploads.
`main queue` load is reduced as `throttle` is applied in a background queue in the upload screen.



Superseding https://github.com/Infomaniak/ios-kDrive/pull/1522