### PR TITLE
chore: Update realm to 20.x branch

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e615561160774b9456b455ee041962f9365ab4abebc05159e2742b7cac60c613",
+  "originHash" : "1586482aa28847c0f3ac69da418ee2241ba271f3b718546746ee4025f6704803",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Infomaniak/ios-core",
       "state" : {
-        "revision" : "abce7c839e7da92252432f08b4c7dc1ba71b903c",
-        "version" : "18.11.1"
+        "branch" : "chore/upgrade-realm",
+        "revision" : "d9c14f63978ce9f5cf18eb068fcc1822ccfe626e"
       }
     },
     {
@@ -240,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "cccb3ca9e26ec452a29f2f0d4050d1e38b8a3d43",
-        "version" : "14.14.0"
+        "revision" : "4cc46f8607516226e5465062fdacd088fbd94552",
+        "version" : "20.1.4"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift",
       "state" : {
-        "revision" : "1c105d34f25af7851c5a3ff146be006de247a6b4",
-        "version" : "10.54.6"
+        "revision" : "600e187711e5fa4e8e2c0429cacee27e8e44f112",
+        "version" : "20.0.4"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -61,7 +61,7 @@ let package = Package(
         .package(url: "https://github.com/getsentry/sentry-cocoa", .upToNextMajor(from: "9.8.0")),
         .package(url: "https://github.com/Infomaniak/DropDown", branch: "master"),
         .package(url: "https://github.com/Infomaniak/ios-bug-tracker", .upToNextMajor(from: "17.0.1")),
-        .package(url: "https://github.com/Infomaniak/ios-core", .upToNextMajor(from: "18.10.2")),
+        .package(url: "https://github.com/Infomaniak/ios-core", branch: "chore/upgrade-realm"),
         .package(url: "https://github.com/Infomaniak/ios-core-ui", .upToNextMajor(from: "24.5.0")),
         .package(url: "https://github.com/Infomaniak/ios-dependency-injection", .upToNextMajor(from: "2.0.5")),
         .package(url: "https://github.com/Infomaniak/ios-device-check", .upToNextMajor(from: "1.1.1")),
@@ -75,7 +75,7 @@ let package = Package(
         .package(url: "https://github.com/matomo-org/matomo-sdk-ios", .upToNextMajor(from: "7.5.1")),
         .package(url: "https://github.com/ProxymanApp/atlantis", .upToNextMajor(from: "1.3.0")),
         .package(url: "https://github.com/ra1028/DifferenceKit", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.52.0")),
+        .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "20.0.4")),
         .package(url: "https://github.com/SCENEE/FloatingPanel", .upToNextMajor(from: "3.0.0")),
         .package(url: "https://github.com/emqx/swift-mqtt", .upToNextMajor(from: "1.5.0")),
         .package(url: "https://github.com/FelixHerrmann/swift-package-list", .upToNextMajor(from: "4.10.0"))


### PR DESCRIPTION
Update from 10.54.6 to 20.1.4

To be merged in a different beta than the Tuist update.