### PR TITLE
chore: Bump import_loco to 2.3.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,7 +4,7 @@ swiftformat = { version = "0.58.6", os = ["macos", "linux"] }
 swiftlint = { version = "0.62.2", os = ["macos", "linux"] }
 sentry-cli = { version = "latest", os = ["macos"] }
 pipx = { version = "1.8.0", os = ["macos", "linux"] }
-"pipx:infomaniak/importloco" = { version = '2.1.0', os = ["macos", "linux"] }
+"pipx:infomaniak/importloco" = { version = '2.3.0', os = ["macos", "linux"] }
 "spm:FelixHerrmann/swift-package-list" = { version = "latest", os = ["macos"] }
 
 [settings]


### PR DESCRIPTION
Bump import_loco to 2.3.0