### PR TITLE
fix: Correctly set isWifiOnly default value in user defaults on clean install

### DIFF
--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -77,6 +77,7 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         } else {
             let syncSetting = PhotoSyncSettings()
             syncSetting.wifiSync = .onlyWifi
+            UserDefaults.shared.isWifiOnly = true
             return syncSetting
         }
     }()


### PR DESCRIPTION
On a clean install, the Wi-Fi only setting was set in base, not in UserDefaults.