### PR TITLE
fix: Crash preview in trash

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -466,17 +466,20 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         var floatingPanelViewController: DriveFloatingPanelController
         switch actionType {
         case .file:
+            guard let file = files.first else {
+                DDLogError("[FileListViewController] Unable to show quick actions panel without a file")
+                return
+            }
+
             floatingPanelViewController = DriveFloatingPanelController()
-            let fileInformationsViewController = FileActionsFloatingPanelViewController()
+            let fileInformationsViewController = FileActionsFloatingPanelViewController(frozenFile: file,
+                                                                                        driveFileManager: driveFileManager)
 
             fileInformationsViewController.presentingParent = self
             fileInformationsViewController.normalFolderHierarchy = viewModel.configuration.normalFolderHierarchy
 
             floatingPanelViewController.layout = fileFloatingPanelLayout(files: files)
-
-            if let file = files.first {
-                fileInformationsViewController.setFile(from: file.uid, driveFileManager: driveFileManager)
-            }
+            fileInformationsViewController.updateFile(from: file.uid, driveFileManager: driveFileManager)
 
             floatingPanelViewController.set(contentViewController: fileInformationsViewController)
             floatingPanelViewController.track(scrollView: fileInformationsViewController.collectionView)

--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -479,8 +479,6 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
             fileInformationsViewController.normalFolderHierarchy = viewModel.configuration.normalFolderHierarchy
 
             floatingPanelViewController.layout = fileFloatingPanelLayout(files: files)
-            fileInformationsViewController.updateFile(from: file.uid, driveFileManager: driveFileManager)
-
             floatingPanelViewController.set(contentViewController: fileInformationsViewController)
             floatingPanelViewController.track(scrollView: fileInformationsViewController.collectionView)
         case .trash:

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController+Actions.swift
@@ -387,7 +387,6 @@ extension FileActionsFloatingPanelViewController {
             present(alert, animated: true)
         } else {
             downloadFile(action: action, indexPath: indexPath) { [weak self, frozenFile] in
-                guard let frozenFile else { return }
                 FileActionsHelper.save(file: frozenFile, from: self)
             }
         }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -71,7 +71,6 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
     // MARK: - Public methods
 
     init(frozenFile: File, driveFileManager: DriveFileManager) {
-        assert(frozenFile.isFrozen, "expecting to set a frozen initially")
         self.frozenFile = frozenFile
         self.driveFileManager = driveFileManager
         super.init(collectionViewLayout: FileActionsFloatingPanelViewController.createLayout())

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -107,9 +107,10 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    func setFile(from fileUid: String, driveFileManager: DriveFileManager) {
+    func updateFile(from fileUid: String, driveFileManager: DriveFileManager) {
         guard let freshFrozenFile = driveFileManager.database.fetchObject(ofType: File.self, forPrimaryKey: fileUid)?.freeze()
         else {
+            DDLogError("Failed to fetch the file in database for fileUid: \(fileUid)")
             dismiss(animated: true)
             return
         }

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -74,6 +74,11 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         self.frozenFile = frozenFile
         self.driveFileManager = driveFileManager
         super.init(collectionViewLayout: FileActionsFloatingPanelViewController.createLayout())
+
+        let frozenFileUid = frozenFile.uid
+        Task { @MainActor in
+            updateAndObserveFile(withFileUid: frozenFileUid, driveFileManager: driveFileManager)
+        }
     }
 
     @available(*, unavailable)
@@ -106,7 +111,7 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         }
     }
 
-    func updateFile(from fileUid: String, driveFileManager: DriveFileManager) {
+    func updateAndObserveFile(withFileUid fileUid: String, driveFileManager: DriveFileManager) {
         guard let freshFrozenFile = driveFileManager.database.fetchObject(ofType: File.self, forPrimaryKey: fileUid)?.freeze()
         else {
             DDLogError("Failed to fetch the file in database for fileUid: \(fileUid)")

--- a/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
+++ b/kDrive/UI/Controller/Files/FileActionsFloatingPanelViewController.swift
@@ -34,8 +34,8 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
         frozenFile.uid
     }
 
-    private(set) var frozenFile: File!
-    private(set) var driveFileManager: DriveFileManager!
+    private(set) var frozenFile: File
+    private(set) var driveFileManager: DriveFileManager
 
     var normalFolderHierarchy = true
     var presentationOrigin = PresentationOrigin.fileList
@@ -70,8 +70,16 @@ final class FileActionsFloatingPanelViewController: UICollectionViewController {
 
     // MARK: - Public methods
 
-    convenience init() {
-        self.init(collectionViewLayout: FileActionsFloatingPanelViewController.createLayout())
+    init(frozenFile: File, driveFileManager: DriveFileManager) {
+        assert(frozenFile.isFrozen, "expecting to set a frozen initially")
+        self.frozenFile = frozenFile
+        self.driveFileManager = driveFileManager
+        super.init(collectionViewLayout: FileActionsFloatingPanelViewController.createLayout())
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -100,7 +100,11 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
 
         floatingPanelViewController = DriveFloatingPanelController()
         floatingPanelViewController.isRemovalInteractionEnabled = false
-        fileInformationsViewController = FileActionsFloatingPanelViewController()
+        fileInformationsViewController = FileActionsFloatingPanelViewController(
+            frozenFile: currentFile,
+            driveFileManager: driveFileManager
+        )
+
         fileInformationsViewController.presentingParent = self
         fileInformationsViewController.normalFolderHierarchy = normalFolderHierarchy
         fileInformationsViewController.presentationOrigin = presentationOrigin

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -253,7 +253,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
     }
 
     private func updateFileForCurrentIndex() {
-        fileInformationsViewController.updateFile(from: currentFile.uid, driveFileManager: driveFileManager)
+        fileInformationsViewController.updateAndObserveFile(withFileUid: currentFile.uid, driveFileManager: driveFileManager)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
+++ b/kDrive/UI/Controller/Files/Preview/PreviewViewController.swift
@@ -253,7 +253,7 @@ final class PreviewViewController: UIViewController, PreviewContentCellDelegate,
     }
 
     private func updateFileForCurrentIndex() {
-        fileInformationsViewController.setFile(from: currentFile.uid, driveFileManager: driveFileManager)
+        fileInformationsViewController.updateFile(from: currentFile.uid, driveFileManager: driveFileManager)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
+++ b/kDrive/UI/Controller/Menu/Trash/TrashListViewModel.swift
@@ -155,6 +155,19 @@ class TrashListViewModel: InMemoryFileListViewModel {
         sortingChanged()
     }
 
+    override func didSelectFile(at indexPath: IndexPath) {
+        guard let file: File = getFile(at: indexPath) else { return }
+        if ReachabilityListener.instance.currentStatus == .offline && !file.isDirectory && !file.isAvailableOffline {
+            return
+        }
+
+        if file.isDirectory {
+            onFilePresented?(file)
+        } else {
+            onPresentQuickActionPanel?([file], .trash)
+        }
+    }
+
     override func shouldShowEmptyView() -> Bool {
         currentDirectory.children.isEmpty
     }


### PR DESCRIPTION
- refactor `PreviewViewController` removed force unwraps.
- fix `TrashListViewModel` tap on a trashed file (not folder) shows the restoration actions.