### PR TITLE
feat: Early upload start during a photo sync

### DIFF
--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader+Scan.swift
@@ -21,6 +21,7 @@ import InfomaniakCore
 import InfomaniakDI
 import Photos
 import RealmSwift
+import UIKit
 
 public protocol PhotoLibraryScanable {
     func scheduleNewPicturesForUpload() async
@@ -79,6 +80,12 @@ extension PhotoLibraryUploader: PhotoLibraryScanable {
     }
 
     private func earlyUploadWhatIsAvailableIfNecessary() async {
+        // The sync _must_ be synchronous in background refresh to work correctly.
+        guard await UIApplication.shared.applicationState == .active else {
+            Log.photoLibraryUploader("No early upload start. Only starting early when app is in foreground.")
+            return
+        }
+
         let filesToUploadCount = uploadDatasource.getAllUploadingFilesFrozen().count
         let activeUploadsCount = uploadService.operationCount
 

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -41,7 +41,7 @@ public final class PhotoLibraryUploader: PhotoLibraryUploadable {
     /// Threshold value to trigger cleaning of photo roll if enabled
     static let removeAssetsCountThreshold = 10
 
-    static let startUploadWhileScanningThreshold = 1000
+    static let startUploadWhileScanningThreshold = 500
 
     /// Predicate to quickly narrow down on uploaded assets
     static let uploadedAssetPredicate = NSPredicate(format: "rawType = %@ AND uploadDate != nil", "phAsset")

--- a/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
+++ b/kDriveCore/Data/Upload/Servicies/PhotoLibraryUploader/PhotoLibraryUploader.swift
@@ -36,9 +36,12 @@ public protocol PhotoLibraryUploadable {
 public final class PhotoLibraryUploader: PhotoLibraryUploadable {
     @LazyInjectService(customTypeIdentifier: kDriveDBID.uploads) var uploadsDatabase: Transactionable
     @LazyInjectService var uploadService: UploadServiceable
+    @LazyInjectService var uploadDatasource: UploadServiceDataSourceable
 
     /// Threshold value to trigger cleaning of photo roll if enabled
     static let removeAssetsCountThreshold = 10
+
+    static let startUploadWhileScanningThreshold = 1000
 
     /// Predicate to quickly narrow down on uploaded assets
     static let uploadedAssetPredicate = NSPredicate(format: "rawType = %@ AND uploadDate != nil", "phAsset")


### PR DESCRIPTION
This works since the recent refactors.
- `uploadService.rebuildUploadQueue()` is costly, so I designed something that would not spam it.
- In background mode, we rely on a synchronous execution of the scan then the upload. 
- In background, the app continues to behave like it does today in production.