### PR TITLE
fix: Exclude shared with me folder from photo sync drive selection

### DIFF
--- a/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectDriveViewController.swift
@@ -85,7 +85,7 @@ class SelectDriveViewController: UIViewController {
     private func initForCurrentAccount(_ account: Account) {
         currentAccount = account
         accounts = accountManager.accounts.filter { $0.userId != account.userId }
-        driveList = Array(driveInfosManager.getDrives(for: account.userId, sharedWithMe: nil))
+        driveList = Array(driveInfosManager.getDrives(for: account.userId))
         dropDown.dataSource = accounts.map(\.user.displayName)
     }
 


### PR DESCRIPTION
Using a default parameter excludes the shared with me drives that are not wanted here.