### PR TITLE
fix: Correctly setup observation in order to prevent a performance issue

### DIFF
--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -600,6 +600,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
         Task { @MainActor [weak self] in
             guard let self else { return }
 
+            self.updateFileForCurrentIndex()
             currentDownloadOperation = nil
 
             guard view.window != nil else { return }


### PR DESCRIPTION
On a first download and display of a PDF there was a scroll performance issue.
By correctly setting things up like when loading from local cache it just works.