### PR TITLE
refactor: Avoiding double usage of localUrl and localContainerUrl

### DIFF
--- a/kDrive/UI/View/Files/Preview/OfficePreviewCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/Preview/OfficePreviewCollectionViewCell.swift
@@ -43,22 +43,23 @@ class OfficePreviewCollectionViewCell: PreviewCollectionViewCell {
 
     override func configureWith(file: File) {
         fileId = file.id
+        let localUrl = file.localUrl
         if file.uti.conforms(to: .plainText) {
             // Load data for plain text to have correct encoding
             do {
-                let data = try Data(contentsOf: file.localUrl)
+                let data = try Data(contentsOf: localUrl)
                 documentPreview.load(
                     data,
                     mimeType: file.uti.preferredMIMEType ?? "text/plain",
                     characterEncodingName: "UTF8",
-                    baseURL: file.localUrl
+                    baseURL: localUrl
                 )
             } catch {
                 // Fallback on file loading
-                documentPreview.loadFileURL(file.localUrl, allowingReadAccessTo: file.localUrl)
+                documentPreview.loadFileURL(localUrl, allowingReadAccessTo: localUrl)
             }
         } else {
-            documentPreview.loadFileURL(file.localUrl, allowingReadAccessTo: file.localUrl)
+            documentPreview.loadFileURL(localUrl, allowingReadAccessTo: localUrl)
         }
     }
 }

--- a/kDrive/Utils/FileActionsHelper.swift
+++ b/kDrive/Utils/FileActionsHelper.swift
@@ -128,6 +128,9 @@ public final class FileActionsHelper {
     public static func save(file: File, from viewController: UIViewController? = nil, showSuccessSnackBar: Bool = true) {
         guard !file.isInvalidated else { return }
 
+        let localUrl = file.localUrl
+        let temporaryUrl = file.temporaryUrl
+
         @InjectService var appNavigable: AppNavigable
         let presenterViewController = viewController != nil
             ? viewController
@@ -141,23 +144,23 @@ public final class FileActionsHelper {
                 .snackbarVideoSavedConfirmation : KDriveResourcesStrings.Localizable
                 .snackbarImageSavedConfirmation
             saveMedia(
-                url: file.localUrl,
+                url: localUrl,
                 type: convertedType.assetMediaType,
                 successMessage: showSuccessSnackBar ? successMessage : nil
             )
         case .folder:
-            guard FileManager.default.fileExists(atPath: file.temporaryUrl.path) else {
+            guard FileManager.default.fileExists(atPath: temporaryUrl.path) else {
                 UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.errorDownload)
                 return
             }
-            let documentExportViewController = UIDocumentPickerViewController(forExporting: [file.temporaryUrl], asCopy: true)
+            let documentExportViewController = UIDocumentPickerViewController(forExporting: [temporaryUrl], asCopy: true)
             presenterViewController?.present(documentExportViewController, animated: true)
         default:
-            guard FileManager.default.fileExists(atPath: file.localUrl.path) else {
+            guard FileManager.default.fileExists(atPath: localUrl.path) else {
                 UIConstants.showSnackBar(message: KDriveResourcesStrings.Localizable.errorDownload)
                 return
             }
-            let documentExportViewController = UIDocumentPickerViewController(forExporting: [file.localUrl], asCopy: true)
+            let documentExportViewController = UIDocumentPickerViewController(forExporting: [localUrl], asCopy: true)
             presenterViewController?.present(documentExportViewController, animated: true)
         }
     }

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+AvailableOffline.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager+AvailableOffline.swift
@@ -155,8 +155,9 @@ public extension DriveFileManager {
 
         let frozenFile = liveFile.freeze()
         if oldUrl != frozenFile.localUrl {
-            try? fileManager.createDirectory(at: frozenFile.cacheLocalContainerUrl, withIntermediateDirectories: true)
-            try? fileManager.moveItem(at: oldUrl, to: frozenFile.localFileUrl(from: frozenFile.cacheLocalContainerUrl))
+            let cacheLocalContainerUrl = frozenFile.cacheLocalContainerUrl
+            try? fileManager.createDirectory(at: cacheLocalContainerUrl, withIntermediateDirectories: true)
+            try? fileManager.moveItem(at: oldUrl, to: frozenFile.localFileUrl(from: cacheLocalContainerUrl))
             try? fileManager.removeItem(at: oldUrl)
         }
 

--- a/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
+++ b/kDriveCore/Data/Cache/DriveFileManager/DriveFileManager.swift
@@ -1223,9 +1223,10 @@ public final class DriveFileManager {
         var orphanFiles = [File]()
 
         for maybeOrphanFile in maybeOrphanFiles {
+            let localContainerUrl = maybeOrphanFile.localContainerUrl
             if newFiles == nil || !(newFiles ?? []).contains(maybeOrphanFile) {
-                if fileManager.fileExists(atPath: maybeOrphanFile.localContainerUrl.path) {
-                    try? fileManager.removeItem(at: maybeOrphanFile.localContainerUrl) // Check that it was correctly removed?
+                if fileManager.fileExists(atPath: localContainerUrl.path) {
+                    try? fileManager.removeItem(at: localContainerUrl) // Check that it was correctly removed?
                 }
                 orphanFiles.append(maybeOrphanFile)
             }
@@ -1269,8 +1270,9 @@ public final class DriveFileManager {
     }
 
     public func renameCachedFile(updatedFile: File, oldFile: File) throws {
-        if updatedFile.name != oldFile.name && fileManager.fileExists(atPath: oldFile.localUrl.path) {
-            try fileManager.moveItem(atPath: oldFile.localUrl.path, toPath: updatedFile.localUrl.path)
+        let oldLocalUrl = oldFile.localUrl.path
+        if updatedFile.name != oldFile.name && fileManager.fileExists(atPath: oldLocalUrl) {
+            try fileManager.moveItem(atPath: oldLocalUrl, toPath: updatedFile.localUrl.path)
         }
     }
 

--- a/kDriveCore/Data/DownloadQueue/DownloadOperation/DownloadAuthenticatedOperation.swift
+++ b/kDriveCore/Data/DownloadQueue/DownloadOperation/DownloadAuthenticatedOperation.swift
@@ -228,8 +228,9 @@ public class DownloadAuthenticatedOperation: DownloadOperation, DownloadFileOper
 
     private func moveFileToCache(downloadPath: URL) throws {
         DDLogInfo("[DownloadOperation] moveFileToCache")
-        try fileManager.removeItemIfExists(at: file.localContainerUrl)
-        try fileManager.createDirectory(at: file.localContainerUrl, withIntermediateDirectories: true)
+        let localContainerUrl = file.localContainerUrl
+        try fileManager.removeItemIfExists(at: localContainerUrl)
+        try fileManager.createDirectory(at: localContainerUrl, withIntermediateDirectories: true)
         try fileManager.moveItem(at: downloadPath, to: file.localUrl)
         file.applyLastModifiedDateToLocalFile()
         file.excludeFileFromSystemBackup()

--- a/kDriveCore/Data/Models/DragAndDropFile.swift
+++ b/kDriveCore/Data/Models/DragAndDropFile.swift
@@ -112,8 +112,9 @@ extension DragAndDropFile: NSItemProviderWriting {
             }
             return nil
         } else {
+            let localUrl = file.localUrl
             if !file.isLocalVersionOlderThanRemote {
-                loadLocalData(for: file.localUrl, completionHandler: completionHandler)
+                loadLocalData(for: localUrl, completionHandler: completionHandler)
                 return nil
             } else {
                 let progress = Progress(totalUnitCount: 100)
@@ -130,7 +131,7 @@ extension DragAndDropFile: NSItemProviderWriting {
                     if let error {
                         completionHandler(nil, error)
                     } else {
-                        let url = file.isDirectory ? file.temporaryUrl : file.localUrl
+                        let url = file.isDirectory ? file.temporaryUrl : localUrl
                         loadLocalData(for: url, completionHandler: completionHandler)
                     }
                 }

--- a/kDriveCore/Data/Models/File.swift
+++ b/kDriveCore/Data/Models/File.swift
@@ -577,12 +577,10 @@ public final class File: Object, Codable {
             .appendingPathComponent("\(id)", isDirectory: true)
     }
 
-    // TODO: Refactor to no longer rely on implicit isAvailableOffline from the database
     public var localUrl: URL {
         return localContainerUrl.appendingPathComponent(name, isDirectory: isDirectory)
     }
 
-    // TODO: Refactor to no longer rely on implicit isAvailableOffline from the database
     public var localContainerUrl: URL {
         return isAvailableOffline ? offlineContainerUrl : cacheLocalContainerUrl
     }


### PR DESCRIPTION
The computed url property may change if the object is live, and it is computed multiple times. 
Here by using a let, we both harden the code and make it more efficient.