### PR TITLE
fix: Proper compatible way to read the locale

### DIFF
--- a/kDriveCore/Data/Models/FileAccess.swift
+++ b/kDriveCore/Data/Models/FileAccess.swift
@@ -44,8 +44,8 @@ public struct FileAccessSettings: Encodable {
         teamIds: [Int]? = nil,
         userIds: [Int]? = nil
     ) {
-        let languageCode = Locale.current.identifier
-        if allowedLanguageCodes.contains(languageCode) {
+        let languageCode = Locale.current.language.languageCode?.identifier
+        if let languageCode, allowedLanguageCodes.contains(languageCode) {
             lang = languageCode
         } else {
             lang = "en"


### PR DESCRIPTION
Actually using the proper iOS16 way to read an identifier that matches the one we had on iOS15.