### PR TITLE
fix: iPad resize navigation issues

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController.swift
@@ -179,6 +179,8 @@ class FileListViewController: UICollectionViewController, SwipeActionCollectionV
         (tabBarController as? PlusButtonObserver)?.updateCenterButton()
 
         tryLoadingFilesOrDisplayError()
+        
+        self.collectionView?.collectionViewLayout.invalidateLayout()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/kDrive/UI/Controller/Files/SidebarViewController.swift
+++ b/kDrive/UI/Controller/Files/SidebarViewController.swift
@@ -507,7 +507,8 @@ class SidebarViewController: CustomLargeTitleCollectionViewController, SelectSwi
     }
 
     @objc func forceRefresh() {
-        Task {
+        Task { @MainActor in
+            setItemsSnapshot(for: collectionView)
             try? await driveFileManager.initRoot()
             refreshControl.endRefreshing()
         }


### PR DESCRIPTION
File listing and drive root failing to resize when changing window size with iPadOS multitasking