### PR TITLE
fix: Liquid crash

### DIFF
--- a/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
+++ b/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
@@ -104,8 +104,8 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
             newStandardNavigationBarAppearance.titleTextAttributes[.foregroundColor] = titleColor
             newCompactNavigationBarAppearance?.titleTextAttributes[.foregroundColor] = titleColor
 
-            navigationBar.standardAppearance = newStandardNavigationBarAppearance
-            navigationBar.compactAppearance = newCompactNavigationBarAppearance
+            navigationItem.standardAppearance = newStandardNavigationBarAppearance
+            navigationItem.compactAppearance = newCompactNavigationBarAppearance
         }
 
         guard let originalTitle else { return }

--- a/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
+++ b/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
@@ -50,10 +50,7 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        // Appearance updates are suppressed while a push/pop transition is in flight (see
-        // updateNavigationBarAppearance) and the navigation bar appearance is shared across the navigation
-        // stack. Force a refresh once the transition has settled so we never leave a stale/outdated bar on
-        // screen. transitionCoordinator is nil here, so applying the appearance is safe.
+        // Refresh once the transition has settled, since updates are skipped during it.
         lastAppliedTitleAlpha = nil
         updateNavigationBarAppearance()
     }
@@ -85,10 +82,8 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
     }
 
     private func updateNavigationBarAppearance() {
-        // Reassigning the navigation bar appearance while a push/pop transition is animating makes iOS 26's
-        // Liquid Glass navigation bar rebuild its transition context, which re-initializes the parallax
-        // dimming view and crashes with "View was already initialized". Never mutate the bar mid-transition
-        // (this also covers the interactive back-swipe, which drives scrollViewDidScroll while transitioning).
+        // Mutating the nav bar appearance mid push/pop re-inits the parallax dimming view on iOS 26
+        // (Liquid Glass) and crashes: "View was already initialized". Skip while transitioning.
         guard navigationController?.transitionCoordinator == nil else { return }
 
         if let title = navigationItem.title {
@@ -102,8 +97,7 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
         let titleStyle = TextStyle.header3
         let alpha = min(1, max(0, (scrollOffset + headerViewHeight) / navigationBarHeight))
 
-        // Avoid redundant appearance reassignments (e.g. while the alpha stays clamped at 0 or 1 during a
-        // scroll), which needlessly churn the navigation bar transition machinery for no visual change.
+        // Skip redundant reassignments when the alpha hasn't changed.
         if lastAppliedTitleAlpha != alpha {
             lastAppliedTitleAlpha = alpha
             let titleColor = titleStyle.color.withAlphaComponent(alpha)

--- a/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
+++ b/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
@@ -82,10 +82,6 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
     }
 
     private func updateNavigationBarAppearance() {
-        // Mutating the nav bar appearance mid push/pop re-inits the parallax dimming view on iOS 26
-        // (Liquid Glass) and crashes: "View was already initialized". Skip while transitioning.
-        guard navigationController?.transitionCoordinator == nil else { return }
-
         if let title = navigationItem.title {
             originalTitle = title
         }
@@ -117,6 +113,10 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
     }
 
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // Mutating the nav bar appearance mid push/pop re-inits the parallax dimming view on iOS 26
+        // (Liquid Glass) and crashes: "View was already initialized". Skip scroll-driven updates while
+        // a push/pop (or back-swipe) is animating; viewDidAppear refreshes once it settles.
+        guard navigationController?.transitionCoordinator == nil else { return }
         updateNavigationBarAppearance()
     }
 }

--- a/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
+++ b/kDrive/Utils/CustomLargeTitleCollectionViewController.swift
@@ -32,6 +32,8 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
 
     private var originalTitle: String?
 
+    private var lastAppliedTitleAlpha: CGFloat?
+
     var isCompactView: Bool {
         guard let rootViewController = appRouter.rootViewController else { return false }
         return rootViewController.traitCollection.horizontalSizeClass.iskDriveCompactSize
@@ -43,6 +45,17 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
         navigationController?.setInfomaniakAppearanceNavigationBar()
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.hideBackButtonText()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Appearance updates are suppressed while a push/pop transition is in flight (see
+        // updateNavigationBarAppearance) and the navigation bar appearance is shared across the navigation
+        // stack. Force a refresh once the transition has settled so we never leave a stale/outdated bar on
+        // screen. transitionCoordinator is nil here, so applying the appearance is safe.
+        lastAppliedTitleAlpha = nil
+        updateNavigationBarAppearance()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
@@ -72,6 +85,12 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
     }
 
     private func updateNavigationBarAppearance() {
+        // Reassigning the navigation bar appearance while a push/pop transition is animating makes iOS 26's
+        // Liquid Glass navigation bar rebuild its transition context, which re-initializes the parallax
+        // dimming view and crashes with "View was already initialized". Never mutate the bar mid-transition
+        // (this also covers the interactive back-swipe, which drives scrollViewDidScroll while transitioning).
+        guard navigationController?.transitionCoordinator == nil else { return }
+
         if let title = navigationItem.title {
             originalTitle = title
         }
@@ -82,16 +101,22 @@ class CustomLargeTitleCollectionViewController: UICollectionViewController {
 
         let titleStyle = TextStyle.header3
         let alpha = min(1, max(0, (scrollOffset + headerViewHeight) / navigationBarHeight))
-        let titleColor = titleStyle.color.withAlphaComponent(alpha)
 
-        let newStandardNavigationBarAppearance = navigationBar.standardAppearance
-        let newCompactNavigationBarAppearance = navigationBar.compactAppearance
+        // Avoid redundant appearance reassignments (e.g. while the alpha stays clamped at 0 or 1 during a
+        // scroll), which needlessly churn the navigation bar transition machinery for no visual change.
+        if lastAppliedTitleAlpha != alpha {
+            lastAppliedTitleAlpha = alpha
+            let titleColor = titleStyle.color.withAlphaComponent(alpha)
 
-        newStandardNavigationBarAppearance.titleTextAttributes[.foregroundColor] = titleColor
-        newCompactNavigationBarAppearance?.titleTextAttributes[.foregroundColor] = titleColor
+            let newStandardNavigationBarAppearance = navigationBar.standardAppearance
+            let newCompactNavigationBarAppearance = navigationBar.compactAppearance
 
-        navigationBar.standardAppearance = newStandardNavigationBarAppearance
-        navigationBar.compactAppearance = newCompactNavigationBarAppearance
+            newStandardNavigationBarAppearance.titleTextAttributes[.foregroundColor] = titleColor
+            newCompactNavigationBarAppearance?.titleTextAttributes[.foregroundColor] = titleColor
+
+            navigationBar.standardAppearance = newStandardNavigationBarAppearance
+            navigationBar.compactAppearance = newCompactNavigationBarAppearance
+        }
 
         guard let originalTitle else { return }
         navigationItem.title = alpha < 0.2 ? nil : originalTitle


### PR DESCRIPTION

`_UIParallaxDimmingView` is the private view UIKit inserts during a `UINavigationController`
push/pop (the "parallax" transition, also driven by the interactive back-swipe). The exception
means UIKit ran that view's initializer twice on the same instance.

## Root cause

`CustomLargeTitleCollectionViewController` (base class of `HomeViewController` and
`SidebarViewController`) fades the large title in/out by **reassigning the navigation bar's
`standardAppearance` / `compactAppearance` on every scroll event** (`scrollViewDidScroll` →
`updateNavigationBarAppearance()`).

During a push/pop, the collection view's content offset settles, so these scroll callbacks fire
**while the transition is still animating**. Before iOS 26 the navigation bar was static during a
transition, so this was tolerated. With Liquid Glass, UIKit reworked the navigation bar /
transition pipeline: swapping the appearance object mid-transition forces the bar to rebuild its
transition context, which re-initializes the already-created `_UIParallaxDimmingView` and traps.

The interactive back-swipe hits the same path because it scrolls both controllers while
transitioning.

## Fix

In `CustomLargeTitleCollectionViewController`:

- **Skip appearance updates while a transition is in flight** — bail out of
  `updateNavigationBarAppearance()` when `navigationController?.transitionCoordinator != nil`.
  This is the crash fix and also covers the back-swipe.
- **Refresh once the transition settles** — reset the cache and reapply in `viewDidAppear`
  (`transitionCoordinator` is `nil` there), so suppressing updates during the transition never
  leaves a stale/outdated bar.
- **Skip redundant reassignments** — only rewrite the appearance when the computed title alpha
  actually changes, avoiding needless churn of the navigation bar on every scroll tick.

## Scope / notes

- Affects only iOS 26's Liquid Glass navigation transition path; behavior on earlier iOS is
  unchanged (the guard is a no-op when no transition is active).
- The title-fade UX is unchanged on a settled screen.

## Testing

On iPad / iOS 26:
- Scroll **Home** and the **Files** sidebar to a mid-fade title position.
- Push into a folder and pop back, including via the **back-swipe** gesture.
- Verify: no crash, and the title color is correct immediately on return.