### PR TITLE
feat: Small file direct upload

### DIFF
--- a/kDriveCore/Data/Upload/UploadQueue/Chunk/RangeProvider.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Chunk/RangeProvider.swift
@@ -42,6 +42,7 @@ public struct RangeProvider: RangeProvidable {
         static let chunkMinSize: UInt64 = 1 * 1024 * 1024
         static let chunkMaxSizeClient: UInt64 = 50 * 1024 * 1024
         static let chunkMaxSizeServer: UInt64 = 1 * 1024 * 1024 * 1024
+        static let smallFileMaxSize: UInt64 = 5 * 1024 * 1024
         static let optimalChunkCount: UInt64 = 200
         static let maxTotalChunks: UInt64 = 10000
         static let minTotalChunks: UInt64 = 1

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import InfomaniakCore
+import InfomaniakDI
 
 extension UploadOperation {
     /// Enqueue a task, while making sure we catch the errors in a standard way
@@ -197,8 +198,22 @@ extension UploadOperation {
                 self.uploadService.suspendAllOperations()
 
             case .uploadNotTerminatedError,
-                 .uploadNotTerminated,
-                 .invalidUploadTokenError,
+                 .uploadNotTerminated:
+                // Direct upload of duplicated files can throw this error.
+                // We silently retry upload with a Session.
+                // Too many retries, we display the error to the end user.
+
+                file.progress = nil
+                file.error = error
+                if file.maxRetryCount > 0 {
+                    file.maxRetryCount -= 1
+                    Task {
+                        @InjectService var uploadService: UploadServiceable
+                        uploadService.retry(self.uploadFileId)
+                    }
+                }
+
+            case .invalidUploadTokenError,
                  .uploadError,
                  .uploadFailedError,
                  .uploadTokenIsNotValid:
@@ -207,7 +222,6 @@ extension UploadOperation {
                 }
                 file.progress = nil
                 file.error = error
-                
 
             case .uploadTokenCanceled:
                 // We cancelled the upload session, running chunks requests are failing

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
@@ -129,7 +129,7 @@ extension UploadOperation {
                      .uploadSessionInvalid:
                     // Clean session, present error, user action required to restart.
                     Task {
-                        await self.cleanUploadFileSession()
+                        try await self.cleanUploadFileSession()
                     }
                     file.error = .localError.wrapping(error)
 
@@ -203,10 +203,11 @@ extension UploadOperation {
                  .uploadFailedError,
                  .uploadTokenIsNotValid:
                 Task {
-                    await self.cleanUploadFileSession()
+                    try await self.cleanUploadFileSession()
                 }
                 file.progress = nil
                 file.error = error
+                
 
             case .uploadTokenCanceled:
                 // We cancelled the upload session, running chunks requests are failing
@@ -219,7 +220,7 @@ extension UploadOperation {
                 file.progress = nil
                 file.error = error
                 Task {
-                    await self.cleanUploadFileSession()
+                    try await self.cleanUploadFileSession()
                 }
                 self.uploadService.cancelAllOperations(withParent: file.parentDirectoryId,
                                                        userId: file.userId,

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Error.swift
@@ -130,7 +130,7 @@ extension UploadOperation {
                      .uploadSessionInvalid:
                     // Clean session, present error, user action required to restart.
                     Task {
-                        try await self.cleanUploadFileSession()
+                        await self.cleanUploadFileSession()
                     }
                     file.error = .localError.wrapping(error)
 
@@ -218,7 +218,7 @@ extension UploadOperation {
                  .uploadFailedError,
                  .uploadTokenIsNotValid:
                 Task {
-                    try await self.cleanUploadFileSession()
+                    await self.cleanUploadFileSession()
                 }
                 file.progress = nil
                 file.error = error
@@ -234,7 +234,7 @@ extension UploadOperation {
                 file.progress = nil
                 file.error = error
                 Task {
-                    try await self.cleanUploadFileSession()
+                    await self.cleanUploadFileSession()
                 }
                 self.uploadService.cancelAllOperations(withParent: file.parentDirectoryId,
                                                        userId: file.userId,

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
@@ -112,7 +112,7 @@ extension UploadOperation {
     }
 
     private func wipeSessionAndRegenerate() async throws {
-        try await cleanUploadFileSession()
+        await cleanUploadFileSession()
         try await generateNewSessionAndStore()
     }
 
@@ -286,12 +286,12 @@ extension UploadOperation {
         }
     }
 
-    public func cleanUploadFileSession() async throws {
+    public func cleanUploadFileSession() async {
         Log.uploadOperation("Clean session for \(uploadFileId)")
         SentryDebug.uploadOperationCleanSessionBreadcrumb(uploadFileId)
 
-        let readOnlyFile = try readOnlyFile()
-        if readOnlyFile.uploadingSession != nil {
+        if let readOnlyFile = try? readOnlyFile(),
+           readOnlyFile.uploadingSession != nil {
             await cleanUploadFileSessionRemotely(readOnlyFile: readOnlyFile)
         }
         cleanUploadFileSessionLocally()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
@@ -425,7 +425,7 @@ extension UploadOperation {
         }
     }
 
-    private func cleanUploadFileSessionLocally(_ file: UploadFile? = nil) {
+    private func cleanUploadFileSessionLocally() {
         // Clean the local uploading session, as well as error
         try? transactionWithFile { file in
             file.uploadingSession = nil

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadSession.swift
@@ -291,10 +291,7 @@ extension UploadOperation {
         SentryDebug.uploadOperationCleanSessionBreadcrumb(uploadFileId)
 
         let readOnlyFile = try readOnlyFile()
-        let fileUrl = try getFileUrlIfReadable(file: readOnlyFile)
-        let fileSize = try fileSize(fileUrl: fileUrl)
-
-        if !isSmallOrEmptyFile(fileSize: fileSize) {
+        if readOnlyFile.uploadingSession != nil {
             await cleanUploadFileSessionRemotely(readOnlyFile: readOnlyFile)
         }
         cleanUploadFileSessionLocally()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -137,7 +137,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             try await self.getPhAssetIfNeeded()
 
             // Check if the file is empty, and uses the 1 shot upload method for it if needed.
-            let handledEmptyFile = try await self.handleSmallFileIfNeeded()
+            let handledEmptyFile = try await self.handleSmallOrEmptyFileIfNeeded()
 
             // Continue if we are dealing with a file with data
             guard !handledEmptyFile else {
@@ -168,7 +168,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         return free
     }
 
-    func handleSmallFileIfNeeded() async throws -> Bool {
+    func handleSmallOrEmptyFileIfNeeded() async throws -> Bool {
         try checkCancelation()
 
         let uploadFile = try readOnlyFile()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -213,9 +213,6 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                                                                            directoryPath: uploadFile.relativePath,
                                                                            fileData: fileData)
 
-        // Make sure the parent of the `File` is transferred from the `UploadFile`
-        driveFile.parentId = uploadFile.parentDirectoryId
-
         try handleDriveFilePostUpload(driveFile)
 
         Log.uploadOperation("Small or empty file upload finishing fid:\(driveFile.id) ufid:\(uploadFileId)")

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -197,7 +197,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             fileData = Data()
         } else {
             Log.uploadOperation("Processing small file ufid:\(uploadFileId)")
-            fileData = try Data(contentsOf: fileUrl)
+            fileData = try Data(contentsOf: fileUrl, options: .alwaysMapped)
         }
 
         let driveFileManager = try getDriveFileManager(for: uploadFile.driveId, userId: uploadFile.userId)

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -182,7 +182,15 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             return false // Continue with standard upload operation
         }
 
-        Log.uploadOperation("Processing an empty file ufid:\(uploadFileId)")
+        let fileData: Data
+        if fileSize == 0 {
+            Log.uploadOperation("Processing empty file ufid:\(uploadFileId)")
+            fileData = Data()
+        } else {
+            Log.uploadOperation("Processing small file ufid:\(uploadFileId)")
+            fileData = try FileHandle(forReadingAtPath: fileUrl.path)?.readToEnd() ?? Data()
+        }
+
         let driveFileManager = try getDriveFileManager(for: uploadFile.driveId, userId: uploadFile.userId)
         let drive = driveFileManager.drive
 
@@ -201,7 +209,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
         try handleDriveFilePostUpload(driveFile)
 
-        Log.uploadOperation("Empty file uploaded finishing fid:\(driveFile.id) ufid:\(uploadFileId)")
+        Log.uploadOperation("Small or empty file upload finishing fid:\(driveFile.id) ufid:\(uploadFileId)")
         end()
         return true
     }

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -137,10 +137,10 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             try await self.getPhAssetIfNeeded()
 
             // Check if the file is empty, and uses the 1 shot upload method for it if needed.
-            let handledEmptyFile = try await self.handleSmallOrEmptyFileIfNeeded()
+            let handledSmallOrEmptyFile = try await self.handleSmallOrEmptyFileIfNeeded()
 
             // Continue if we are dealing with a file with data
-            guard !handledEmptyFile else {
+            guard !handledSmallOrEmptyFile else {
                 return
             }
 

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -196,6 +196,10 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             Log.uploadOperation("Processing empty file ufid:\(uploadFileId)")
             fileData = Data()
         } else {
+            guard uploadFile.error == nil, uploadFile.maxRetryCount == UploadFile.defaultMaxRetryCount else {
+                return false // On retry we disable direct uploads. Session upload is more stable.
+            }
+
             Log.uploadOperation("Processing small file ufid:\(uploadFileId)")
             fileData = try Data(contentsOf: fileUrl, options: .alwaysMapped)
         }

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -188,7 +188,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
             fileData = Data()
         } else {
             Log.uploadOperation("Processing small file ufid:\(uploadFileId)")
-            fileData = try FileHandle(forReadingAtPath: fileUrl.path)?.readToEnd() ?? Data()
+            fileData = try Data(contentsOf: fileUrl)
         }
 
         let driveFileManager = try getDriveFileManager(for: uploadFile.driveId, userId: uploadFile.userId)
@@ -202,7 +202,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                                                                            createdAt: uploadFile.creationDate,
                                                                            directoryId: uploadFile.parentDirectoryId,
                                                                            directoryPath: uploadFile.relativePath,
-                                                                           fileData: Data(contentsOf: fileUrl))
+                                                                           fileData: fileData)
 
         // Make sure the parent of the `File` is transferred from the `UploadFile`
         driveFile.parentId = uploadFile.parentDirectoryId

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -203,6 +203,10 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         let driveFileManager = try getDriveFileManager(for: uploadFile.driveId, userId: uploadFile.userId)
         let drive = driveFileManager.drive
 
+        try transactionWithFile { uploadFile in
+            uploadFile.progress = 0.01
+        }
+
         let driveFile = try await driveFileManager.apiFetcher.directUpload(drive: drive,
                                                                            totalSize: fileSize,
                                                                            fileName: uploadFile.name,

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
@@ -61,7 +61,7 @@ public protocol UploadOperationable: Operationable {
     func uploadCompletion(data: Data?, response: URLResponse?, error: Error?)
 
     /// Clean the remote then local session; and cancel running upload chunk operations.
-    func cleanUploadFileSession() async throws
+    func cleanUploadFileSession() async
 
     /// Process errors and terminate the operation
     func end()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
@@ -61,7 +61,7 @@ public protocol UploadOperationable: Operationable {
     func uploadCompletion(data: Data?, response: URLResponse?, error: Error?)
 
     /// Clean the remote then local session; and cancel running upload chunk operations.
-    func cleanUploadFileSession() async
+    func cleanUploadFileSession() async throws
 
     /// Process errors and terminate the operation
     func end()

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -111,7 +111,7 @@ extension UploadQueue: UploadQueueable {
         if let operation = keyedUploadOperations.getObject(forKey: uploadFileId) {
             Log.uploadQueue("\(self) operation to cancel:\(operation)")
             Task {
-                try await operation.cleanUploadFileSession()
+                await operation.cleanUploadFileSession()
                 operation.cancel()
             }
         }

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -111,7 +111,7 @@ extension UploadQueue: UploadQueueable {
         if let operation = keyedUploadOperations.getObject(forKey: uploadFileId) {
             Log.uploadQueue("\(self) operation to cancel:\(operation)")
             Task {
-                await operation.cleanUploadFileSession()
+                try await operation.cleanUploadFileSession()
                 operation.cancel()
             }
         }

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue+Queue.swift
@@ -210,8 +210,7 @@ extension UploadQueue: UploadQueueable {
             guard let self else { return }
             Log.uploadQueue("\(self) operation.completionBlock for operation:\(operation) ufid:\(uploadFileId)")
             keyedUploadOperations.removeObject(forKey: uploadFileId)
-            if let error = operation.result.uploadFile?.error,
-               error == .taskRescheduled || error == .taskCancelled || error == .uploadOverDataRestrictedError {
+            if let error = operation.result.uploadFile?.error, Self.silentErrors.contains(error) {
                 Log.uploadQueue("\(self) skipping task")
                 return
             }

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
@@ -34,6 +34,9 @@ public class UploadQueue: ParallelismHeuristicDelegate {
 
     private var queueObserver: UploadQueueObserver?
 
+    static let silentErrors: [DriveError] =
+        [.taskRescheduled, .taskCancelled, .uploadOverDataRestrictedError, .uploadNotTerminatedError, .uploadNotTerminated]
+
     weak var delegate: UploadQueueDelegate?
 
     var name = "kDrive base upload queue"


### PR DESCRIPTION
### Abstract

This PR enables direct upload for small files (under 5Mib).

This brings performance improvements and reduces energy consumption by drastically reducing upload overhead.
Benefits may differ given the average size of files uploaded.