### PR TITLE
fix: Folder selection improvements

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/LocationFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/LocationFolderViewController.swift
@@ -25,10 +25,6 @@ import RealmSwift
 import UIKit
 
 class LocationFolderViewController: SidebarViewController {
-    private var selectedIndexPath: IndexPath?
-    private let selectHandler: ((File) -> Void)?
-    weak var locationDelegate: SelectFolderDelegate?
-
     private static let recentItems: [RootMenuItem] = [RootMenuItem(name: KDriveResourcesStrings.Localizable.lastEditsTitle,
                                                                    image: KDriveResourcesAsset.clock.image,
                                                                    destination: .file(DriveFileManager
@@ -43,8 +39,13 @@ class LocationFolderViewController: SidebarViewController {
                                                     RootMenuItem(name: KDriveResourcesStrings.Localizable.mySharesTitle,
                                                                  image: KDriveResourcesAsset.folderSelect.image,
                                                                  destination: .file(DriveFileManager.mySharedRootFile))]
+    private var selectedIndexPath: IndexPath?
+    private let selectHandler: ((File) -> Void)?
+    private let disabledDirectoriesSelection: [Int]
+    private let fileToMove: Int?
+    private weak var locationDelegate: SelectFolderDelegate?
+    private let viewModel: FileListViewModel
 
-    var viewModel: FileListViewModel
     private var rootChildrenObservationToken: NotificationToken?
     private var dataSource: MenuDataSource?
     override var itemsSnapshot: DataSourceSnapshot {
@@ -102,11 +103,15 @@ class LocationFolderViewController: SidebarViewController {
         viewModel: FileListViewModel,
         selectMode: Bool,
         isCompactView: Bool,
+        disabledDirectoriesSelection: [Int],
+        fileToMove: Int?,
         locationDelegate: SelectFolderDelegate? = nil,
         selectHandler: ((File) -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.locationDelegate = locationDelegate
+        self.disabledDirectoriesSelection = disabledDirectoriesSelection
+        self.fileToMove = fileToMove
         self.selectHandler = selectHandler
         super.init(driveFileManager: driveFileManager, selectMode: selectMode, isCompactView: isCompactView)
     }
@@ -160,6 +165,8 @@ class LocationFolderViewController: SidebarViewController {
 
         let destinationViewController = SelectFolderViewController(
             viewModel: destinationViewModel,
+            disabledDirectoriesSelection: disabledDirectoriesSelection,
+            fileToMove: fileToMove,
             delegate: locationDelegate,
             selectHandler: selectHandler
         )

--- a/kDrive/UI/Controller/Files/Save File/LocationFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/LocationFolderViewController.swift
@@ -63,6 +63,7 @@ class LocationFolderViewController: SidebarViewController {
                 .filter("rawType == %@", FileType.dir.rawValue)
                 .filter("id > %@", DriveFileManager.constants.rootID)
                 .filter("parentId > %@", DriveFileManager.constants.rootID)
+                .filter("_capabilities.canWrite == true")
                 .sorted(byKeyPath: "lastModifiedAt", ascending: false)
                 .freeze()
         }.prefix(3)

--- a/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
+++ b/kDrive/UI/Controller/Files/Save File/SaveFileViewController+UITableViewDelegate.swift
@@ -51,7 +51,6 @@ extension SaveFileViewController: UITableViewDelegate {
             guard let driveFileManager = selectedDriveFileManager else { return }
             let selectFolderNavigationController = SelectFolderViewController.instantiateInNavigationController(
                 driveFileManager: driveFileManager,
-                startDirectory: selectedDirectory,
                 delegate: self
             )
             present(selectFolderNavigationController, animated: true)

--- a/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoSyncSettingsViewController.swift
@@ -437,7 +437,6 @@ extension PhotoSyncSettingsViewController {
                 if let driveFileManager {
                     let selectFolderNavigationController = SelectFolderViewController.instantiateInNavigationController(
                         driveFileManager: driveFileManager,
-                        startDirectory: selectedDirectory,
                         disabledDirectoriesSelection: [driveFileManager.getCachedRootFile()],
                         delegate: self
                     )


### PR DESCRIPTION
- Rebuild hierarchy on move
- Start from root when saving file or selecting sync folder for photos
- Prevent showing non writable directories in recent
