### PR TITLE
fix: Update state of FileListBarButtonType in MultiSelection

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
@@ -575,7 +575,7 @@ class FileListViewController: UICollectionViewController, SceneStateRestorable {
               !multipleSelectionViewModel.isMultipleSelectionEnabled
         else { return }
 
-        multipleSelectionViewModel.isMultipleSelectionEnabled = true
+        multipleSelectionViewModel.enableMultipleSelection(realmDirectoryCount: viewModel.directoryFilesCount)
         // Necessary for events to trigger in the right order
         Task { @MainActor [weak self] in
             guard let self else { return }

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -104,6 +104,7 @@ class FileListViewModel: SelectDelegate {
     var currentDirectoryObservationToken: NotificationToken?
 
     var currentDirectory: File
+    var directoryFilesCount: FileCount?
     var driveFileManager: DriveFileManager {
         didSet {
             multipleSelectionViewModel?.driveFileManager = driveFileManager
@@ -237,6 +238,11 @@ class FileListViewModel: SelectDelegate {
                 guard let newResults else { return }
                 currentDirectory = getRefreshedCurrentDirectory()
                 files = Array(newResults.freezeIfNeeded())
+                directoryFilesCount = FileCount(
+                    count: files.count,
+                    files: files.filter { !$0.isDirectory }.count,
+                    directories: files.filter { $0.isDirectory }.count
+                )
                 isShowingEmptyView = shouldShowEmptyView()
             }
 

--- a/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewModel.swift
@@ -238,10 +238,19 @@ class FileListViewModel: SelectDelegate {
                 guard let newResults else { return }
                 currentDirectory = getRefreshedCurrentDirectory()
                 files = Array(newResults.freezeIfNeeded())
+
+                let fileTypeCounts = files.reduce(into: (files: 0, directories: 0)) { counts, file in
+                    if file.isDirectory {
+                        counts.directories += 1
+                    } else {
+                        counts.files += 1
+                    }
+                }
+
                 directoryFilesCount = FileCount(
                     count: files.count,
-                    files: files.filter { !$0.isDirectory }.count,
-                    directories: files.filter { $0.isDirectory }.count
+                    files: fileTypeCounts.files,
+                    directories: fileTypeCounts.directories
                 )
                 isShowingEmptyView = shouldShowEmptyView()
             }

--- a/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
@@ -223,8 +223,8 @@ class MultipleSelectionFileListViewModel {
     func enableMultipleSelection(realmDirectoryCount: FileCount? = nil) {
         isMultipleSelectionEnabled = true
         directoryCount = realmDirectoryCount
+        rightBarButtons = [.loading]
         Task { [proxyCurrentDirectory = currentDirectory.proxify()] in
-            rightBarButtons = [.loading]
             if let publicShareProxy = driveFileManager.publicShareProxy {
                 directoryCount = try await PublicShareApiFetcher()
                     .countPublicShare(drive: publicShareProxy.proxyDrive,
@@ -240,7 +240,6 @@ class MultipleSelectionFileListViewModel {
 
     func selectAll() {
         selectedItems.removeAll()
-        isSelectAllModeEnabled = true
         setRightBarButtons(from: .selectAll)
         onSelectAll?()
     }
@@ -284,6 +283,7 @@ class MultipleSelectionFileListViewModel {
         guard let directoryCount else { return }
         switch from {
         case .selectAll:
+            isSelectAllModeEnabled = true
             selectedCount = directoryCount.count
             rightBarButtons = [.deselectAll]
         case .deselectAll:

--- a/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
+++ b/kDrive/UI/Controller/Files/File List/MultipleSelectionFileListViewModel.swift
@@ -119,6 +119,8 @@ class MultipleSelectionFileListViewModel {
     private var currentDirectory: File
     private var configuration: FileListViewModel.Configuration
 
+    private var directoryCount: FileCount?
+
     init(configuration: FileListViewModel.Configuration, driveFileManager: DriveFileManager, currentDirectory: File) {
         isMultipleSelectionEnabled = false
         selectedCount = 0
@@ -218,30 +220,29 @@ class MultipleSelectionFileListViewModel {
         }
     }
 
+    func enableMultipleSelection(realmDirectoryCount: FileCount? = nil) {
+        isMultipleSelectionEnabled = true
+        directoryCount = realmDirectoryCount
+        Task { [proxyCurrentDirectory = currentDirectory.proxify()] in
+            rightBarButtons = [.loading]
+            if let publicShareProxy = driveFileManager.publicShareProxy {
+                directoryCount = try await PublicShareApiFetcher()
+                    .countPublicShare(drive: publicShareProxy.proxyDrive,
+                                      linkUuid: publicShareProxy.shareLinkUid,
+                                      fileId: publicShareProxy.fileId,
+                                      token: publicShareProxy.token)
+            } else {
+                directoryCount = try await driveFileManager.apiFetcher.count(of: proxyCurrentDirectory)
+            }
+        }
+        setRightBarButtons()
+    }
+
     func selectAll() {
         selectedItems.removeAll()
         isSelectAllModeEnabled = true
-        rightBarButtons = [.loading]
+        setRightBarButtons(from: .selectAll)
         onSelectAll?()
-        Task { [proxyCurrentDirectory = currentDirectory.proxify()] in
-            do {
-                let directoryCount: FileCount
-                if let publicShareProxy = driveFileManager.publicShareProxy {
-                    directoryCount = try await PublicShareApiFetcher()
-                        .countPublicShare(drive: publicShareProxy.proxyDrive,
-                                          linkUuid: publicShareProxy.shareLinkUid,
-                                          fileId: publicShareProxy.fileId,
-                                          token: publicShareProxy.token)
-                } else {
-                    directoryCount = try await driveFileManager.apiFetcher.count(of: proxyCurrentDirectory)
-                }
-
-                selectedCount = directoryCount.count
-                rightBarButtons = [.deselectAll]
-            } catch {
-                deselectAll()
-            }
-        }
     }
 
     func deselectAll() {
@@ -249,7 +250,7 @@ class MultipleSelectionFileListViewModel {
         selectedItems.removeAll()
         exceptItemIds.removeAll()
         isSelectAllModeEnabled = false
-        rightBarButtons = [.selectAll]
+        setRightBarButtons(from: .deselectAll)
         onDeselectAll?()
     }
 
@@ -261,6 +262,7 @@ class MultipleSelectionFileListViewModel {
             selectedItems.insert(file)
             selectedCount = selectedItems.count
         }
+        setRightBarButtons()
         onItemSelected?(indexPath)
     }
 
@@ -274,6 +276,25 @@ class MultipleSelectionFileListViewModel {
         } else {
             selectedItems.remove(file)
             selectedCount = selectedItems.count
+        }
+        setRightBarButtons()
+    }
+
+    private func setRightBarButtons(from: FileListBarButtonType? = nil) {
+        guard let directoryCount else { return }
+        switch from {
+        case .selectAll:
+            selectedCount = directoryCount.count
+            rightBarButtons = [.deselectAll]
+        case .deselectAll:
+            selectedCount = 0
+            rightBarButtons = [.selectAll]
+        default:
+            if selectedCount == directoryCount.count {
+                rightBarButtons = [.deselectAll]
+            } else {
+                rightBarButtons = [.selectAll]
+            }
         }
     }
 

--- a/kDriveCore/Data/Models/FileCount.swift
+++ b/kDriveCore/Data/Models/FileCount.swift
@@ -22,4 +22,10 @@ public class FileCount: Codable {
     public let count: Int
     public let files: Int
     public let directories: Int
+
+    public init(count: Int, files: Int, directories: Int) {
+        self.count = count
+        self.files = files
+        self.directories = directories
+    }
 }


### PR DESCRIPTION
When a multi-select event happens, we retrieve the directoryCount from Realm (passed from FileListViewModel)
Then we check directoryCount, if the network call succeeds.
Add a new method that checks the button's state whenever there's a change (Select, Deselect, AllSelect, and AllDeselect)

Depends On #1907 