### PR TITLE
fix: Handle incompatible videos

### DIFF
--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -486,6 +486,8 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
             handleOfficePreviewError(error, previewIndex: index)
         } else if file.convertedType == .audio {
             handleAudioPreviewError(error, previewIndex: index)
+        } else if file.convertedType == .video {
+            handleVideoPreviewError(error, previewIndex: index)
         }
 
         // We have to delay reload because errorWhilePreviewing can be called when the collectionView requests a new cell in
@@ -506,6 +508,17 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
         previewErrors[file.id] = PreviewError(fileId: file.id, downloadError: nil)
         guard file.isLocalVersionOlderThanRemote else { return }
         downloadFile(at: IndexPath(item: previewIndex, section: 0))
+    }
+
+    func handleVideoPreviewError(_ error: Error, previewIndex: Int) {
+        let file = previewFiles[previewIndex]
+
+        guard let videoError = error as? VideoPlayer.ErrorDomain,
+              videoError == .incompatibleFile else {
+            return
+        }
+
+        previewErrors[file.id] = PreviewError(fileId: file.id, downloadError: nil)
     }
 
     func handleOfficePreviewError(_ error: Error, previewIndex: Int) {

--- a/kDrive/UI/View/Files/Preview/VideoCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/VideoCollectionViewCell.swift
@@ -27,7 +27,7 @@ import Kingfisher
 import MediaPlayer
 import UIKit
 
-class VideoCollectionViewCell: PreviewCollectionViewCell {
+class VideoCollectionViewCell: PreviewCollectionViewCell, VideoViewCellDelegate {
     private class VideoPlayerNavigationController: UINavigationController {
         var disappearCallback: (() -> Void)?
 
@@ -69,9 +69,9 @@ class VideoCollectionViewCell: PreviewCollectionViewCell {
         file.getThumbnail { preview, hasThumbnail in
             self.previewFrameImageView.image = hasThumbnail ? preview : nil
         }
-        Task { @MainActor in
-            videoPlayer = VideoPlayer(frozenFile: file, driveFileManager: driveFileManager)
-        }
+        playButton.isEnabled = false
+
+        videoPlayer = VideoPlayer(frozenFile: file, driveFileManager: driveFileManager, previewDelegate: self)
     }
 
     override func didEndDisplaying() {
@@ -108,5 +108,16 @@ class VideoCollectionViewCell: PreviewCollectionViewCell {
         if let floatingPanelController = parentViewController?.presentedViewController as? FloatingPanelController {
             floatingPanelController.dismiss(animated: true)
         }
+    }
+
+    func errorWhilePreviewing(error: any Error) {
+        guard let file, let previewDelegate else { return }
+        previewDelegate.errorWhilePreviewing(fileId: file.id, error: error)
+        videoPlayer = nil
+        playButton.isEnabled = false
+    }
+
+    func readyToPlay() {
+        playButton.isEnabled = true
     }
 }


### PR DESCRIPTION
Hide play button when video can't be played

This PR fixes an issue where the play button was still shown even if the video couldn't be played. Now, the play button is hidden in such cases.