### PR TITLE
fix(UploadQueueViewController): NSInternalInconsistencyException

### DIFF
--- a/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
+++ b/kDrive/UI/Controller/Files/Upload/UploadQueueViewController.swift
@@ -157,6 +157,7 @@ final class UploadQueueViewController: UIViewController {
 
         observedFilesSubject
             .throttle(for: .seconds(1), scheduler: observationQueue, latest: true)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] throttledFiles in
                 self?.reloadCollectionView(with: throttledFiles)
             }
@@ -167,18 +168,16 @@ final class UploadQueueViewController: UIViewController {
         let newSections = buildSections(files: frozenFiles)
         let changeSet = StagedChangeset(source: sections, target: newSections)
 
-        Task { @MainActor in
-            tableView.reload(using: changeSet,
-                             with: UITableView.RowAnimation.automatic,
-                             interrupt: { $0.changeCount > Endpoint.itemsPerPage },
-                             setData: { newValues in
-                                 frozenUploadingFiles = frozenFiles
-                                 sections = newValues
-                             })
+        tableView.reload(using: changeSet,
+                         with: UITableView.RowAnimation.automatic,
+                         interrupt: { $0.changeCount > Endpoint.itemsPerPage },
+                         setData: { newValues in
+                             frozenUploadingFiles = frozenFiles
+                             sections = newValues
+                         })
 
-            if frozenFiles.isEmpty {
-                navigationController?.popViewController(animated: true)
-            }
+        if frozenFiles.isEmpty {
+            navigationController?.popViewController(animated: true)
         }
     }
 


### PR DESCRIPTION
This is an old bug that could trigger while looking at files uploading.

Data source diffing could still be an issue and trigger a NSInternalInconsistencyException, root cause was a race condition.

Now we make sure, any event is processed on the main thread, since it does require local class state, thus not inherently thread safe.