### PR TITLE
fix: Seek native player

### DIFF
--- a/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
+++ b/kDriveCore/AudioPlayer/SingleTrackPlayer.swift
@@ -125,7 +125,6 @@ public final class SingleTrackPlayer: Pausable {
     private func setupStreamingAsset(_ urlAsset: AVURLAsset, fileName: String) async {
         player = AVPlayer(playerItem: AVPlayerItem(asset: urlAsset))
         await setMetaData(from: urlAsset.commonMetadata, playableFileName: fileName)
-        setUpObservers()
 
         currentItemStatusObserver = player?.observe(\.currentItem?.status) { _, _ in
             self.handleItemStatusChange()
@@ -163,8 +162,6 @@ public final class SingleTrackPlayer: Pausable {
     private func updateNowPlayingInfo() {
         var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
 
-        print("JE JOUE MAINTENANT: \(nowPlayingInfo[MPMediaItemPropertyTitle] as? String ?? "NULL")")
-
         nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
         nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = false
 
@@ -175,6 +172,8 @@ public final class SingleTrackPlayer: Pausable {
             if let artwork = currentTrackMetadata.artwork {
                 let artworkItem = MPMediaItemArtwork(boundsSize: artwork.size) { _ in artwork }
                 nowPlayingInfo[MPMediaItemPropertyArtwork] = artworkItem
+            } else {
+                nowPlayingInfo[MPMediaItemPropertyArtwork] = nil
             }
         }
 
@@ -322,6 +321,7 @@ public final class SingleTrackPlayer: Pausable {
 
     public func play() {
         if playerState == .stopped {
+            setUpObservers()
             updateNowPlayingInfo()
             do {
                 try AVAudioSession.sharedInstance().setActive(true)
@@ -368,6 +368,7 @@ public final class SingleTrackPlayer: Pausable {
     }
 
     public func seek(to position: TimeInterval) {
+        stopPlaybackObservation()
         seek(to: CMTime(seconds: position, preferredTimescale: 1))
     }
 


### PR DESCRIPTION
This pull request refactors how the `SingleTrackPlayer` manages and updates the Now Playing metadata for audio playback, consolidating and improving the logic for updating playback information, and making several related improvements for correctness and maintainability.

**Now Playing Info Management:**

* Removed the old `setNowPlayingMetadata` and `setNowPlayingPlaybackInfo` methods, replacing them with a unified `updateNowPlayingInfo` method that updates all relevant metadata, including track details, artwork, playback position, and duration, with improved checks for finite values. [[1]](diffhunk://#diff-6bb96aac10cac4844f2192f6c37a36632bc33099099e2c727e839cf0889ee2f5L150-L166) [[2]](diffhunk://#diff-6bb96aac10cac4844f2192f6c37a36632bc33099099e2c727e839cf0889ee2f5L179-L201)
* Ensured that Now Playing info is cleared when playback stops by setting `MPNowPlayingInfoCenter.default().nowPlayingInfo` to `nil` in the stop logic.

**Playback State and Observers:**

* Updated observer setup and usage to call the new `updateNowPlayingInfo` method instead of the removed methods, ensuring metadata stays in sync with playback state changes. [[1]](diffhunk://#diff-6bb96aac10cac4844f2192f6c37a36632bc33099099e2c727e839cf0889ee2f5L263-R261) [[2]](diffhunk://#diff-6bb96aac10cac4844f2192f6c37a36632bc33099099e2c727e839cf0889ee2f5L329-R325)
* Added a guard in the `pause` method to prevent pausing unless the player is actually playing, improving state handling.
* Ensured playback observation is stopped before seeking to a new position, preventing potential conflicts or redundant updates.

**Progress Calculation:**

* Improved the `progressPercentage` property in the `AVPlayer` extension to check for a valid duration before calculating progress, preventing division by zero.