### PR TITLE
fix: Dynamic framework dropdown

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -20,6 +20,7 @@ let packageSettings = PackageSettings(
         "DesignSystem": .framework,
         "DeviceAssociation": .framework,
         "DifferenceKit": .framework,
+        "DropDown": .framework,
         "InAppTwoFactorAuthentication": .framework,
         "InfomaniakBugTracker": .framework,
         "InfomaniakConcurrency": .framework,


### PR DESCRIPTION
Fix a crash in share extension created by the recent update of Tuist