### PR TITLE
ci: Periphery

### DIFF
--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -1,0 +1,32 @@
+name: CI workflow
+
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  periphery:
+    name: Scan unused code
+    runs-on: [ self-hosted, iOS ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
+      - name: Create test env
+        env:
+          ENV_PATH: "kDriveTestShared/Env.swift"
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          USER_ID: ${{ secrets.USER_ID }}
+          INVITE_USER_ID: ${{ secrets.INVITE_USER_ID }}
+          INVITE_EMAIL: ${{ secrets.INVITE_EMAIL }}
+        run: |
+          touch $ENV_PATH
+          echo -e "enum Env {\n    static let token = \"$ACCESS_TOKEN\"\n\n    static let driveId = 420132\n\n    static let userId = $USER_ID\n\n    static let inviteUserId = $INVITE_USER_ID\n\n    static let inviteMail = \"$INVITE_EMAIL\"\n\n    static let inviteTeam = 0\n\n    static let commonDocumentsId = 3\n}" > $ENV_PATH
+      - name: Generate
+        run: tuist install && tuist generate
+      - name: Periphery
+        run: periphery scan --retain-codable-properties --format github-actions --relative-results --strict
+        

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8
+        with:
+          cache: false
       - name: Create test env
         env:
           ENV_PATH: "kDriveTestShared/Env.swift"

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,9 @@
+project: kDrive.xcworkspace
+retain_public: true
+schemes:
+  - kDrive
+index_exclude:
+  - "kDriveAPITests/**"
+  - "kDriveTestShared/**"
+  - "kDriveTests/**"
+  - "kDriveUITests/**"

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -38,7 +38,7 @@ import VersionChecker
 
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
-    /// Making sure the DI is registered at a very early stage of the app launch.
+    /// periphery:ignore - Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .app)
 
     private var reachabilityListener: ReachabilityListener!

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -41,8 +41,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     /// periphery:ignore - Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .app)
 
-    private var reachabilityListener: ReachabilityListener!
-
     @LazyInjectService var infomaniakLogin: InfomaniakLogin
     @LazyInjectService var notificationHelper: NotificationsHelpable
     @LazyInjectService var accountManager: AccountManageable

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -68,7 +68,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         ]
         ImageDownloader.default.sessionConfiguration = sessionConfiguration
 
-        reachabilityListener = ReachabilityListener.instance
+        _ = ReachabilityListener.instance
 
         // Start audio session
         do {

--- a/kDrive/AppDelegate.swift
+++ b/kDrive/AppDelegate.swift
@@ -45,7 +45,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     @LazyInjectService var notificationHelper: NotificationsHelpable
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var backgroundTasksService: BackgroundTasksServiceable
-    @LazyInjectService var appRestorationService: AppRestorationServiceable
     @LazyInjectService var appNavigable: AppNavigable
     @LazyInjectService var backgroundDownloadSessionManager: BackgroundDownloadSessionManager
     @LazyInjectService var backgroundUploadSessionManager: BackgroundUploadSessionManager

--- a/kDrive/AppRouter.swift
+++ b/kDrive/AppRouter.swift
@@ -778,6 +778,7 @@ public struct AppRouter: AppNavigable {
         presentingViewController.present(SFSafariViewController(url: url), animated: true)
     }
 
+    // periphery:ignore
     public func refreshCacheScanLibraryAndUpload(preload: Bool, isSwitching: Bool) async {
         Log.sceneDelegate("refreshCacheScanLibraryAndUpload preload:\(preload) isSwitching:\(preload)")
 

--- a/kDrive/IAP/StoreManager.swift
+++ b/kDrive/IAP/StoreManager.swift
@@ -41,6 +41,7 @@ class StoreManager: NSObject {
         fetchProducts(matchingIdentifiers: identifiers)
     }
 
+    // periphery:ignore
     /// Existing product's title matching the specified product identifier.
     func title(matchingIdentifier identifier: String) -> String? {
         guard !availableProducts.isEmpty else { return nil }
@@ -51,6 +52,7 @@ class StoreManager: NSObject {
         return result?.localizedTitle
     }
 
+    // periphery:ignore
     /// Existing product's title associated with the specified payment transaction.
     func title(matchingPaymentTransaction transaction: SKPaymentTransaction) -> String {
         let title = title(matchingIdentifier: transaction.payment.productIdentifier)
@@ -63,6 +65,7 @@ class StoreManager: NSObject {
         // META: keep SonarCloud happy
     }
 
+    // periphery:ignore
     /// Fetches information about your products from the App Store.
     private func fetchProducts(matchingIdentifiers identifiers: [String]) {
         // Create a set for the product identifiers

--- a/kDrive/IAP/StoreObserver.swift
+++ b/kDrive/IAP/StoreObserver.swift
@@ -67,6 +67,7 @@ class StoreObserver: NSObject {
         SKPaymentQueue.default().add(payment)
     }
 
+    // periphery:ignore
     /// Restores all previously completed purchases.
     func restore() {
         if !restored.isEmpty {

--- a/kDrive/SceneDelegate.swift
+++ b/kDrive/SceneDelegate.swift
@@ -38,6 +38,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, AccountManagerDel
     @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
     @LazyInjectService var uploadObservation: UploadObservable
 
+    // periphery:ignore
     private var mediaHelper: OpenMediaHelper?
     var currentRootViewControllerState: RootViewControllerState = .splashScreen
     var shortcutItemToProcess: UIApplicationShortcutItem?
@@ -112,6 +113,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, AccountManagerDel
         appNavigable.updateTheme()
     }
 
+    // periphery:ignore
     func configure(window: UIWindow?, session: UISceneSession, with activity: NSUserActivity) -> Bool {
         Log.sceneDelegate("configure session with")
         return true
@@ -240,6 +242,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, AccountManagerDel
         }
     }
 
+    // periphery:ignore
     @discardableResult
     private func continueWebActivityIfPossible(_ scene: UIScene, userActivity: NSUserActivity) async -> Bool {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
@@ -282,6 +285,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate, AccountManagerDel
 
     // MARK: - Reload drive notification
 
+    // periphery:ignore
     @objc func reloadDrive(_ notification: Notification) {
         Task {
             await self.appNavigable.refreshCacheScanLibraryAndUpload(preload: false, isSwitching: false)

--- a/kDrive/UI/Controller/Alert/AlertDocViewController.swift
+++ b/kDrive/UI/Controller/Alert/AlertDocViewController.swift
@@ -47,6 +47,7 @@ class AlertDocViewController: AlertFieldViewController {
         textFieldConfiguration = .fileNameConfiguration
     }
 
+    // periphery:ignore
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/kDrive/UI/Controller/Home/HomeViewController.swift
+++ b/kDrive/UI/Controller/Home/HomeViewController.swift
@@ -105,6 +105,7 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
         case insufficientStorage
     }
 
+    // periphery:ignore
     enum RecentFileRow: Differentiable {
         case file
         case loading
@@ -112,8 +113,6 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
 
     var driveFileManager: DriveFileManager
 
-    private var floatingPanelViewController: DriveFloatingPanelController?
-    private var fileInformationsViewController: FileActionsFloatingPanelViewController!
     private lazy var filePresenter = FilePresenter(viewController: self)
 
     private var recentActivitiesController: HomeRecentActivitiesController?
@@ -125,7 +124,6 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
         isLoading: false
     )
     private var showInsufficientStorage = true
-    private var filesObserver: ObservationToken?
 
     private let refreshControl = UIRefreshControl()
 
@@ -204,6 +202,7 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
         reload(newViewModel: newViewModel)
     }
 
+    // periphery:ignore
     func reloadWith(fetchedFiles: [FileActivity], isEmpty: Bool) {
         refreshControl.endRefreshing()
         let newViewModel = HomeViewModel(topRows: viewModel.topRows,
@@ -342,6 +341,7 @@ class HomeViewController: CustomLargeTitleCollectionViewController, UpdateAccoun
 
     // MARK: - State restoration
 
+    // periphery:ignore
     var currentSceneMetadata: [AnyHashable: Any] {
         [:]
     }

--- a/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
+++ b/kDrive/UI/Controller/Menu/PhotoList/PhotoListViewController.swift
@@ -75,8 +75,6 @@ final class PhotoListViewController: FileListViewController {
         return viewModel as? PhotoListViewModel
     }
 
-    private weak var currentNavigationController: UINavigationController?
-
     enum SelectionMode {
         case selecting
         case deselecting
@@ -86,7 +84,6 @@ final class PhotoListViewController: FileListViewController {
     var selectionMode: SelectionMode = .none
     var lastTouchPoint: CGPoint = .zero
     var startIndexPath: IndexPath?
-    var initialTouchPoint: CGPoint?
     var displayLink: CADisplayLink?
     var scrollSpeed: CGFloat = 0
 
@@ -207,8 +204,6 @@ final class PhotoListViewController: FileListViewController {
         navigationController?.navigationBar.standardAppearance = navbarAppearance
         navigationController?.navigationBar.compactAppearance = navbarAppearance
         navigationController?.navigationBar.scrollEdgeAppearance = navbarAppearance
-
-        currentNavigationController = navigationController
     }
 
     override func showEmptyView(_ isShowing: Bool) {
@@ -268,10 +263,6 @@ final class PhotoListViewController: FileListViewController {
         collectionView.reloadSections(IndexSet(integersIn: 0 ..< numberOfSections(in: collectionView)))
     }
 
-    func updateTitle(_ count: Int) {
-        headerTitleLabel.text = KDriveResourcesStrings.Localizable.fileListMultiSelectedTitle(count)
-    }
-
     @objc func handleSelectionPan(_ gesture: UIPanGestureRecognizer) {
         let location = gesture.location(in: collectionView)
 
@@ -290,15 +281,13 @@ final class PhotoListViewController: FileListViewController {
             }
 
             startIndexPath = indexPath
-            initialTouchPoint = location
             startDisplayLink()
 
         case .changed:
             updateScrollSpeed(for: lastTouchPoint)
-            updateSelection(to: location, current: indexPath)
+            updateSelection(current: indexPath)
 
         case .ended, .cancelled, .failed:
-            initialTouchPoint = nil
             stopDisplayLink()
             selectionMode = .none
 
@@ -307,7 +296,7 @@ final class PhotoListViewController: FileListViewController {
         }
     }
 
-    func updateSelection(to location: CGPoint, current: IndexPath) {
+    func updateSelection(current: IndexPath) {
         guard let start = startIndexPath,
               let multipleSelectionViewModel = photoListViewModel.multipleSelectionViewModel else { return }
 
@@ -455,6 +444,7 @@ final class PhotoListViewController: FileListViewController {
         return cell
     }
 
+    // periphery:ignore
     func collectionView(
         _ collectionView: UICollectionView,
         layout collectionViewLayout: UICollectionViewLayout,

--- a/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
+++ b/kDriveCore/Data/DownloadQueue/BackgroundDownloadSessionManager.swift
@@ -21,6 +21,7 @@ import Foundation
 import InfomaniakCoreDB
 import InfomaniakDI
 
+// periphery:ignore
 protocol BackgroundDownloadSessionManagable: NSObject, URLSessionTaskDelegate {
     // MARK: - Type aliases
 

--- a/kDriveCore/Data/Upload/Servicies/BackgroundUploadSessionManager.swift
+++ b/kDriveCore/Data/Upload/Servicies/BackgroundUploadSessionManager.swift
@@ -27,6 +27,7 @@ public typealias RequestCompletionHandler = (Data?, URLResponse?, Error?) -> Voi
 /// A completion handler to call to terminate the handling of a background task finishing
 public typealias BackgroundCompletionHandler = () -> Void
 
+// periphery:ignore
 protocol BackgroundUploadSessionManageable: URLSessionTaskDelegate, URLSessionDelegate, URLSessionDataDelegate {
     var backgroundSession: URLSession! { get }
 

--- a/kDriveCore/Data/Upload/Servicies/BackgroundUploadSessionManager.swift
+++ b/kDriveCore/Data/Upload/Servicies/BackgroundUploadSessionManager.swift
@@ -38,6 +38,7 @@ protocol BackgroundUploadSessionManageable: URLSessionTaskDelegate, URLSessionDe
     func rescheduleForBackground(task: URLSessionDataTask, fileUrl: URL) -> String?
 }
 
+// periphery:ignore
 /// Something that can provide a completion handler for a request
 protocol BackgroundUploadSessionCompletionable {
     /// Fetch completion handler for a specified request

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Database.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Database.swift
@@ -19,6 +19,7 @@
 import Foundation
 import RealmSwift
 
+// periphery:ignore
 extension UploadOperation {
     /// The standard way to interact with a UploadFile within an UploadOperation
     ///

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Database.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+Database.swift
@@ -29,7 +29,7 @@ extension UploadOperation {
     ///   - function: The name of the function performing the transaction
     ///   - task: A closure to mutate the current `UploadFile`
     func transactionWithFile(function: StaticString = #function, _ task: @escaping (_ file: UploadFile) throws -> Void) throws {
-        /// A cancelled operation can access database for cleanup, _not_ a finished one.
+        // A cancelled operation can access database for cleanup, _not_ a finished one.
         guard !isFinished else {
             throw ErrorDomain.operationFinished
         }

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -105,6 +105,7 @@ extension UploadOperation {
         return chunkPath
     }
 
+    // periphery:ignore
     /// Prepare chunk upload requests, and start them.
     private func scheduleNextChunk(filePath: String, chunksToGenerateCount: Int) async throws {
         do {

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -64,7 +64,6 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
     // MARK: - Attributes
 
-    @LazyInjectService var backgroundUploadManager: BackgroundUploadSessionManager
     @LazyInjectService var uploadService: UploadServiceable
     @LazyInjectService var accountManager: AccountManageable
     @LazyInjectService var photoLibraryUploader: PhotoLibraryUploadable
@@ -387,6 +386,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         }
     }
 
+    // periphery:ignore
     private func uploadCompletionSuccess(data: Data, response: URLResponse?, error: Error?) async throws {
         Log.uploadOperation("completion successful \(uploadFileId)")
 
@@ -442,6 +442,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         enqueueTryFinishOrEnqueueNextChunk()
     }
 
+    // periphery:ignore
     private func uploadCompletionLocalFailure(data: Data?, response: URLResponse?, error: Error) throws {
         Log.uploadOperation("completion Client-side error:\(error) ufid:\(uploadFileId)", level: .error)
         let nsError = error as NSError
@@ -468,6 +469,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         }
     }
 
+    // periphery:ignore
     private func uploadCompletionRemoteFailure(data: Data?, response: URLResponse?, error: Error?) {
         // Silent handling if error if cancel error
         guard let nsError = error as? NSError,

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -163,8 +163,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
     /// Return the available chunking slots.
     func availableWorkerSlots() -> Int {
         let uploadTasksCount = uploadTasks.count
-        let free = max(Self.parallelism - uploadTasksCount, 0)
-        return free
+        return max(Self.parallelism - uploadTasksCount, 0)
     }
 
     func fileSize(fileUrl: URL) throws -> UInt64 {
@@ -362,7 +361,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
     // MARK: Network callback
 
-    // Chunk upload network callback
+    /// Chunk upload network callback
     public func uploadCompletion(data: Data?, response: URLResponse?, error: Error?) {
         enqueueCatching {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
@@ -454,8 +453,8 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
         switch nsError.code {
         case NSURLErrorCancelled, NSURLErrorNetworkConnectionLost:
-            /// Here a Chunk request canceled on .taskRescheduled _or_ the network connection was lost
-            /// Either way we catch silently the issue, the operation will seamlessly retry the chunk
+            // Here a Chunk request canceled on .taskRescheduled _or_ the network connection was lost
+            // Either way we catch silently the issue, the operation will seamlessly retry the chunk
             var iterator = uploadTasks.makeIterator()
             try cleanUploadSessionUploadTaskNotUploading(iterator: &iterator)
 

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
@@ -75,8 +75,7 @@ public class UploadQueue: ParallelismHeuristicDelegate {
         }
 
         let status = ReachabilityListener.instance.currentStatus
-        let shouldBeSuspended = status == .offline
-        return shouldBeSuspended
+        return status == .offline
     }
 
     /// Should suspend operation queue based on explicit `suspendAllOperations()` call

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueue.swift
@@ -23,6 +23,7 @@ import InfomaniakDI
 import RealmSwift
 import Sentry
 
+// periphery:ignore
 public protocol UploadQueueDelegate: AnyObject {
     func operationQueueBecameEmpty(_ queue: UploadQueue)
     func operationQueueNoLongerEmpty(_ queue: UploadQueue)
@@ -32,6 +33,7 @@ public class UploadQueue: ParallelismHeuristicDelegate {
     @LazyInjectService var appContextService: AppContextServiceable
     @LazyInjectService var uploadPublisher: UploadPublishable
 
+    // periphery:ignore
     private var queueObserver: UploadQueueObserver?
 
     static let silentErrors: [DriveError] =

--- a/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Queue/UploadQueueable.swift
@@ -20,6 +20,7 @@ import FileProvider
 import Foundation
 import RealmSwift
 
+// periphery:ignore
 public protocol UploadQueueable {
     func getOperation(forUploadFileId uploadFileId: String) -> UploadOperationable?
 

--- a/kDriveCore/VideoPlayer/VideoPlayer.swift
+++ b/kDriveCore/VideoPlayer/VideoPlayer.swift
@@ -94,6 +94,7 @@ public final class VideoPlayer: Pausable {
         onPlaybackEnded?()
     }
 
+    // periphery:ignore
     @objc func playerStateChanged(notification: Notification) {
         guard let file else { return }
         guard let player else { return }

--- a/kDriveFileProvider/Enumerators/RootEnumerator.swift
+++ b/kDriveFileProvider/Enumerators/RootEnumerator.swift
@@ -22,6 +22,7 @@ import InfomaniakDI
 import kDriveCore
 import RealmSwift
 
+// periphery:ignore:all
 class RootEnumerator: NSObject, NSFileProviderEnumerator {
     private let driveFileManager: DriveFileManager
     private let domain: NSFileProviderDomain?

--- a/kDriveFileProvider/FileProviderExtension.swift
+++ b/kDriveFileProvider/FileProviderExtension.swift
@@ -57,6 +57,7 @@ final class FileProviderExtension: NSFileProviderExtension {
     @LazyInjectService var uploadService: UploadServiceable
     @LazyInjectService var uploadDataSource: UploadServiceDataSourceable
 
+    // periphery:ignore
     /// Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .fileProviderExtension)
 

--- a/kDriveFileProvider/NSFileProviderPage+Extension.swift
+++ b/kDriveFileProvider/NSFileProviderPage+Extension.swift
@@ -20,10 +20,6 @@ import Foundation
 import kDriveCore
 
 extension NSFileProviderPage {
-    init(_ integer: Int) {
-        self.init(withUnsafeBytes(of: integer.littleEndian) { Data($0) })
-    }
-
     init?(_ cursor: FileCursor) {
         guard let cursorData = cursor.data(using: .utf8) else { return nil }
         self.init(cursorData)

--- a/kDriveFileProvider/NSFileProviderPage+Extension.swift
+++ b/kDriveFileProvider/NSFileProviderPage+Extension.swift
@@ -19,6 +19,7 @@
 import Foundation
 import kDriveCore
 
+// periphery:ignore:all
 extension NSFileProviderPage {
     init?(_ cursor: FileCursor) {
         guard let cursorData = cursor.data(using: .utf8) else { return nil }

--- a/kDriveShareExtension/ShareNavigationViewController.swift
+++ b/kDriveShareExtension/ShareNavigationViewController.swift
@@ -24,6 +24,8 @@ import UIKit
 import VersionChecker
 
 final class ShareNavigationViewController: TitleSizeAdjustingNavigationController {
+    
+    // periphery:ignore
     /// Making sure the DI is registered at a very early stage of the app launch.
     private let dependencyInjectionHook = EarlyDIHook(context: .shareExtension)
 


### PR DESCRIPTION
An implementation that should not slow us up, still allow testing the app correctly, while working great with a mature code base.

To be merged post ios15 drop
depends on https://github.com/Infomaniak/ios-kDrive/pull/1715

To test locally ` periphery scan --retain-codable-properties --format json --relative-results --strict`

Issue to resolve regarding disabling periphery in one target fails in another where the call is superfluous.
My research shows it cannot be silenced