### PR TITLE
fix: Download action loading state was incorrect

### DIFF
--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -202,7 +202,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         downloadObserver = downloadQueue
             .observeFileDownloaded(observerViewController, fileId: frozenFile.id) { [weak self] _, error in
                 self?.downloadAction = nil
-                self?.setLoading(true, action: action, at: indexPath)
+                self?.setLoading(false, action: action, at: indexPath)
                 Task { @MainActor in
                     guard error == nil else {
                         UIConstants.showSnackBarIfNeeded(error: DriveError.downloadFailed)


### PR DESCRIPTION
Fixed :
![AGXS9228-ezgif com-resize](https://github.com/user-attachments/assets/71ceaed2-312c-42f6-92ca-e32c453b55e6)
