### PR TITLE
fix: Prevent presentation issues on iPad

### DIFF
--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -453,7 +453,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
     func hideFloatingPanel(_ hide: Bool) {
         if hide {
             floatingPanelViewController.dismiss(animated: true)
-        } else {
+        } else if floatingPanelViewController.presentingViewController == nil {
             present(floatingPanelViewController, animated: true)
         }
     }

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -266,6 +266,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        hideFloatingPanel(true)
         navigationController?.setNavigationBarHidden(false, animated: true)
         let currentCell = (collectionView.cellForItem(at: currentIndex) as? PreviewCollectionViewCell)
         currentCell?.didEndDisplaying()

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -254,7 +254,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        present(floatingPanelViewController, animated: true)
+        hideFloatingPanel(false)
         UIApplication.shared.beginReceivingRemoteControlEvents()
         becomeFirstResponder()
 
@@ -842,6 +842,6 @@ extension PreviewViewController: UIDocumentInteractionControllerDelegate {
     }
 
     func documentInteractionControllerDidDismissOpenInMenu(_ controller: UIDocumentInteractionController) {
-        present(floatingPanelViewController, animated: true)
+        hideFloatingPanel(false)
     }
 }

--- a/kDrive/UI/Controller/Files/SidebarViewController.swift
+++ b/kDrive/UI/Controller/Files/SidebarViewController.swift
@@ -323,6 +323,15 @@ class SidebarViewController: CustomLargeTitleCollectionViewController, SelectSwi
         }
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard let previousTraitCollection else { return }
+        guard traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass
+            || traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass else { return }
+        forceRefresh()
+    }
+
     private static func generateProfileTabImages(image: UIImage) -> (UIImage) {
         let iconSize = UIConstants.Button.profileImageSize
 


### PR DESCRIPTION
I now make sure that we only try to present the faulty View Controller when it is not already been presented.
Also, the content of the `SidebarViewController` was not correctly updated when switching size class on iPad (resizing window)