### PR TITLE
chore: Explicit sendability to prevent a random build issue

### DIFF
--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperationable.swift
@@ -38,7 +38,7 @@ public protocol Operationable: AnyObject {
     func removeDependency(_ op: Operation)
     var dependencies: [Operation] { get }
     var queuePriority: Operation.QueuePriority { get set }
-    var completionBlock: (() -> Void)? { get set }
+    var completionBlock: (@Sendable () -> Void)? { get set }
     func waitUntilFinished()
     var threadPriority: Double { get }
     var qualityOfService: QualityOfService { get }


### PR DESCRIPTION
Explicit sendability of a closure to match existing Foundation type that is sendable to prevent a random build issue