### PR TITLE
chore: Update tuist to 4.195.6

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-tuist = { version = "4.133.1", os = ["macos"] }
+tuist = { version = "4.195.6", os = ["macos"] }
 swiftformat = { version = "0.58.6", os = ["macos", "linux"] }
 swiftlint = { version = "0.62.2", os = ["macos", "linux"] }
 sentry-cli = { version = "latest", os = ["macos"] }

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-features",
       "state" : {
-        "revision" : "87cc1a846fc0dad2a25b2261d33950d98395e66e",
-        "version" : "8.9.1"
+        "revision" : "cc3fb4c8fc5756246b53b293a94abdd111bc674b",
+        "version" : "8.9.2"
       }
     },
     {


### PR DESCRIPTION
`Tuist` needs to be updated regularly, I waited for the final build of iOS15, which is now behind us, so here is the update PR.

depends on https://github.com/Infomaniak/ios-kDrive/pull/1915