### PR TITLE
fix(OnlyOfficeViewController): Navigation outside of edit mode

### DIFF
--- a/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
+++ b/kDrive/UI/Controller/Files/OnlyOfficeViewController.swift
@@ -223,7 +223,8 @@ extension OnlyOfficeViewController: WKUIDelegate {
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         guard let url = navigationAction.request.url else { return nil }
-        if navigationAction.targetFrame == nil && url.host == ApiEnvironment.current.driveHost {
+        let matchingDomain = url.host == ApiEnvironment.current.driveHost || url.host == URLConstants.kSuiteWeb.url.host
+        if navigationAction.targetFrame == nil && matchingDomain {
             dismiss()
             return nil
         }

--- a/kDriveCore/Utils/Constants.swift
+++ b/kDriveCore/Utils/Constants.swift
@@ -33,6 +33,7 @@ public enum PhotoLibraryImport: Int {
 public struct URLConstants {
     public static let kDriveRedirection = URLConstants(urlString: "https://kdrive.infomaniak.com/app/drive")
     public static let kDriveWeb = URLConstants(urlString: "https://kdrive.infomaniak.com")
+    public static let kSuiteWeb = URLConstants(urlString: "https://ksuite.infomaniak.com")
     public static let signUp = URLConstants(urlString: "https://welcome.infomaniak.com/signup/ikdrive/steps")
     public static let shop = URLConstants(urlString: "https://shop.infomaniak.com/order/drive")
     public static let appStore = URLConstants(urlString: "https://apps.apple.com/app/infomaniak-kdrive/id1482778676")


### PR DESCRIPTION
Navigate outside an OnlyOffice edit webview now works with ksuite based links.