### PR TITLE
fix: Crash on iPad share extension when selecting a destination

### DIFF
--- a/kDrive/UI/Controller/Files/SidebarViewController.swift
+++ b/kDrive/UI/Controller/Files/SidebarViewController.swift
@@ -283,7 +283,7 @@ class SidebarViewController: CustomLargeTitleCollectionViewController, SelectSwi
         } else if !isCompactView && !selectMode {
             applySnapshotForLargeView(userRootFolders: userRootFolders)
         } else {
-            dataSource.apply(itemsSnapshot, animatingDifferences: true)
+            dataSource.apply(itemsSnapshot, animatingDifferences: false)
         }
     }
 


### PR DESCRIPTION
fix(SidebarViewController): DiffKit crashes when animating changes on iPad, animation is disabled on select mode only