### PR TITLE
fix: Two clicks to open first folder extension

### DIFF
--- a/kDrive/UI/Controller/Files/SidebarViewController.swift
+++ b/kDrive/UI/Controller/Files/SidebarViewController.swift
@@ -414,7 +414,9 @@ class SidebarViewController: CustomLargeTitleCollectionViewController, SelectSwi
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        applySnapshot()
+        if !selectMode {
+            applySnapshot()
+        }
         if let lastSelectedDestination {
             guard let rootMenuDestination = lastSelectedDestination.rootMenuDestination else { return }
             let snapshot = dataSource.snapshot()


### PR DESCRIPTION
https://github.com/Infomaniak/ios-kDrive/issues/1962