### PR TITLE
fix: New NSInternalInconsistencyException in 6.0.0 beta

### DIFF
--- a/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
@@ -819,7 +819,7 @@ extension FileListViewController {
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let item = sections[safe: indexPath.section]?.elements[safe: indexPath.item] else {
-            return UICollectionViewCell()
+            return collectionView.dequeueReusableCell(type: FileCollectionViewCell.self, for: indexPath)
         }
 
         switch item {
@@ -834,7 +834,7 @@ extension FileListViewController {
             cell.configure(driveFileManager: driveFileManager, presenter: self)
             return cell
             #else
-            return UICollectionViewCell()
+            return collectionView.dequeueReusableCell(type: FileCollectionViewCell.self, for: indexPath)
             #endif
         case .file(let file):
             let cellType: UICollectionViewCell.Type

--- a/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
+++ b/kDrive/UI/Controller/Files/File List/FileListViewController/FileListViewController.swift
@@ -837,7 +837,7 @@ extension FileListViewController {
             return collectionView.dequeueReusableCell(type: FileCollectionViewCell.self, for: indexPath)
             #endif
         case .file(let file):
-            let cellType: UICollectionViewCell.Type
+            let cellType: FileCollectionViewCell.Type
 
             switch viewModel.listStyle {
             case .list:
@@ -846,7 +846,7 @@ extension FileListViewController {
                 cellType = FileGridCollectionViewCell.self
             }
 
-            let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath) as! FileCollectionViewCell
+            let cell = collectionView.dequeueReusableCell(type: cellType, for: indexPath)
 
             cell.initStyle(inFolderSelectMode: false)
             cell.configureWith(

--- a/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
+++ b/kDrive/UI/Controller/Files/Save File/SelectFolderViewController.swift
@@ -222,15 +222,17 @@ final class SelectFolderViewController: FileListViewController {
     // MARK: - Collection view data source
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let file = getDisplayedFile(at: indexPath) else {
-            return UICollectionViewCell()
-        }
-        let cell = super.collectionView(collectionView, cellForItemAt: indexPath) as! FileCollectionViewCell
+        let cell = super.collectionView(collectionView, cellForItemAt: indexPath)
 
-        cell.setEnabled(file.isDirectory && file.id != fileToMove?.id &&
+        guard let fileCell = cell as? FileCollectionViewCell,
+              let file = getDisplayedFile(at: indexPath) else {
+            return cell
+        }
+
+        fileCell.setEnabled(file.isDirectory && file.id != fileToMove?.id &&
             (!disabledDirectoriesSelection.contains(file.id) || file.id == originDirectory?.id))
-        cell.moreButton.isHidden = true
-        return cell
+        fileCell.moreButton.isHidden = true
+        return fileCell
     }
 
     // MARK: - Collection view delegate

--- a/kDrive/UI/View/Files/FileCollectionViewCell.swift
+++ b/kDrive/UI/View/Files/FileCollectionViewCell.swift
@@ -448,10 +448,10 @@ extension FileCollectionViewCell: UICollectionViewDelegate, UICollectionViewData
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let viewModel else {
-            return UICollectionViewCell()
-        }
         let cell = collectionView.dequeueReusableCell(type: CategoryBadgeCollectionViewCell.self, for: indexPath)
+        guard let viewModel else {
+            return cell
+        }
         let category = viewModel.categories[indexPath.row]
         let more = indexPath.item == 2 && viewModel.categories.count > 3 ? viewModel.categories.count - 3 : nil
         cell.configure(with: category, more: more)


### PR DESCRIPTION
## Context

We were seeing crashes with:

> `NSInternalInconsistencyException` — The collection view's data source returned a cell without a reuseIdentifier.

The crash originated in `SelectFolderViewController`, but the root cause was shared across several file-list collection views.

## Root cause

Several `cellForItemAt` implementations returned a bare `UICollectionViewCell()` in their guard/fallback branches. A directly-allocated cell has no `reuseIdentifier`, which UIKit strictly forbids.

`DifferenceKit` keeps the collection view's item counts in sync with our `sections` model in the normal flow, so these branches were assumed unreachable. But for **off-window** collection views (and on the `interrupt` path), `DifferenceKit` bypasses animated batch updates and calls `reloadData()`. `SelectFolderViewController` pushes a whole stack of controllers at once, so several are off-window. During that `reloadData()`, while the layout is still flushing, the data-source lookup can transiently return `nil` for an index path UIKit is querying → the fallback fabricated an unregistered cell → crash.

## Fix

Never return a non-dequeued cell. Every fallback now returns a dequeued, registered cell instead of `UICollectionViewCell()`:

- **`SelectFolderViewController`** — defers to the base class dequeue and only applies its select-mode customization when the item is an actual file cell (also removes a fragile `as!` force cast).
- **`FileListViewController`** — dequeues a `FileCollectionViewCell` in both fallback branches.
- **`FileCollectionViewCell`** (inner category badges) — dequeues its badge cell before the view-model guard.

The transient inconsistency is now harmless and self-corrects on the next reload instead of crashing.

## Scope / notes

- Audited the whole app: no remaining non-dequeued **cell** returns.
- Supplementary-view fallbacks (`UICollectionReusableView()`) are intentionally left as-is — they are only reached for unregistered kinds where dequeuing is not possible, and no current layout requests them.

## Testing

- Navigate the "Select folder" / move flow through nested folders (including deep-linking into a pre-built navigation stack).
- Verify no crash and cells render correctly on refresh.