### PR TITLE
fix: Limit fetch querry to first one

### DIFF
--- a/kDriveCore/Data/Models/Upload/UploadFile.swift
+++ b/kDriveCore/Data/Models/Upload/UploadFile.swift
@@ -312,7 +312,9 @@ public final class UploadFile: Object, UploadFilable {
             return nil
         }
 
-        localAsset = PHAsset.fetchAssets(withLocalIdentifiers: [assetLocalIdentifier], options: nil).firstObject
+        let fetchAssetOption = PHFetchOptions()
+        fetchAssetOption.fetchLimit = 1
+        localAsset = PHAsset.fetchAssets(withLocalIdentifiers: [assetLocalIdentifier], options: fetchAssetOption).firstObject
         return localAsset
     }
 


### PR DESCRIPTION
I limit fetched assets to one as we only use the first one