### PR TITLE
fix: Crash in upload queue view controller

### DIFF
--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -48,7 +48,7 @@ final class UploadQueueViewController: UIViewController {
     var currentDirectory: File!
     private var frozenUploadingFiles = [UploadFileDisplayed]()
     private lazy var sections = buildSections(files: [UploadFileDisplayed]())
-    private var notificationToken: NotificationToken?
+    private var observedFilesNotificationToken: NotificationToken?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -95,7 +95,7 @@ final class UploadQueueViewController: UIViewController {
     }
 
     deinit {
-        notificationToken?.invalidate()
+        observedFilesNotificationToken?.invalidate()
         wifiOnlyNotificationToken?.invalidate()
     }
 
@@ -104,12 +104,12 @@ final class UploadQueueViewController: UIViewController {
             return
         }
 
-        notificationToken?.invalidate()
+        observedFilesNotificationToken?.invalidate()
 
         let observedFiles = AnyRealmCollection(uploadDataSource.getUploadingFiles(withParent: currentDirectory.id,
                                                                                   userId: accountManager.currentUserId,
                                                                                   driveId: currentDirectory.driveId))
-        notificationToken = observedFiles.observe(keyPaths: UploadFile.observedProperties, on: .main) { [weak self] change in
+        observedFilesNotificationToken = observedFiles.observe(keyPaths: UploadFile.observedProperties, on: .main) { [weak self] change in
             guard let self else {
                 return
             }

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -29,7 +29,7 @@ typealias UploadFileDisplayed = CornerCellContainer<UploadFile>
 
 final class UploadQueueViewController: UIViewController {
     private let errorFile = UploadFileDisplayed(isFirstInList: true, isLastInList: true, content: UploadFile())
-    private var isWifiOnly: Bool = false
+    private var isWifiOnly = false
     private var wifiOnlyNotificationToken: NotificationToken?
 
     enum SectionModel: Differentiable {

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -65,7 +65,7 @@ final class UploadQueueViewController: UIViewController {
 
         ReachabilityListener.instance.observeNetworkChange(self) { [weak self] _ in
             Task { @MainActor in
-                self?.reloadCollectionView()
+                self?.reloadCollectionView(with: nil)
             }
         }
     }

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -214,7 +214,7 @@ extension UploadQueueViewController: UITableViewDataSource {
             }
 
             let progress: CGFloat? = (file.progress != nil) ? CGFloat(file.progress!) : nil
-            cell.configureWith(frozenUploadFile: file, progress: progress)
+            cell.configureWith(frozenUploadFile: file, progress: progress, isUploadLimited: isUploadLimited)
             cell.selectionStyle = .none
             return cell
         }

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -109,36 +109,37 @@ final class UploadQueueViewController: UIViewController {
         let observedFiles = AnyRealmCollection(uploadDataSource.getUploadingFiles(withParent: currentDirectory.id,
                                                                                   userId: accountManager.currentUserId,
                                                                                   driveId: currentDirectory.driveId))
-        observedFilesNotificationToken = observedFiles.observe(keyPaths: UploadFile.observedProperties, on: .main) { [weak self] change in
-            guard let self else {
-                return
-            }
+        observedFilesNotificationToken = observedFiles
+            .observe(keyPaths: UploadFile.observedProperties, on: .main) { [weak self] change in
+                guard let self else {
+                    return
+                }
 
-            let newResults: AnyRealmCollection<UploadFile>?
-            switch change {
-            case .initial(let results):
-                newResults = results
-            case .update(let results, _, _, _):
-                newResults = results
-            case .error(let error):
-                newResults = nil
-                DDLogError("Realm observer error: \(error)")
-            }
+                let newResults: AnyRealmCollection<UploadFile>?
+                switch change {
+                case .initial(let results):
+                    newResults = results
+                case .update(let results, _, _, _):
+                    newResults = results
+                case .error(let error):
+                    newResults = nil
+                    DDLogError("Realm observer error: \(error)")
+                }
 
-            guard let newResults else {
-                reloadCollectionView(with: [])
-                return
-            }
+                guard let newResults else {
+                    reloadCollectionView(with: [])
+                    return
+                }
 
-            let wrappedFrozenFiles = newResults.enumerated().map { index, file in
-                let frozenFile = file.freeze()
-                return UploadFileDisplayed(isFirstInList: index == 0,
-                                           isLastInList: index == newResults.count - 1,
-                                           content: frozenFile)
-            }
+                let wrappedFrozenFiles = newResults.enumerated().map { index, file in
+                    let frozenFile = file.freeze()
+                    return UploadFileDisplayed(isFirstInList: index == 0,
+                                               isLastInList: index == newResults.count - 1,
+                                               content: frozenFile)
+                }
 
-            reloadCollectionView(with: wrappedFrozenFiles)
-        }
+                reloadCollectionView(with: wrappedFrozenFiles)
+            }
     }
 
     @MainActor func reloadCollectionView(with frozenFiles: [UploadFileDisplayed]? = nil) {

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -34,7 +34,6 @@ final class UploadTableViewCell: InsetTableViewCell {
     private var progressObservation: NotificationToken?
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) private var uploadsDatabase: Transactionable
     @LazyInjectService var uploadService: UploadServiceable
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
+++ b/kDrive/UI/View/Files/Upload/UploadTableViewCell.swift
@@ -28,7 +28,7 @@ import UIKit
 final class UploadTableViewCell: InsetTableViewCell {
     // This view is reused if FileListCollectionView header
     @IBOutlet var cardContentView: UploadCardView!
-    private var isUploadLimited: Bool = false
+    private var isUploadLimited = false
     private var currentFileId: String?
     private var thumbnailRequest: UploadFile.ThumbnailRequest?
     private var progressObservation: NotificationToken?

--- a/kDriveCore/Data/Cache/PhotoSyncSettings.swift
+++ b/kDriveCore/Data/Cache/PhotoSyncSettings.swift
@@ -102,3 +102,9 @@ public final class PhotoSyncSettings: Object {
             wifiSync == settings.wifiSync
     }
 }
+
+public extension PhotoSyncSettings {
+    var isWifiOnly: Bool {
+        return wifiSync == .onlyWifi
+    }
+}

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -51,8 +51,7 @@ public extension PhotoLibraryUploader {
                 }
             }
 
-            writableRealm.delete(writableRealm.objects(PhotoSyncSettings.self))
-            writableRealm.add(liveNewSyncSettings)
+            writableRealm.add(liveNewSyncSettings, update: .all)
         }
     }
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -49,11 +49,14 @@ public final class PhotoLibraryUploader {
         case importCancelledBySystem
     }
 
-    public var frozenSettings: PhotoSyncSettings? {
-        let settings = uploadsDatabase.fetchObject(ofType: PhotoSyncSettings.self) { lazyCollection in
+    public var liveSettings: PhotoSyncSettings? {
+        return uploadsDatabase.fetchObject(ofType: PhotoSyncSettings.self) { lazyCollection in
             lazyCollection.first
         }
+    }
 
+    public var frozenSettings: PhotoSyncSettings? {
+        let settings = liveSettings
         return settings?.freeze()
     }
 
@@ -65,7 +68,7 @@ public final class PhotoLibraryUploader {
         guard let frozenSettings else {
             return false
         }
-        return frozenSettings.wifiSync == .onlyWifi
+        return frozenSettings.isWifiOnly
     }
 
     public init() {


### PR DESCRIPTION
#### Abstract

`UploadQueueViewController` had issues working with sync settings from Realm (instead of user defaults).
This PR aims at observing the settings in order to work seamlessly with settings when they get updated.