### PR TITLE
fix: Reduce imageCompression when scanning PDFs

### DIFF
--- a/kDriveCore/Utils/Files/FileImportHelper.swift
+++ b/kDriveCore/Utils/Files/FileImportHelper.swift
@@ -75,6 +75,7 @@ public final class FileImportHelper {
     @LazyInjectService var appContextService: AppContextServiceable
 
     static let imageCompression = 0.8
+    static let pdfCompression = 0.5
 
     /// Domain specific errors
     public enum ErrorDomain: Error {

--- a/kDriveCore/Utils/Files/PDFScanImportHelper.swift
+++ b/kDriveCore/Utils/Files/PDFScanImportHelper.swift
@@ -50,7 +50,7 @@ struct PDFScanImportHelper {
 
         for pageIndex in 0 ..< scan.pageCount {
             let pageImage = scan.imageOfPage(at: pageIndex)
-            guard let pageData = pageImage.jpegData(compressionQuality: FileImportHelper.imageCompression),
+            guard let pageData = pageImage.jpegData(compressionQuality: FileImportHelper.pdfCompression),
                   let compressedPageImage = UIImage(data: pageData) else {
                 return nil
             }


### PR DESCRIPTION
Following a customer request reported in Redmine, the PDF image compression level has been adjusted from 0.8 to 0.5.
This change reduces the overall PDF file size while maintaining an acceptable image quality.