### PR TITLE
fix: Missing PhotoSync object in DI in tests

### DIFF
--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -657,8 +657,8 @@ public struct AppRouter: AppNavigable {
         backgroundUploadSessionManager.reconnectBackgroundTasks()
 
         Log.sceneDelegate("Restart queue")
-        @InjectService var photoUploader: PhotoLibraryUploader
-        photoUploader.scheduleNewPicturesForUpload()
+        @InjectService var photoScan: PhotoLibraryScanable
+        photoScan.scheduleNewPicturesForUpload()
 
         // Resolving an upload queue will restart it if this is the first time
         @InjectService var uploadService: UploadServiceable

--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -46,7 +46,7 @@ final class UploadQueueViewController: UIViewController {
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var uploadService: UploadServiceable
     @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
     var currentDirectory: File!
     private var frozenUploadingFiles = [UploadFileDisplayed]()

--- a/kDrive/UI/Controller/Home/RootMenuHeaderView.swift
+++ b/kDrive/UI/Controller/Home/RootMenuHeaderView.swift
@@ -25,7 +25,7 @@ import UIKit
 class RootMenuHeaderView: UICollectionReusableView {
     static let kind: UICollectionView.UICollectionViewSupplementaryViewKind = .custom("menuHeader")
 
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
     @IBOutlet var topConstraint: NSLayoutConstraint!
     @IBOutlet var bottomConstraint: NSLayoutConstraint!

--- a/kDrive/UI/Controller/LaunchPanelsController.swift
+++ b/kDrive/UI/Controller/LaunchPanelsController.swift
@@ -85,7 +85,7 @@ class LaunchPanelsController {
                 return driveFloatingPanelController
             },
             displayCondition: InjectService<AccountManageable>().wrappedValue.currentDriveFileManager != nil && UserDefaults
-                .shared.numberOfConnections == 1 && !InjectService<PhotoLibraryUploader>().wrappedValue.isSyncEnabled,
+                .shared.numberOfConnections == 1 && !InjectService<PhotoLibraryUploadable>().wrappedValue.isSyncEnabled,
             priority: 3
         )
 

--- a/kDrive/UI/Controller/Menu/MenuViewController.swift
+++ b/kDrive/UI/Controller/Menu/MenuViewController.swift
@@ -28,7 +28,7 @@ final class MenuViewController: UITableViewController, SelectSwitchDriveDelegate
     @LazyInjectService private var accountManager: AccountManageable
     @LazyInjectService private var matomo: MatomoUtils
     @LazyInjectService var appNavigable: AppNavigable
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
     private let driveFileManager: DriveFileManager
     var uploadCountManager: UploadCountManager?

--- a/kDrive/UI/Controller/Menu/ParameterTableViewController.swift
+++ b/kDrive/UI/Controller/Menu/ParameterTableViewController.swift
@@ -30,7 +30,7 @@ import UIKit
 class ParameterTableViewController: BaseGroupedTableViewController {
     @LazyInjectService private var matomo: MatomoUtils
     @LazyInjectService var accountManager: AccountManageable
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
     @LazyInjectService var appNavigable: AppNavigable
 
     let driveFileManager: DriveFileManager

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -69,6 +69,30 @@ public enum FactoryService {
             Factory(type: PhotoLibraryUploader.self) { _, _ in
                 PhotoLibraryUploader()
             },
+            Factory(type: PhotoLibraryUploadable.self) { _, _ in
+                try resolver.resolve(type: PhotoLibraryUploader.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
+            },
+            Factory(type: PhotoLibraryQueryable.self) { _, _ in
+                try resolver.resolve(type: PhotoLibraryUploader.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
+            },
+            Factory(type: PhotoLibraryScanable.self) { _, _ in
+                try resolver.resolve(type: PhotoLibraryUploader.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
+            },
+            Factory(type: PhotoLibrarySyncable.self) { _, _ in
+                try resolver.resolve(type: PhotoLibraryUploader.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
+            },
             Factory(type: FileImportHelper.self) { _, _ in
                 FileImportHelper()
             },

--- a/kDriveCore/DI/FactoryService.swift
+++ b/kDriveCore/DI/FactoryService.swift
@@ -69,25 +69,25 @@ public enum FactoryService {
             Factory(type: PhotoLibraryUploader.self) { _, _ in
                 PhotoLibraryUploader()
             },
-            Factory(type: PhotoLibraryUploadable.self) { _, _ in
+            Factory(type: PhotoLibraryUploadable.self) { _, resolver in
                 try resolver.resolve(type: PhotoLibraryUploader.self,
                                      forCustomTypeIdentifier: nil,
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
-            Factory(type: PhotoLibraryQueryable.self) { _, _ in
+            Factory(type: PhotoLibraryQueryable.self) { _, resolver in
                 try resolver.resolve(type: PhotoLibraryUploader.self,
                                      forCustomTypeIdentifier: nil,
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
-            Factory(type: PhotoLibraryScanable.self) { _, _ in
+            Factory(type: PhotoLibraryScanable.self) { _, resolver in
                 try resolver.resolve(type: PhotoLibraryUploader.self,
                                      forCustomTypeIdentifier: nil,
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
-            Factory(type: PhotoLibrarySyncable.self) { _, _ in
+            Factory(type: PhotoLibrarySyncable.self) { _, resolver in
                 try resolver.resolve(type: PhotoLibraryUploader.self,
                                      forCustomTypeIdentifier: nil,
                                      factoryParameters: nil,

--- a/kDriveCore/Data/Cache/AccountManager.swift
+++ b/kDriveCore/Data/Cache/AccountManager.swift
@@ -94,7 +94,8 @@ public protocol AccountManageable: AnyObject {
 
 public class AccountManager: RefreshTokenDelegate, AccountManageable {
     @LazyInjectService var driveInfosManager: DriveInfosManager
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
+    @LazyInjectService var photoLibrarySync: PhotoLibrarySyncable
     @LazyInjectService var tokenStore: TokenStore
     @LazyInjectService var notificationHelper: NotificationsHelpable
     @LazyInjectService var networkLogin: InfomaniakNetworkLoginable
@@ -371,7 +372,7 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
             if photoLibraryUploader.isSyncEnabled,
                frozenSettings?.userId == user.id,
                frozenSettings?.driveId == driveRemoved.id {
-                photoLibraryUploader.disableSync()
+                photoLibrarySync.disableSync()
             }
             if currentDriveFileManager?.driveId == driveRemoved.id {
                 setCurrentDriveForCurrentAccount(for: firstDrive.id, userId: firstDrive.userId)
@@ -525,7 +526,7 @@ public class AccountManager: RefreshTokenDelegate, AccountManageable {
             currentUserId = 0
         }
         if photoLibraryUploader.isSyncEnabled && photoLibraryUploader.frozenSettings?.userId == toDeleteAccount.userId {
-            photoLibraryUploader.disableSync()
+            photoLibrarySync.disableSync()
         }
         driveInfosManager.deleteFileProviderDomains(for: toDeleteAccount.userId)
         DriveFileManager.deleteUserDriveFiles(userId: toDeleteAccount.userId)

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryCleanerService.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryCleanerService.swift
@@ -37,7 +37,7 @@ public struct PhotoLibraryCleanerService: PhotoLibraryCleanerServiceable {
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) private var uploadsDatabase: Transactionable
     @LazyInjectService private var uploadService: UploadServiceable
     @LazyInjectService private var uploadDataSource: UploadServiceDataSourceable
-    @LazyInjectService private var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService private var photoLibraryUploader: PhotoLibraryUploadable
 
     /// Threshold value to trigger cleaning of photo roll if enabled
     static let removeAssetsCountThreshold = 10

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Query.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Query.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Photos
 
-protocol PhotoLibraryQueryable {
+public protocol PhotoLibraryQueryable {
     /// Create predicate related to dates from settings
     func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate
 
@@ -28,7 +28,7 @@ protocol PhotoLibraryQueryable {
 }
 
 extension PhotoLibraryUploader: PhotoLibraryQueryable {
-    func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate {
+    public func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate {
         let lastSyncDate = settings.lastSync as NSDate
         let syncFromDate = settings.fromDate as NSDate
         let datePredicate: NSPredicate
@@ -47,7 +47,7 @@ extension PhotoLibraryUploader: PhotoLibraryQueryable {
         return datePredicate
     }
 
-    func getAssetPredicates(forSettings settings: PhotoSyncSettings) -> [NSPredicate] {
+    public func getAssetPredicates(forSettings settings: PhotoSyncSettings) -> [NSPredicate] {
         var typesPredicates = [NSPredicate]()
 
         if settings.syncPicturesEnabled && settings.syncScreenshotsEnabled {

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Query.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Query.swift
@@ -19,8 +19,15 @@
 import Foundation
 import Photos
 
-extension PhotoLibraryUploader {
+protocol PhotoLibraryQueryable {
     /// Create predicate related to dates from settings
+    func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate
+
+    /// Create predicate related to file format from settings
+    func getAssetPredicates(forSettings settings: PhotoSyncSettings) -> [NSPredicate]
+}
+
+extension PhotoLibraryUploader: PhotoLibraryQueryable {
     func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate {
         let lastSyncDate = settings.lastSync as NSDate
         let syncFromDate = settings.fromDate as NSDate
@@ -40,7 +47,6 @@ extension PhotoLibraryUploader {
         return datePredicate
     }
 
-    /// Create predicate related to file format from settings
     func getAssetPredicates(forSettings settings: PhotoSyncSettings) -> [NSPredicate] {
         var typesPredicates = [NSPredicate]()
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -22,6 +22,10 @@ import InfomaniakDI
 import Photos
 import RealmSwift
 
+protocol PhotoLibraryScanable {
+    @discardableResult func scheduleNewPicturesForUpload() -> Int
+}
+
 public extension PhotoLibraryUploader {
     @discardableResult
     func scheduleNewPicturesForUpload() -> Int {

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -22,13 +22,13 @@ import InfomaniakDI
 import Photos
 import RealmSwift
 
-protocol PhotoLibraryScanable {
+public protocol PhotoLibraryScanable {
     @discardableResult func scheduleNewPicturesForUpload() -> Int
 }
 
-public extension PhotoLibraryUploader {
+extension PhotoLibraryUploader: PhotoLibraryScanable {
     @discardableResult
-    func scheduleNewPicturesForUpload() -> Int {
+    public func scheduleNewPicturesForUpload() -> Int {
         Log.photoLibraryUploader("scheduleNewPicturesForUpload")
         guard let frozenSettings,
               PHPhotoLibrary.authorizationStatus() == .authorized else {

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Sync.swift
@@ -19,8 +19,13 @@
 import Foundation
 import RealmSwift
 
-public extension PhotoLibraryUploader {
-    @MainActor func enableSync(_ liveNewSyncSettings: PhotoSyncSettings) {
+public protocol PhotoLibrarySyncable {
+    @MainActor func enableSync(_ liveNewSyncSettings: PhotoSyncSettings)
+    func disableSync()
+}
+
+extension PhotoLibraryUploader: PhotoLibrarySyncable {
+    @MainActor public func enableSync(_ liveNewSyncSettings: PhotoSyncSettings) {
         let currentSyncSettings = frozenSettings
         try? uploadsDatabase.writeTransaction { writableRealm in
             guard liveNewSyncSettings.userId != -1,
@@ -55,7 +60,7 @@ public extension PhotoLibraryUploader {
         }
     }
 
-    func disableSync() {
+    public func disableSync() {
         try? uploadsDatabase.writeTransaction { writableRealm in
             writableRealm.delete(writableRealm.objects(PhotoSyncSettings.self))
         }

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -30,6 +30,7 @@ public protocol PhotoLibraryUploadable {
     var frozenSettings: PhotoSyncSettings? { get }
     var isSyncEnabled: Bool { get }
     var isWifiOnly: Bool { get }
+    func getUrl(for asset: PHAsset) async -> URL?
 }
 
 public final class PhotoLibraryUploader: PhotoLibraryUploadable {
@@ -83,7 +84,7 @@ public final class PhotoLibraryUploader: PhotoLibraryUploadable {
         // META: SonarClound happy
     }
 
-    func getUrl(for asset: PHAsset) async -> URL? {
+    public func getUrl(for asset: PHAsset) async -> URL? {
         return await asset.getUrl(preferJPEGFormat: frozenSettings?.photoFormat == .jpg)
     }
 }

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -25,7 +25,14 @@ import Photos
 import RealmSwift
 import Sentry
 
-public final class PhotoLibraryUploader {
+public protocol PhotoLibraryUploadable {
+    var liveSettings: PhotoSyncSettings? { get }
+    var frozenSettings: PhotoSyncSettings? { get }
+    var isSyncEnabled: Bool { get }
+    var isWifiOnly: Bool { get }
+}
+
+public final class PhotoLibraryUploader: PhotoLibraryUploadable {
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
     @LazyInjectService var uploadService: UploadServiceable
 

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
@@ -227,7 +227,7 @@ extension UploadOperation {
 
                 if self.photoLibraryUploader.isSyncEnabled,
                    self.photoLibraryUploader.frozenSettings?.parentDirectoryId == file.parentDirectoryId {
-                    self.photoLibraryUploader.disableSync()
+                    self.photoLibrarySync.disableSync()
                     self.notificationHelper.sendPhotoSyncErrorNotification()
                 }
 

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -67,7 +67,8 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
     @LazyInjectService var backgroundUploadManager: BackgroundUploadSessionManager
     @LazyInjectService var uploadService: UploadServiceable
     @LazyInjectService var accountManager: AccountManageable
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
+    @LazyInjectService var photoLibrarySync: PhotoLibrarySyncable
     @LazyInjectService var fileManager: FileManagerable
     @LazyInjectService var fileMetadata: FileMetadatable
     @LazyInjectService var freeSpaceService: FreeSpaceService

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/PhotoUploadQueue.swift
@@ -21,7 +21,7 @@ import InfomaniakCore
 import InfomaniakDI
 
 public class PhotoUploadQueue: UploadQueue {
-    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploader
+    @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
 
     /// Should suspend operation queue based on network status and user defined parameters
     override var shouldSuspendQueue: Bool {

--- a/kDriveCore/Services/BackgroundTasksService.swift
+++ b/kDriveCore/Services/BackgroundTasksService.swift
@@ -49,7 +49,7 @@ struct BackgroundTasksService: BackgroundTasksServiceable {
     @LazyInjectService private var scheduler: BGTaskScheduler
     @LazyInjectService private var accountManager: AccountManageable
     @LazyInjectService private var uploadService: UploadServiceable
-    @LazyInjectService private var photoUploader: PhotoLibraryUploader
+    @LazyInjectService private var photoScan: PhotoLibraryScanable
 
     public init() {
         // META: keep SonarCloud happy
@@ -115,7 +115,7 @@ struct BackgroundTasksService: BackgroundTasksServiceable {
         }
 
         Log.backgroundTaskScheduling("Enqueue new pictures")
-        photoUploader.scheduleNewPicturesForUpload()
+        photoScan.scheduleNewPicturesForUpload()
 
         guard !expiringActivity.shouldTerminate else {
             Log.backgroundTaskScheduling(Self.activityShouldTerminateMessage, level: .error)

--- a/kDriveCore/Utils/Logging.swift
+++ b/kDriveCore/Utils/Logging.swift
@@ -99,7 +99,7 @@ public enum Logging {
             options.dsn = "https://ba647a8cc6fc437baf797d2eb33dfafb@sentry-mobile.infomaniak.com/6"
             options.beforeSend = { event in
                 // if the application is in debug mode discard the events
-                @InjectService var photoLibraryUploader: PhotoLibraryUploader
+                @InjectService var photoLibraryUploader: PhotoLibraryUploadable
                 event.context?["AppState"] = [
                     "AppLock enabled": UserDefaults.shared.isAppLockEnabled,
                     "Wifi only enabled": photoLibraryUploader.isWifiOnly

--- a/kDriveTestShared/MCKPhotoLibraryQueryable.swift
+++ b/kDriveTestShared/MCKPhotoLibraryQueryable.swift
@@ -1,0 +1,26 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+
+struct MCKPhotoLibraryQueryable: PhotoLibraryQueryable {
+    func getDatePredicate(with settings: PhotoSyncSettings) -> NSPredicate { NSPredicate(value: true) }
+
+    func getAssetPredicates(forSettings settings: PhotoSyncSettings) -> [NSPredicate] { [NSPredicate]() }
+}

--- a/kDriveTestShared/MCKPhotoLibraryScanable.swift
+++ b/kDriveTestShared/MCKPhotoLibraryScanable.swift
@@ -1,0 +1,24 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+
+struct MCKPhotoLibraryScanable: PhotoLibraryScanable {
+    @discardableResult func scheduleNewPicturesForUpload() -> Int { 0 }
+}

--- a/kDriveTestShared/MCKPhotoLibrarySyncable.swift
+++ b/kDriveTestShared/MCKPhotoLibrarySyncable.swift
@@ -1,0 +1,26 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+
+struct MCKPhotoLibrarySyncable: PhotoLibrarySyncable {
+    @MainActor func enableSync(_ liveNewSyncSettings: PhotoSyncSettings) {}
+
+    func disableSync() {}
+}

--- a/kDriveTestShared/MCKPhotoLibraryUploadable.swift
+++ b/kDriveTestShared/MCKPhotoLibraryUploadable.swift
@@ -1,0 +1,33 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import kDriveCore
+import Photos
+
+struct MCKPhotoLibraryUploadable: PhotoLibraryUploadable {
+    var liveSettings: PhotoSyncSettings? { nil }
+
+    var frozenSettings: PhotoSyncSettings? { nil }
+
+    var isSyncEnabled: Bool { false }
+
+    var isWifiOnly: Bool { false }
+
+    func getUrl(for asset: PHAsset) async -> URL? { nil }
+}

--- a/kDriveTestShared/MockingHelper.swift
+++ b/kDriveTestShared/MockingHelper.swift
@@ -71,6 +71,12 @@ public enum MockingHelper {
                                          forCustomTypeIdentifier: nil,
                                          factoryParameters: nil,
                                          resolver: resolver)
+                },
+                Factory(type: PhotoLibrarySyncable.self) { _, resolver in
+                    try resolver.resolve(type: PhotoLibraryUploader.self,
+                                         forCustomTypeIdentifier: nil,
+                                         factoryParameters: nil,
+                                         resolver: resolver)
                 }
             ]
         case .minimal:

--- a/kDriveTestShared/MockingHelper.swift
+++ b/kDriveTestShared/MockingHelper.swift
@@ -50,6 +50,27 @@ public enum MockingHelper {
                 },
                 Factory(type: AppNavigable.self) { _, _ in
                     AppRouter()
+                },
+                Factory(type: PhotoLibraryUploader.self) { _, _ in
+                    PhotoLibraryUploader()
+                },
+                Factory(type: PhotoLibraryUploadable.self) { _, resolver in
+                    try resolver.resolve(type: PhotoLibraryUploader.self,
+                                         forCustomTypeIdentifier: nil,
+                                         factoryParameters: nil,
+                                         resolver: resolver)
+                },
+                Factory(type: PhotoLibraryQueryable.self) { _, resolver in
+                    try resolver.resolve(type: PhotoLibraryUploader.self,
+                                         forCustomTypeIdentifier: nil,
+                                         factoryParameters: nil,
+                                         resolver: resolver)
+                },
+                Factory(type: PhotoLibraryScanable.self) { _, resolver in
+                    try resolver.resolve(type: PhotoLibraryUploader.self,
+                                         forCustomTypeIdentifier: nil,
+                                         factoryParameters: nil,
+                                         resolver: resolver)
                 }
             ]
         case .minimal:
@@ -62,6 +83,18 @@ public enum MockingHelper {
                 },
                 Factory(type: AppNavigable.self) { _, _ in
                     MCKRouter()
+                },
+                Factory(type: PhotoLibraryUploadable.self) { _, _ in
+                    MCKPhotoLibraryUploadable()
+                },
+                Factory(type: PhotoLibraryQueryable.self) { _, _ in
+                    MCKPhotoLibraryQueryable()
+                },
+                Factory(type: PhotoLibraryScanable.self) { _, _ in
+                    MCKPhotoLibraryScanable()
+                },
+                Factory(type: PhotoLibrarySyncable.self) { _, _ in
+                    MCKPhotoLibrarySyncable()
                 }
             ]
         }

--- a/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
+++ b/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
@@ -85,8 +85,8 @@ final class ITAppLaunchTest: XCTestCase {
             Factory(type: PhotoLibrarySyncable.self) { _, _ in
                 MCKPhotoLibrarySyncable()
             },
-            Factory(type: PhotoLibrarySyncable.self) { _, _ in
-                MCKPhotoLibrarySyncable()
+            Factory(type: PhotoLibraryScanable.self) { _, _ in
+                MCKPhotoLibraryScanable()
             },
             Factory(type: DriveInfosManager.self) { _, _ in
                 DriveInfosManager()

--- a/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
+++ b/kDriveTests/kDrive/Launch/ITAppLaunchTest.swift
@@ -76,8 +76,17 @@ final class ITAppLaunchTest: XCTestCase {
             Factory(type: AppLockHelper.self) { _, _ in
                 AppLockHelper()
             },
-            Factory(type: PhotoLibraryUploader.self) { _, _ in
-                PhotoLibraryUploader()
+            Factory(type: PhotoLibraryUploadable.self) { _, _ in
+                MCKPhotoLibraryUploadable()
+            },
+            Factory(type: PhotoLibraryQueryable.self) { _, _ in
+                MCKPhotoLibraryQueryable()
+            },
+            Factory(type: PhotoLibrarySyncable.self) { _, _ in
+                MCKPhotoLibrarySyncable()
+            },
+            Factory(type: PhotoLibrarySyncable.self) { _, _ in
+                MCKPhotoLibrarySyncable()
             },
             Factory(type: DriveInfosManager.self) { _, _ in
                 DriveInfosManager()

--- a/kDriveTests/kDriveCore/Files/UTPHAssetNameProvider.swift
+++ b/kDriveTests/kDriveCore/Files/UTPHAssetNameProvider.swift
@@ -22,6 +22,11 @@ import XCTest
 
 /// Unit tests of image asset name generation
 final class UTPHAssetNameProvider: XCTestCase {
+    override func setUp() {
+        MockingHelper.clearRegisteredTypes()
+        MockingHelper.registerConcreteTypes(configuration: .minimal)
+    }
+
     // MARK: - Fallback Name
 
     func testDefaultName() {


### PR DESCRIPTION
#### Abstract

Tests are flaky since an object can be missing in DI during tests

I created protocols around the already divided class `PhotoLibraryUploader`
Using DI I was able to register mocks of the `PhotoLibraryUploader` where needed

Both app and tests are no longer resolving directly the concrete type `PhotoLibraryUploader`