### PR TITLE
feat: Chunk uploads from memory

### DIFF
--- a/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
+++ b/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
@@ -18,13 +18,10 @@
 
 import Foundation
 import InfomaniakCore
-import InfomaniakDI
 import RealmSwift
 
 /// Tracks the upload of a chunk
 public final class UploadingChunkTask: EmbeddedObject {
-    @LazyInjectService var fileManager: FileManagerable
-
     override public init() {
         // Required by Realm
         super.init()
@@ -94,16 +91,22 @@ public final class UploadingChunkTask: EmbeddedObject {
 
     // MARK: - Computed Properties
 
-    /// The chunk is stored locally inside a file, with a path and we have a valid hash of it.
-    public var hasLocalChunk: Bool {
-        guard let path,
-              !path.isEmpty,
-              fileManager.isReadableFile(atPath: path),
-              let sha256,
+    /// The chunk hash has been computed and is ready for upload.
+    /// With the streaming upload optimization, we no longer write temp chunk files.
+    /// We only need the SHA256 hash to be computed from the source file range.
+    public var isReadyForUpload: Bool {
+        guard let sha256,
               !sha256.isEmpty else {
             return false
         }
         return true
+    }
+
+    /// Legacy property for backward compatibility during migration.
+    /// Now delegates to `isReadyForUpload` since we no longer write temp chunk files.
+    @available(*, deprecated, renamed: "isReadyForUpload")
+    public var hasLocalChunk: Bool {
+        return isReadyForUpload
     }
 
     /// The range of the original file

--- a/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
+++ b/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
@@ -102,13 +102,6 @@ public final class UploadingChunkTask: EmbeddedObject {
         return true
     }
 
-    /// Legacy property for backward compatibility during migration.
-    /// Now delegates to `isReadyForUpload` since we no longer write temp chunk files.
-    @available(*, deprecated, renamed: "isReadyForUpload")
-    public var hasLocalChunk: Bool {
-        return isReadyForUpload
-    }
-
     /// The range of the original file
     public var range: DataRange {
         get {

--- a/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
+++ b/kDriveCore/Data/Models/Upload/UploadingChunkTask.swift
@@ -92,8 +92,6 @@ public final class UploadingChunkTask: EmbeddedObject {
     // MARK: - Computed Properties
 
     /// The chunk hash has been computed and is ready for upload.
-    /// With the streaming upload optimization, we no longer write temp chunk files.
-    /// We only need the SHA256 hash to be computed from the source file range.
     public var isReadyForUpload: Bool {
         guard let sha256,
               !sha256.isEmpty else {

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -20,7 +20,8 @@ import Foundation
 import InfomaniakCore
 
 extension UploadOperation {
-    /// Generate some chunks into a temporary folder from a file
+    /// Compute SHA256 hash for chunks that need it, then fan out for upload.
+    /// This optimized version reads directly from the source file without writing temporary chunk files.
     func generateChunksAndFanOutIfNeeded() async throws {
         Log.uploadOperation("generateChunksAndFanOutIfNeeded ufid:\(uploadFileId)")
         try checkCancelation()
@@ -35,12 +36,11 @@ extension UploadOperation {
             }
 
             filePath = file.pathURL?.path ?? ""
-            let sessionToken = uploadingSessionTask.token
 
-            // Look for the next chunk to generate
+            // Look for the next chunk that needs hash computation
             let chunksToGenerate = uploadingSessionTask.chunkTasks
                 .filter(UploadingChunkTask.notDoneUploadingPredicate)
-                .filter { $0.hasLocalChunk == false }
+                .filter { !$0.isReadyForUpload }
             guard let chunkTask = chunksToGenerate.first else {
                 Log.uploadOperation("generateChunksAndFanOutIfNeeded no remaining chunks to generate ufid:\(self.uploadFileId)")
                 return
@@ -51,58 +51,30 @@ extension UploadOperation {
             let chunkNumber = chunkTask.chunkNumber
             let range = chunkTask.range
             let fileUrl = try self.getFileUrlIfReadable(file: file)
+
+            // Read chunk data from source file to compute SHA256 hash
             guard let chunkProvider = ChunkProvider(fileURL: fileUrl, ranges: [range]),
-                  let chunk = chunkProvider.next() else {
+                  let chunkData = chunkProvider.next() else {
                 Log.uploadOperation("Unable to get a ChunkProvider for \(self.uploadFileId)", level: .error)
                 throw ErrorDomain.chunkError
             }
 
             Log.uploadOperation(
-                "Storing Chunk count:\(chunkNumber) of \(chunksToGenerateCount) to write, ufid:\(self.uploadFileId)"
+                "Computing hash for chunk:\(chunkNumber) of \(chunksToGenerateCount) remaining, ufid:\(self.uploadFileId)"
             )
-            do {
-                try self.checkCancelation()
 
-                let chunkSHA256 = chunk.SHA256DigestString
-                let chunkPath = try self.storeChunk(chunk,
-                                                    number: chunkNumber,
-                                                    uploadFileId: self.uploadFileId,
-                                                    sessionToken: sessionToken,
-                                                    hash: chunkSHA256)
-                Log.uploadOperation("chunk stored count:\(chunkNumber) for:\(self.uploadFileId)")
+            try self.checkCancelation()
 
-                // set path + sha
-                chunkTask.path = chunkPath.path
-                chunkTask.sha256 = chunkSHA256
+            // Compute and store only the SHA256 hash - no temp file needed
+            let chunkSHA256 = chunkData.SHA256DigestString
+            chunkTask.sha256 = chunkSHA256
 
-            } catch {
-                Log.uploadOperation(
-                    "Unable to save a chunk to storage. number:\(chunkNumber) error:\(error) for:\(self.uploadFileId)",
-                    level: .error
-                )
-                throw error
-            }
+            Log.uploadOperation("Hash computed for chunk:\(chunkNumber) ufid:\(self.uploadFileId)")
         }
 
         // Schedule next step
         try await scheduleNextChunk(filePath: filePath,
                                     chunksToGenerateCount: chunksToGenerateCount)
-    }
-
-    /// Store a chunk at the root of NSTemporaryDirectory with a stable name
-    func storeChunk(_ buffer: Data, number: Int64,
-                    uploadFileId: String,
-                    sessionToken: String,
-                    hash: String) throws -> URL {
-        // Store chunks at the root of NSTemporaryDirectory
-        let tempRoot = FileManager.default.temporaryDirectory
-        let chunkName = chunkName(number: number, fileId: uploadFileId, sessionToken: sessionToken, hash: hash)
-        let chunkPath = tempRoot.appendingPathComponent(chunkName)
-
-        try buffer.write(to: chunkPath, options: [.atomic])
-        Log.uploadOperation("wrote chunk:\(chunkPath) ufid:\(uploadFileId)")
-
-        return chunkPath
     }
 
     /// Prepare chunk upload requests, and start them.
@@ -133,6 +105,8 @@ extension UploadOperation {
     }
 
     /// Prepare chunk upload requests, and start them.
+    /// This optimized version reads chunk data directly from the source file using memory mapping,
+    /// avoiding the need to write temporary chunk files to disk.
     func fanOutChunks() async throws {
         try checkCancelation()
         try checkForRestrictedUploadOverDataMode()
@@ -156,7 +130,7 @@ extension UploadOperation {
 
             let chunksToUpload = Array(uploadingSessionTask.chunkTasks
                 .filter(UploadingChunkTask.canStartUploadingPreconditionPredicate)
-                .filter { $0.hasLocalChunk == true })
+                .filter { $0.isReadyForUpload })
                 .prefix(freeSlots) // Iterate over only the available worker slots
 
             Log.uploadOperation("fanOut chunksToUpload:\(chunksToUpload.count) freeSlots:\(freeSlots) for:\(self.uploadFileId)")
@@ -168,20 +142,44 @@ extension UploadOperation {
                 throw ErrorDomain.unableToBuildRequest
             }
 
+            // Get the source file URL for reading chunk data
+            let sourceFileUrl = try self.getFileUrlIfReadable(file: file)
+
+            // Memory-map the source file for efficient chunk reading
+            let mappedFileData: Data
+            do {
+                mappedFileData = try Data(contentsOf: sourceFileUrl, options: .mappedIfSafe)
+            } catch {
+                Log.uploadOperation("Failed to memory-map source file: \(error) ufid:\(self.uploadFileId)", level: .error)
+                throw error
+            }
+
             // Schedule all the chunks to be uploaded
             for chunkToUpload: UploadingChunkTask in chunksToUpload {
                 try self.checkCancelation()
 
                 do {
-                    guard let chunkPath = chunkToUpload.path,
-                          let sha256 = chunkToUpload.sha256 else {
+                    guard let sha256 = chunkToUpload.sha256 else {
                         throw ErrorDomain.missingChunkHash
                     }
 
                     let chunkHashHeader = "sha256:\(sha256)"
-                    let chunkUrl = URL(fileURLWithPath: chunkPath, isDirectory: false)
                     let chunkNumber = chunkToUpload.chunkNumber
                     let chunkSize = chunkToUpload.chunkSize
+                    let range = chunkToUpload.range
+
+                    // Extract chunk data directly from memory-mapped source file
+                    let startIndex = Int(range.lowerBound)
+                    let endIndex = Int(range.upperBound) + 1 // upperBound is inclusive in DataRange
+                    guard startIndex >= 0, endIndex <= mappedFileData.count else {
+                        Log.uploadOperation(
+                            "Chunk range out of bounds: \(range) for file size \(mappedFileData.count) ufid:\(self.uploadFileId)",
+                            level: .error
+                        )
+                        throw ErrorDomain.chunkError
+                    }
+                    let chunkData = mappedFileData[startIndex ..< endIndex]
+
                     let request = try self.buildRequest(chunkNumber: chunkNumber,
                                                         chunkSize: chunkSize,
                                                         chunkHash: chunkHashHeader,
@@ -190,8 +188,9 @@ extension UploadOperation {
                                                         accessToken: accessToken,
                                                         host: uploadSession.uploadHost)
 
+                    // Upload directly from memory-mapped data slice - no temp file needed
                     let uploadTask = self.urlSession.uploadTask(with: request,
-                                                                fromFile: chunkUrl,
+                                                                from: chunkData,
                                                                 completionHandler: self.uploadCompletion)
                     // Extra 512 bytes for request headers
                     uploadTask.countOfBytesClientExpectsToSend = Int64(chunkSize) + 512
@@ -217,12 +216,6 @@ extension UploadOperation {
                 }
             }
         }
-    }
-
-    private func chunkName(number: Int64, fileId: String, sessionToken: String, hash: String) -> String {
-        // Hashing name as it can break path building. Also it keeps it short
-        let fileName = "upload_\(fileId)_\(hash)_\(number)_\(sessionToken)".SHA256DigestString
-        return fileName + ".part"
     }
 
     /// Make sure all `uploadTasks` canceled or completed are up to date in database.

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -21,7 +21,6 @@ import InfomaniakCore
 
 extension UploadOperation {
     /// Compute SHA256 hash for chunks that need it, then fan out for upload.
-    /// This optimized version reads directly from the source file without writing temporary chunk files.
     func generateChunksAndFanOutIfNeeded() async throws {
         Log.uploadOperation("generateChunksAndFanOutIfNeeded ufid:\(uploadFileId)")
         try checkCancelation()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -139,14 +139,6 @@ extension UploadOperation {
 
             let sourceFileUrl = try self.getFileUrlIfReadable(file: file)
 
-            let mappedFileData: Data
-            do {
-                mappedFileData = try Data(contentsOf: sourceFileUrl, options: .mappedIfSafe)
-            } catch {
-                Log.uploadOperation("Failed to memory-map source file: \(error) ufid:\(self.uploadFileId)", level: .error)
-                throw error
-            }
-
             // Schedule all the chunks to be uploaded
             for chunkToUpload: UploadingChunkTask in chunksToUpload {
                 try self.checkCancelation()
@@ -161,17 +153,11 @@ extension UploadOperation {
                     let chunkSize = chunkToUpload.chunkSize
                     let range = chunkToUpload.range
 
-                    // Extract chunk data directly from memory-mapped source file
-                    let startIndex = Int(range.lowerBound)
-                    let endIndex = Int(range.upperBound) + 1 // upperBound is inclusive in DataRange
-                    guard startIndex >= 0, endIndex <= mappedFileData.count else {
-                        Log.uploadOperation(
-                            "Chunk range out of bounds: \(range) for file size \(mappedFileData.count) ufid:\(self.uploadFileId)",
-                            level: .error
-                        )
+                    guard let chunkProvider = ChunkProvider(fileURL: sourceFileUrl, ranges: [range]),
+                          let chunkData = chunkProvider.next() else {
+                        Log.uploadOperation("Unable to read chunk data for \(self.uploadFileId)", level: .error)
                         throw ErrorDomain.chunkError
                     }
-                    let chunkData = mappedFileData[startIndex ..< endIndex]
 
                     let request = try self.buildRequest(chunkNumber: chunkNumber,
                                                         chunkSize: chunkSize,

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -52,7 +52,6 @@ extension UploadOperation {
             let range = chunkTask.range
             let fileUrl = try self.getFileUrlIfReadable(file: file)
 
-            // Read chunk data from source file to compute SHA256 hash
             guard let chunkProvider = ChunkProvider(fileURL: fileUrl, ranges: [range]),
                   let chunkData = chunkProvider.next() else {
                 Log.uploadOperation("Unable to get a ChunkProvider for \(self.uploadFileId)", level: .error)
@@ -65,7 +64,6 @@ extension UploadOperation {
 
             try self.checkCancelation()
 
-            // Compute and store only the SHA256 hash - no temp file needed
             let chunkSHA256 = chunkData.SHA256DigestString
             chunkTask.sha256 = chunkSHA256
 
@@ -105,8 +103,6 @@ extension UploadOperation {
     }
 
     /// Prepare chunk upload requests, and start them.
-    /// This optimized version reads chunk data directly from the source file using memory mapping,
-    /// avoiding the need to write temporary chunk files to disk.
     func fanOutChunks() async throws {
         try checkCancelation()
         try checkForRestrictedUploadOverDataMode()
@@ -142,10 +138,8 @@ extension UploadOperation {
                 throw ErrorDomain.unableToBuildRequest
             }
 
-            // Get the source file URL for reading chunk data
             let sourceFileUrl = try self.getFileUrlIfReadable(file: file)
 
-            // Memory-map the source file for efficient chunk reading
             let mappedFileData: Data
             do {
                 mappedFileData = try Data(contentsOf: sourceFileUrl, options: .mappedIfSafe)
@@ -188,7 +182,6 @@ extension UploadOperation {
                                                         accessToken: accessToken,
                                                         host: uploadSession.uploadHost)
 
-                    // Upload directly from memory-mapped data slice - no temp file needed
                     let uploadTask = self.urlSession.uploadTask(with: request,
                                                                 from: chunkData,
                                                                 completionHandler: self.uploadCompletion)

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation+UploadChunk.swift
@@ -26,15 +26,12 @@ extension UploadOperation {
         try checkCancelation()
         try checkForRestrictedUploadOverDataMode()
 
-        var filePath = ""
         var chunksToGenerateCount = 0
         try transactionWithFile { file in
             // Get the current uploading session
             guard let uploadingSessionTask = file.uploadingSession else {
                 throw ErrorDomain.uploadSessionTaskMissing
             }
-
-            filePath = file.pathURL?.path ?? ""
 
             // Look for the next chunk that needs hash computation
             let chunksToGenerate = uploadingSessionTask.chunkTasks
@@ -70,12 +67,11 @@ extension UploadOperation {
         }
 
         // Schedule next step
-        try await scheduleNextChunk(filePath: filePath,
-                                    chunksToGenerateCount: chunksToGenerateCount)
+        try await scheduleNextChunk(chunksToGenerateCount: chunksToGenerateCount)
     }
 
     /// Prepare chunk upload requests, and start them.
-    private func scheduleNextChunk(filePath: String, chunksToGenerateCount: Int) async throws {
+    private func scheduleNextChunk(chunksToGenerateCount: Int) async throws {
         do {
             try checkCancelation()
             try checkForRestrictedUploadOverDataMode()

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -313,9 +313,16 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 )
             }
 
-            // If task is cancelled, remove it from list
+            // If task is cancelled, remove it from list and clean source file
             if file.error == DriveError.taskCancelled {
                 shouldCleanUploadFile = true
+
+                // Also clean source file for cancelled uploads to prevent data leaks
+                if file.cleanSourceFileIfNeeded() {
+                    Log.uploadOperation(
+                        "Removed local file for cancelled upload at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
+                    )
+                }
             }
 
             // otherwise only reset success

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -416,17 +416,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 assertionFailure("unable to lookup chunk task id, ufid:\(self.uploadFileId)")
             }
 
-            // Cleanup chunks in storage
-            if let path = chunkTask.path {
-                let url = URL(fileURLWithPath: path, isDirectory: false)
-                let chunkNumber = chunkTask.chunkNumber
-                Log.uploadOperation("cleanup chunk:\(chunkNumber) ufid:\(self.uploadFileId)")
-                do {
-                    try self.fileManager.removeItem(at: url)
-                } catch {
-                    Log.uploadOperation("failed to clean chunk \(error) ufid:\(self.uploadFileId)", level: .error)
-                }
-            }
+            // Note: No temp file cleanup needed - chunks are now uploaded directly from memory-mapped source file
         } notFound: {
             Log.uploadOperation("matching chunk:\(uploadedChunk.number) failed ufid:\(self.uploadFileId)", level: .error)
             let context = ["Chunk number": uploadedChunk.number, "fid": self.uploadFileId]

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -313,16 +313,9 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 )
             }
 
-            // If task is cancelled, remove it from list and clean source file
+            // If task is cancelled, remove it from list
             if file.error == DriveError.taskCancelled {
                 shouldCleanUploadFile = true
-
-                // Also clean source file for cancelled uploads to prevent data leaks
-                if file.cleanSourceFileIfNeeded() {
-                    Log.uploadOperation(
-                        "Removed local file for cancelled upload at path:\(String(describing: file.pathURL)) ufid:\(self.uploadFileId)"
-                    )
-                }
             }
 
             // otherwise only reset success

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -422,8 +422,6 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
                 // We may be running both the app and the extension
                 assertionFailure("unable to lookup chunk task id, ufid:\(self.uploadFileId)")
             }
-
-            // Note: No temp file cleanup needed - chunks are now uploaded directly from memory-mapped source file
         } notFound: {
             Log.uploadOperation("matching chunk:\(uploadedChunk.number) failed ufid:\(self.uploadFileId)", level: .error)
             let context = ["Chunk number": uploadedChunk.number, "fid": self.uploadFileId]

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -458,8 +458,8 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
 
     private func uploadCompletionRemoteFailure(data: Data?, response: URLResponse?, error: Error?) {
         // Silent handling if error if cancel error
-        guard let nsError = error as? NSError,
-              nsError.code == NSURLErrorCancelled else {
+        if let nsError = error as? NSError,
+           nsError.code == NSURLErrorCancelled {
             return
         }
 

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -382,7 +382,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
 
             // Server-side error
             else {
-                self.uploadCompletionRemoteFailure(data: data, response: response, error: error)
+                self.uploadCompletionRemoteFailure(data: data, response: response)
             }
         }
     }
@@ -456,17 +456,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
         }
     }
 
-    private func uploadCompletionRemoteFailure(data: Data?, response: URLResponse?, error: Error?) {
-        // Silent handling if error if cancel error
-        if let nsError = error as? NSError,
-           nsError.code == NSURLErrorCancelled {
-            Log.uploadOperation(
-                "uploadCompletionRemoteFailure NSURLErrorCancelled ufid:\(uploadFileId)",
-                level: .error
-            )
-            return
-        }
-
+    private func uploadCompletionRemoteFailure(data: Data?, response: URLResponse?) {
         defer {
             end()
         }
@@ -482,10 +472,6 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
         if let data,
            let apiError = try? DriveApiFetcher.decoder.decode(ApiResponse<Empty>.self, from: data).error {
             driveError = DriveError(apiError: apiError)
-        }
-
-        if let error {
-            driveError = driveError.wrapping(error)
         }
 
         Log.uploadOperation("completion  Server-side error:\(driveError) ufid:\(uploadFileId) ", level: .error)

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -31,7 +31,7 @@ public struct UploadCompletionResult {
     var driveFile: File?
 }
 
-public final class UploadOperation: AsynchronousOperation, UploadOperationable {
+public final class UploadOperation: AsynchronousOperation, UploadOperationable, @unchecked Sendable {
     /// Local specialized errors
     enum ErrorDomain: Error {
         /// Building a request failed

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -460,6 +460,10 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable {
         // Silent handling if error if cancel error
         if let nsError = error as? NSError,
            nsError.code == NSURLErrorCancelled {
+            Log.uploadOperation(
+                "uploadCompletionRemoteFailure NSURLErrorCancelled ufid:\(uploadFileId)",
+                level: .error
+            )
             return
         }
 

--- a/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
+++ b/kDriveCore/Data/Upload/UploadQueue/Operation/UploadOperation.swift
@@ -382,7 +382,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
 
             // Server-side error
             else {
-                self.uploadCompletionRemoteFailure(data: data, response: response)
+                self.uploadCompletionRemoteFailure(data: data)
             }
         }
     }
@@ -456,7 +456,7 @@ public final class UploadOperation: AsynchronousOperation, UploadOperationable, 
         }
     }
 
-    private func uploadCompletionRemoteFailure(data: Data?, response: URLResponse?) {
+    private func uploadCompletionRemoteFailure(data: Data?) {
         defer {
             end()
         }


### PR DESCRIPTION
Optimization regarding upload chunking. No major change to the upload mechanism. It only touches the chunking part.

Change: No longer copy on storage the content of the chunks of a file that is already a protective copy.

Optimization: Uploading each chunk from the exact "slice" of the file in memory.