### PR TITLE
fix: Delete photos in realm when we change drive for sync

### DIFF
--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -687,7 +687,7 @@ public struct AppRouter: AppNavigable {
 
         Log.sceneDelegate("Restart queue")
         @InjectService var photoScan: PhotoLibraryScanable
-        photoScan.scheduleNewPicturesForUpload()
+        await photoScan.scheduleNewPicturesForUpload()
 
         // Resolving an upload queue will restart it if this is the first time
         @InjectService var uploadService: UploadServiceable

--- a/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
@@ -19,6 +19,7 @@
 import DropDown
 import InfomaniakCore
 import InfomaniakCoreCommonUI
+import InfomaniakCoreDB
 import InfomaniakDI
 import kDriveCore
 import UIKit
@@ -173,6 +174,15 @@ extension SelectDriveViewController: UITableViewDelegate {
             dropDown.show()
         case .selectDrive:
             let drive = driveList[indexPath.row]
+            if selectedDrive?.objectId != drive.objectId {
+                @InjectService var uploadDataSource: UploadServiceDataSourceable
+                @InjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
+                let objectsToDelete = uploadDataSource
+                    .getUploadedFiles(optionalPredicate: PhotoLibraryCleanerService.photoAssetPredicate)
+                try? uploadsDatabase.writeTransaction { writableRealm in
+                    writableRealm.delete(objectsToDelete)
+                }
+            }
             delegate?.didSelectDrive(drive)
             if let navigationController {
                 navigationController.popViewController(animated: true)

--- a/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
@@ -174,15 +174,6 @@ extension SelectDriveViewController: UITableViewDelegate {
             dropDown.show()
         case .selectDrive:
             let drive = driveList[indexPath.row]
-            if selectedDrive?.objectId != drive.objectId {
-                @InjectService var uploadDataSource: UploadServiceDataSourceable
-                @InjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
-                let objectsToDelete = uploadDataSource
-                    .getUploadedFiles(optionalPredicate: PhotoLibraryCleanerService.photoAssetPredicate)
-                try? uploadsDatabase.writeTransaction { writableRealm in
-                    writableRealm.delete(objectsToDelete)
-                }
-            }
             delegate?.didSelectDrive(drive)
             if let navigationController {
                 navigationController.popViewController(animated: true)

--- a/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
@@ -19,7 +19,6 @@
 import DropDown
 import InfomaniakCore
 import InfomaniakCoreCommonUI
-import InfomaniakCoreDB
 import InfomaniakDI
 import kDriveCore
 import UIKit

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -248,7 +248,6 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
 
             @InjectService var photoLibraryScan: PhotoLibraryScanable
             photoLibraryScan.scheduleNewPicturesForUpload()
-            @InjectService var uploadService: UploadServiceable
             uploadService.rebuildUploadQueue()
         }
     }
@@ -493,7 +492,6 @@ extension PhotoSyncSettingsViewController {
 
 extension PhotoSyncSettingsViewController: SelectDriveDelegate {
     func didSelectDrive(_ drive: Drive) {
-        let previousDriveId = driveFileManager?.driveId
         driveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: drive.userId)
         selectedDirectory = nil
         updateSaveButtonState()

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -33,7 +33,6 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
     @LazyInjectService var freeSpaceService: FreeSpaceService
     @LazyInjectService var uploadService: UploadServiceable
-    @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
 
     private enum PhotoSyncSection: Int {
         case syncSwitch
@@ -231,14 +230,6 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         guard photoSyncEnabled else {
             photoLibrarySync.disableSync()
             return
-        }
-
-        if didDriveSelectionChange {
-            let objectsToDelete = uploadDataSource
-                .getUploadedFiles(optionalPredicate: PhotoLibraryCleanerService.photoAssetPredicate)
-            try? uploadsDatabase.writeTransaction { writableRealm in
-                writableRealm.delete(objectsToDelete)
-            }
         }
 
         let newSettings = PhotoSyncSettings(value: liveNewSyncSettings)

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -83,7 +83,6 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         }
     }()
 
-    private var didDriveSelectionChange = false
     private var photoSyncEnabled: Bool = InjectService<PhotoLibraryUploadable>().wrappedValue.isSyncEnabled
     private var selectedDirectory: File? {
         didSet {
@@ -495,9 +494,6 @@ extension PhotoSyncSettingsViewController {
 extension PhotoSyncSettingsViewController: SelectDriveDelegate {
     func didSelectDrive(_ drive: Drive) {
         let previousDriveId = driveFileManager?.driveId
-        if previousDriveId != drive.id {
-            didDriveSelectionChange = true
-        }
         driveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: drive.userId)
         selectedDirectory = nil
         updateSaveButtonState()

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -33,6 +33,7 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
     @LazyInjectService var freeSpaceService: FreeSpaceService
     @LazyInjectService var uploadService: UploadServiceable
+    @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
 
     private enum PhotoSyncSection: Int {
         case syncSwitch
@@ -233,8 +234,6 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         }
 
         if didDriveSelectionChange {
-            @InjectService var uploadDataSource: UploadServiceDataSourceable
-            @InjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
             let objectsToDelete = uploadDataSource
                 .getUploadedFiles(optionalPredicate: PhotoLibraryCleanerService.photoAssetPredicate)
             try? uploadsDatabase.writeTransaction { writableRealm in

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -232,24 +232,7 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         }
 
         let newSettings = PhotoSyncSettings(value: liveNewSyncSettings)
-        let shouldReset = photoLibrarySync.enableSync(newSettings)
-
-        Task {
-            if shouldReset {
-                await photoLibrarySync.cleanUploadedPhotos()
-            }
-
-            uploadService.retryAllOperations(
-                withParent: newSettings.parentDirectoryId,
-                userId: newSettings.userId,
-                driveId: newSettings.driveId
-            )
-            uploadService.updateQueueSuspension()
-
-            @InjectService var photoLibraryScan: PhotoLibraryScanable
-            photoLibraryScan.scheduleNewPicturesForUpload()
-            uploadService.rebuildUploadQueue()
-        }
+        photoLibrarySync.enableSync(newSettings)
     }
 
     private func requestAuthorization() async -> PHAuthorizationStatus {

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -233,13 +233,25 @@ final class PhotoSyncSettingsViewController: BaseGroupedTableViewController {
         }
 
         let newSettings = PhotoSyncSettings(value: liveNewSyncSettings)
-        photoLibrarySync.enableSync(newSettings)
-        uploadService.retryAllOperations(
-            withParent: newSettings.parentDirectoryId,
-            userId: newSettings.userId,
-            driveId: newSettings.driveId
-        )
-        uploadService.updateQueueSuspension()
+        let shouldReset = photoLibrarySync.enableSync(newSettings)
+
+        Task {
+            if shouldReset {
+                await photoLibrarySync.cleanUploadedPhotos()
+            }
+
+            uploadService.retryAllOperations(
+                withParent: newSettings.parentDirectoryId,
+                userId: newSettings.userId,
+                driveId: newSettings.driveId
+            )
+            uploadService.updateQueueSuspension()
+
+            @InjectService var photoLibraryScan: PhotoLibraryScanable
+            photoLibraryScan.scheduleNewPicturesForUpload()
+            @InjectService var uploadService: UploadServiceable
+            uploadService.rebuildUploadQueue()
+        }
     }
 
     private func requestAuthorization() async -> PHAuthorizationStatus {
@@ -544,17 +556,10 @@ extension PhotoSyncSettingsViewController: FooterButtonDelegate {
         trackPhotoSync(isEnabled: photoSyncEnabled, with: liveNewSyncSettings)
 
         saveSettings()
+
         Task { @MainActor in
             self.navigationController?.popViewController(animated: true)
             sender.setLoading(false)
-        }
-
-        DispatchQueue.global(qos: .default).async {
-            // Add new pictures to be uploaded and reload upload queue
-            @InjectService var photoLibraryScan: PhotoLibraryScanable
-            photoLibraryScan.scheduleNewPicturesForUpload()
-            @InjectService var uploadService: UploadServiceable
-            uploadService.rebuildUploadQueue()
         }
     }
 }

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryCleanerService.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryCleanerService.swift
@@ -43,7 +43,7 @@ public struct PhotoLibraryCleanerService: PhotoLibraryCleanerServiceable {
     static let removeAssetsCountThreshold = 10
 
     /// A predicate to only keep the `phAsset`
-    static let photoAssetPredicate = NSPredicate(format: "rawType = %@", argumentArray: [UploadFileType.phAsset.rawValue])
+    public static let photoAssetPredicate = NSPredicate(format: "rawType = %@", argumentArray: [UploadFileType.phAsset.rawValue])
 
     /// `True` if feature setting is ON
     private var removePictureEnabled: Bool {

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -23,21 +23,18 @@ import Photos
 import RealmSwift
 
 public protocol PhotoLibraryScanable {
-    @discardableResult func scheduleNewPicturesForUpload() -> Int
+    func scheduleNewPicturesForUpload()
     func cancelScan() async
 }
 
 extension PhotoLibraryUploader: PhotoLibraryScanable {
-    @discardableResult
-    public func scheduleNewPicturesForUpload() -> Int {
+    public func scheduleNewPicturesForUpload() {
         Log.photoLibraryUploader("scheduleNewPicturesForUpload")
         guard let frozenSettings,
               PHPhotoLibrary.authorizationStatus() == .authorized else {
             Log.photoLibraryUploader("0 new assets")
-            return 0
+            return
         }
-
-        var newAssetsCount = 0
 
         Task {
             await cancelScan()
@@ -69,8 +66,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
                         updateLastSyncDate(syncDate, writableRealm: writableRealm)
                     }
 
-                    newAssetsCount = assetsFetchResult.count
-                    Log.photoLibraryUploader("New assets count:\(newAssetsCount)")
+                    Log.photoLibraryUploader("New assets count:\(assetsFetchResult.count)")
                 } catch ErrorDomain.importCancelledBySystem {
                     Log.photoLibraryUploader("System is requesting to stop", level: .error)
                 } catch {
@@ -78,8 +74,6 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
                 }
             }
         }
-
-        return newAssetsCount
     }
 
     public func cancelScan() async {

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -60,7 +60,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
                 )
 
                 if Task.isCancelled {
-                    Log.photoLibraryUploader("Scan Task cancelled")
+                    Log.photoLibraryUploader("Scan Task cancelled before updating last sync date")
                     return
                 }
 
@@ -162,7 +162,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
             )
 
             if Task.isCancelled {
-                Log.photoLibraryUploader("Scan Task cancelled")
+                Log.photoLibraryUploader("Scan Task cancelled before hashing asset")
                 stop.pointee = true
                 return
             }
@@ -179,7 +179,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
             Log.photoLibraryUploader("Asset hash:\(String(describing: bestResourceSHA256))")
 
             guard !expiringActivity.shouldTerminate, !Task.isCancelled else {
-                Log.photoLibraryUploader("Scan Task cancelled")
+                Log.photoLibraryUploader("Scan Task cancelled after hashing asset")
                 stop.pointee = true
                 return
             }

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -75,7 +75,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
         }
 
         workerTask = worker
-        await worker.finish()
+        await worker.value
     }
 
     public func cancelScan() async {
@@ -84,7 +84,7 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
         }
 
         workerTask.cancel()
-        await workerTask.finish()
+        await workerTask.value
         self.workerTask = nil
     }
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -24,6 +24,7 @@ import RealmSwift
 
 public protocol PhotoLibraryScanable {
     @discardableResult func scheduleNewPicturesForUpload() -> Int
+    func cancelScan()
 }
 
 extension PhotoLibraryUploader: PhotoLibraryScanable {
@@ -38,7 +39,8 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
 
         var newAssetsCount = 0
 
-        serialQueue.sync {
+        cancelScan()
+        workerTask = Task {
             let options = PHFetchOptions()
             options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
 
@@ -71,6 +73,11 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
         }
 
         return newAssetsCount
+    }
+
+    public func cancelScan() {
+        workerTask?.cancel()
+        workerTask = nil
     }
 
     // MARK: - Private

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -82,7 +82,7 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
 
     private func postSaveSettings(shouldReset: Bool, parentDirectoryId: Int, userId: Int, driveId: Int) async {
         @InjectService var photoLibraryScan: PhotoLibraryScanable
-        photoLibraryScan.cancelScan()
+        await photoLibraryScan.cancelScan()
 
         if shouldReset {
             try? await uploadService.cancelAnyPhotoSync()
@@ -107,7 +107,7 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
 
         Task {
             @InjectService var photoLibraryScan: PhotoLibraryScanable
-            photoLibraryScan.cancelScan()
+            await photoLibraryScan.cancelScan()
 
             do {
                 try await uploadService.cancelAnyPhotoSync()

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -96,7 +96,7 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
         )
         uploadService.updateQueueSuspension()
 
-        photoLibraryScan.scheduleNewPicturesForUpload()
+        await photoLibraryScan.scheduleNewPicturesForUpload()
         uploadService.rebuildUploadQueue()
     }
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -61,6 +61,8 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
                 }
             }
 
+            let oldSettings = writableRealm.objects(PhotoSyncSettings.self)
+            writableRealm.delete(oldSettings)
             writableRealm.add(liveNewSyncSettings, update: .all)
         }
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -28,7 +28,8 @@ public protocol PhotoLibrarySyncable {
 extension PhotoLibraryUploader: PhotoLibrarySyncable {
     @MainActor public func enableSync(_ liveNewSyncSettings: PhotoSyncSettings) {
         let currentSyncSettings = frozenSettings
-        let shouldReset = currentSyncSettings?.driveId != liveNewSyncSettings.driveId
+        let shouldReset = (currentSyncSettings?.driveId != liveNewSyncSettings.driveId)
+            || (currentSyncSettings?.userId != liveNewSyncSettings.userId)
         try? uploadsDatabase.writeTransaction { writableRealm in
             guard liveNewSyncSettings.userId != -1,
                   liveNewSyncSettings.driveId != -1,

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -82,6 +82,7 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
 
     private func postSaveSettings(shouldReset: Bool, parentDirectoryId: Int, userId: Int, driveId: Int) async {
         if shouldReset {
+            try? await uploadService.cancelAnyPhotoSync()
             await forgetUploadedPhotos()
         }
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -87,6 +87,8 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
         if shouldReset {
             try? await uploadService.cancelAnyPhotoSync()
             await forgetUploadedPhotos()
+            @InjectService(customTypeIdentifier: UploadQueueID.photo) var photoUploadQueue: UploadQueueable
+            photoUploadQueue.cancelAllOperations()
         }
 
         uploadService.retryAllOperations(

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -81,6 +81,9 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
     }
 
     private func postSaveSettings(shouldReset: Bool, parentDirectoryId: Int, userId: Int, driveId: Int) async {
+        @InjectService var photoLibraryScan: PhotoLibraryScanable
+        photoLibraryScan.cancelScan()
+
         if shouldReset {
             try? await uploadService.cancelAnyPhotoSync()
             await forgetUploadedPhotos()
@@ -93,7 +96,6 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
         )
         uploadService.updateQueueSuspension()
 
-        @InjectService var photoLibraryScan: PhotoLibraryScanable
         photoLibraryScan.scheduleNewPicturesForUpload()
         uploadService.rebuildUploadQueue()
     }

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -23,7 +23,6 @@ import RealmSwift
 public protocol PhotoLibrarySyncable {
     @MainActor func enableSync(_ liveNewSyncSettings: PhotoSyncSettings)
     func disableSync()
-    func cleanUploadedPhotos() async
 }
 
 extension PhotoLibraryUploader: PhotoLibrarySyncable {
@@ -82,7 +81,7 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
 
     private func postSaveSettings(shouldReset: Bool, parentDirectoryId: Int, userId: Int, driveId: Int) async {
         if shouldReset {
-            await cleanUploadedPhotos()
+            await forgetUploadedPhotos()
         }
 
         uploadService.retryAllOperations(
@@ -105,14 +104,14 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
         Task {
             do {
                 try await uploadService.cancelAnyPhotoSync()
-                await cleanUploadedPhotos()
+                await forgetUploadedPhotos()
             } catch {
                 Log.photoLibraryUploader("Failed to clear photo sync queue: \(error)", level: .error)
             }
         }
     }
 
-    public func cleanUploadedPhotos() async {
+    public func forgetUploadedPhotos() async {
         @InjectService var uploadDataSource: UploadServiceDataSourceable
 
         let objectsIdsToDelete = uploadDataSource

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -106,6 +106,9 @@ extension PhotoLibraryUploader: PhotoLibrarySyncable {
         }
 
         Task {
+            @InjectService var photoLibraryScan: PhotoLibraryScanable
+            photoLibraryScan.cancelScan()
+
             do {
                 try await uploadService.cancelAnyPhotoSync()
                 await forgetUploadedPhotos()

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -37,16 +37,6 @@ public final class PhotoLibraryUploader: PhotoLibraryUploadable {
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
     @LazyInjectService var uploadService: UploadServiceable
 
-    let serialQueue: DispatchQueue = {
-        @LazyInjectService var appContextService: AppContextServiceable
-        let autoreleaseFrequency: DispatchQueue.AutoreleaseFrequency = appContextService.isExtension ? .workItem : .inherit
-
-        return DispatchQueue(
-            label: "com.infomaniak.drive.photo-library",
-            autoreleaseFrequency: autoreleaseFrequency
-        )
-    }()
-
     /// Threshold value to trigger cleaning of photo roll if enabled
     static let removeAssetsCountThreshold = 10
 
@@ -57,6 +47,8 @@ public final class PhotoLibraryUploader: PhotoLibraryUploadable {
         /// System is asking to terminate the operation
         case importCancelledBySystem
     }
+
+    var workerTask: Task<Void, Never>?
 
     public var liveSettings: PhotoSyncSettings? {
         return uploadsDatabase.fetchObject(ofType: PhotoSyncSettings.self) { lazyCollection in

--- a/kDriveCore/Data/Upload/Servicies/UploadService/UploadService+Datasource.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/UploadService+Datasource.swift
@@ -39,6 +39,8 @@ public protocol UploadServiceDataSourceable {
 
     func getUploadedFiles(writableRealm: Realm, optionalPredicate: NSPredicate?) -> Results<UploadFile>
 
+    func getUploadedFilesIDs(optionalPredicate: NSPredicate?) -> [String]
+
     @discardableResult
     func saveToRealm(_ uploadFile: UploadFile,
                      itemIdentifier: NSFileProviderItemIdentifier?,
@@ -124,6 +126,10 @@ extension UploadService: UploadServiceDataSourceable {
                 .filter("uploadDate != nil AND ownedByFileProvider == %@", NSNumber(value: ownedByFileProvider))
                 .filter(optionalPredicate: optionalPredicate)
         }
+    }
+
+    public func getUploadedFilesIDs(optionalPredicate: NSPredicate? = nil) -> [String] {
+        getUploadedFiles(optionalPredicate: optionalPredicate).map { $0.id }
     }
 
     public func getUploadedFiles(writableRealm: Realm, optionalPredicate: NSPredicate? = nil) -> Results<UploadFile> {

--- a/kDriveCore/Data/Upload/Servicies/UploadService/UploadService.swift
+++ b/kDriveCore/Data/Upload/Servicies/UploadService/UploadService.swift
@@ -28,6 +28,8 @@ public enum UploadServiceBackgroundIdentifier {
 }
 
 public final class UploadService {
+    private static let batchSize = 100
+
     @InjectService(customTypeIdentifier: UploadQueueID.global) var globalUploadQueue: UploadQueueable
     @InjectService(customTypeIdentifier: UploadQueueID.photo) var photoUploadQueue: UploadQueueable
 
@@ -129,7 +131,7 @@ extension UploadService: UploadServiceable {
         let uploadingFileIds = Array(uploadingFiles.map(\.id))
         Log.uploadQueue("rebuildUploadQueueFromObjectsInRealm uploads to restart:\(uploadingFileIds.count)")
 
-        let batches = uploadingFileIds.chunks(ofCount: 100)
+        let batches = uploadingFileIds.chunks(ofCount: Self.batchSize)
         Log.uploadQueue("batched count:\(batches.count)")
         for batch in batches {
             Log.uploadQueue("rebuildUploadQueueFromObjectsInRealm in batch")
@@ -204,7 +206,7 @@ extension UploadService: UploadServiceable {
 
         serialTransactionQueue.async {
             let failedFileIds = self.getFailedFileIds(parentId: parentId, userId: userId, driveId: driveId)
-            let batches = failedFileIds.chunks(ofCount: 100)
+            let batches = failedFileIds.chunks(ofCount: Self.batchSize)
             Log.uploadQueue("batches:\(batches.count)")
 
             for batch in batches {
@@ -323,7 +325,7 @@ extension UploadService: UploadServiceable {
         }
 
         let allPhotoSyncUploadIDs = getAllUploadingPhotoSyncFileIDs()
-        let chunks = allPhotoSyncUploadIDs.chunks(ofCount: 50)
+        let chunks = allPhotoSyncUploadIDs.chunks(ofCount: Self.batchSize)
 
         try chunks.forEach { chunk in
             try self.uploadsDatabase.writeTransaction { writableRealm in

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/KeyedUploadOperationable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/KeyedUploadOperationable.swift
@@ -54,4 +54,10 @@ final class KeyedUploadOperationable {
         }
         return empty
     }
+
+    public func removeAll() {
+        queue.sync {
+            self.operationsInQueue.removeAll()
+        }
+    }
 }

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
@@ -24,7 +24,7 @@ public class PhotoUploadQueue: UploadQueue {
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
     var queueName = "kDrive photo upload queue"
-    
+
     /// Should suspend operation queue based on network status and user defined parameters
     override var shouldSuspendQueue: Bool {
         // Explicitly disable the upload queue from the share extension

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
@@ -23,6 +23,8 @@ import InfomaniakDI
 public class PhotoUploadQueue: UploadQueue {
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
+    var queueName = "kDrive photo upload queue"
+    
     /// Should suspend operation queue based on network status and user defined parameters
     override var shouldSuspendQueue: Bool {
         // Explicitly disable the upload queue from the share extension

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -142,6 +142,10 @@ extension UploadQueue: UploadQueueable {
         }
     }
 
+    public func cancelAllOperations() {
+        operationQueue.cancelAllOperations()
+    }
+
     private func operation(uploadFileId: String) -> UploadOperationable? {
         Log.uploadQueue("\(self) operation fileId:\(uploadFileId)")
         guard appContextService.context != .shareExtension else {

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -144,6 +144,7 @@ extension UploadQueue: UploadQueueable {
 
     public func cancelAllOperations() {
         operationQueue.cancelAllOperations()
+        keyedUploadOperations.removeAll()
     }
 
     private func operation(uploadFileId: String) -> UploadOperationable? {

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
@@ -36,12 +36,14 @@ public class UploadQueue: ParallelismHeuristicDelegate {
 
     weak var delegate: UploadQueueDelegate?
 
+    var name = "kDrive base upload queue"
+
     /// Something to track an operation for a File ID
     let keyedUploadOperations = KeyedUploadOperationable()
 
     public lazy var operationQueue: OperationQueue = {
         let queue = OperationQueue()
-        queue.name = "kDrive upload queue"
+        queue.name = self.name
         queue.qualityOfService = .userInitiated
         queue.isSuspended = shouldSuspendQueue
         return queue

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
@@ -36,6 +36,8 @@ public protocol UploadQueueable {
 
     func cancelAllOperations(uploadingFilesIds: [String])
 
+    func cancelAllOperations()
+    
     func rescheduleRunningOperations()
 
     func parallelismShouldChange(value: Int)

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
@@ -37,7 +37,7 @@ public protocol UploadQueueable {
     func cancelAllOperations(uploadingFilesIds: [String])
 
     func cancelAllOperations()
-    
+
     func rescheduleRunningOperations()
 
     func parallelismShouldChange(value: Int)

--- a/kDriveTestShared/MCKPhotoLibraryScanable.swift
+++ b/kDriveTestShared/MCKPhotoLibraryScanable.swift
@@ -20,5 +20,5 @@ import Foundation
 import kDriveCore
 
 struct MCKPhotoLibraryScanable: PhotoLibraryScanable {
-    @discardableResult func scheduleNewPicturesForUpload() -> Int { 0 }
+    @discardableResult func scheduleNewPicturesForUpload() {}
 }

--- a/kDriveTestShared/MCKPhotoLibraryScanable.swift
+++ b/kDriveTestShared/MCKPhotoLibraryScanable.swift
@@ -20,5 +20,7 @@ import Foundation
 import kDriveCore
 
 struct MCKPhotoLibraryScanable: PhotoLibraryScanable {
-    @discardableResult func scheduleNewPicturesForUpload() {}
+    func scheduleNewPicturesForUpload() async {}
+
+    func cancelScan() async {}
 }


### PR DESCRIPTION
Change drive OR disable photo sync will make the app forget about uploaded assets.

Other changes that were needed
- The initial scan process is now cancellable.
- The photoUploadQueue now can be purged, and behaves correctly when we reset the photo uploads.