### PR TITLE
feat: Add App Entity

### DIFF
--- a/kDrive/App Intents/KDriveExtensionAppIntentsPackage.swift
+++ b/kDrive/App Intents/KDriveExtensionAppIntentsPackage.swift
@@ -1,0 +1,27 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppIntents
+import kDriveCore
+
+@available(iOS 17.0, *)
+struct KDriveAppIntentsPackage: AppIntentsPackage {
+    static var includedPackages: [any AppIntentsPackage.Type] {
+        [KDriveCoreIntentsPackage.self]
+    }
+}

--- a/kDrive/Resources/da.lproj/Localizable.strings
+++ b/kDrive/Resources/da.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Udløbstid";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Element";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Seneste ændringer";
 

--- a/kDrive/Resources/de.lproj/Localizable.strings
+++ b/kDrive/Resources/de.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Verfallszeit";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Element";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Letzte Änderungen";
 

--- a/kDrive/Resources/el.lproj/Localizable.strings
+++ b/kDrive/Resources/el.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Ώρα λήξης";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Θέμα";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Πιο πρόσφατες αλλαγές";
 

--- a/kDrive/Resources/en.lproj/Localizable.strings
+++ b/kDrive/Resources/en.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Expiration time";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Item";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Most recent changes";
 

--- a/kDrive/Resources/es.lproj/Localizable.strings
+++ b/kDrive/Resources/es.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Tiempo de expiración";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Elemento";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Últimas modificaciones";
 

--- a/kDrive/Resources/fi.lproj/Localizable.strings
+++ b/kDrive/Resources/fi.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Vanhenemisaika";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Kohde";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Viimeisimmät muutokset";
 

--- a/kDrive/Resources/fr.lproj/Localizable.strings
+++ b/kDrive/Resources/fr.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Heure d’expiration";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Élément";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Dernières modifications";
 

--- a/kDrive/Resources/it.lproj/Localizable.strings
+++ b/kDrive/Resources/it.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Tempo di scadenza";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Elemento";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Ultime modifiche";
 

--- a/kDrive/Resources/nb.lproj/Localizable.strings
+++ b/kDrive/Resources/nb.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Utløpstid";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Element";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Siste endringer";
 

--- a/kDrive/Resources/nl.lproj/Localizable.strings
+++ b/kDrive/Resources/nl.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Verlooptijd";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Item";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Meest recente wijzigingen";
 

--- a/kDrive/Resources/pl.lproj/Localizable.strings
+++ b/kDrive/Resources/pl.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Godzina wygaśnięcia";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Element";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Najnowsze zmiany";
 

--- a/kDrive/Resources/pt.lproj/Localizable.strings
+++ b/kDrive/Resources/pt.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Hora de expiração";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Item";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Alterações mais recentes";
 

--- a/kDrive/Resources/sv.lproj/Localizable.strings
+++ b/kDrive/Resources/sv.lproj/Localizable.strings
@@ -1294,6 +1294,9 @@
 /* loco:617b99510ec1ee7d7e2accd2 */
 "inputExpirationTime" = "Utgångstid";
 
+/* loco:6a9a68f38cdf25fae40adb63 */
+"itemLabel" = "Objekt";
+
 /* loco:6049df4d5c2c3a04bc3979fc */
 "lastEditsTitle" = "Senaste ändringar";
 

--- a/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
+++ b/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
@@ -18,4 +18,4 @@
 
 import AppIntents
 
-public struct KDriveCoreIntentsPackage: AppIntentsPackage { }
+public struct KDriveCoreIntentsPackage: AppIntentsPackage {}

--- a/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
+++ b/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
@@ -18,4 +18,5 @@
 
 import AppIntents
 
+@available(iOS 17.0, *)
 public struct KDriveCoreIntentsPackage: AppIntentsPackage {}

--- a/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
+++ b/kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift
@@ -1,0 +1,21 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppIntents
+
+public struct KDriveCoreIntentsPackage: AppIntentsPackage { }

--- a/kDriveCore/App Intents/KDriveFileEntity.swift
+++ b/kDriveCore/App Intents/KDriveFileEntity.swift
@@ -29,6 +29,12 @@ struct KDriveFileEntity: FileEntity {
 
     static let defaultQuery = KDriveEntityQuery()
 
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(
+            name: LocalizedStringResource("itemLabel", table: "Localizable")
+        )
+    }
+
     static let supportedContentTypes: [UTType] = [.item, .folder]
 
     var id: FileEntityIdentifier

--- a/kDriveCore/App Intents/KDriveFileEntity.swift
+++ b/kDriveCore/App Intents/KDriveFileEntity.swift
@@ -1,0 +1,212 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppIntents
+import FileProvider
+import Foundation
+import InfomaniakDI
+import UniformTypeIdentifiers
+
+@available(iOS 18.0, *)
+@AppEntity(schema: .files.file)
+struct KDriveFileEntity: FileEntity {
+    private static let maximumResultCount = 25
+
+    static let defaultQuery = KDriveEntityQuery()
+
+    static let supportedContentTypes: [UTType] = [.item, .folder]
+
+    var id: FileEntityIdentifier
+
+    var creationDate: Date?
+    var fileModificationDate: Date?
+
+    var objectId: String
+    var userId: Int
+    var driveId: Int
+    var fileId: Int
+    var name: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(name)"
+        )
+    }
+
+    init(file: File, userId: Int, fileProviderURL: URL) throws {
+        try self.init(file: file, userId: userId, id: .file(url: fileProviderURL))
+    }
+
+    static func makeEntity(
+        for file: File,
+        driveFileManager: DriveFileManager
+    ) async -> KDriveFileEntity {
+        let userId = driveFileManager.drive.userId
+
+        if let domains = try? await NSFileProviderManager.domains(),
+           let domain = domains.first(where: {
+               $0.identifier.rawValue == driveFileManager.drive.objectId
+           }),
+           let manager = NSFileProviderManager(for: domain),
+           let fileProviderURL = try? await manager.getUserVisibleURL(
+               for: NSFileProviderItemIdentifier(file.id)
+           ),
+           let entity = try? KDriveFileEntity(
+               file: file,
+               userId: userId,
+               fileProviderURL: fileProviderURL
+           ) {
+            return entity
+        }
+
+        return KDriveFileEntity(
+            file: file,
+            userId: userId,
+            id: .draft(
+                identifier: "\(userId):\(file.driveId):\(file.id)"
+            )
+        )
+    }
+
+    private init(file: File, userId: Int, id: FileEntityIdentifier) {
+        self.id = id
+        objectId = file.uid
+        self.userId = userId
+        driveId = file.driveId
+        fileId = file.id
+        name = file.name
+        creationDate = file.createdAt
+        fileModificationDate = file.lastModifiedAt
+    }
+
+    struct KDriveEntityQuery: EntityStringQuery {
+        func entities(
+            for identifiers: [KDriveFileEntity.ID]
+        ) async throws -> [KDriveFileEntity] {
+            @InjectService var accountManager: AccountManageable
+            @InjectService var driveInfosManager: DriveInfosManager
+
+            var entities = [KDriveFileEntity]()
+            entities.reserveCapacity(identifiers.count)
+
+            for identifier in identifiers {
+                if let draftIdentifier = identifier.draftIdentifier {
+                    let components = draftIdentifier.split(separator: ":")
+
+                    if components.count == 3,
+                       let userId = Int(components[0]),
+                       let driveId = Int(components[1]),
+                       let fileId = Int(components[2]),
+                       let driveFileManager = accountManager.getDriveFileManager(
+                           for: driveId,
+                           userId: userId
+                       ),
+                       let file = driveFileManager.getCachedFile(id: fileId),
+                       !file.isTrashed {
+                        entities.append(KDriveFileEntity(file: file, userId: userId, id: identifier))
+                        continue
+                    }
+                }
+
+                guard let fileURL = try? await identifier.fileURL,
+                      let providerIdentifiers = try? await Self.providerIdentifiers(for: fileURL),
+                      let drive = driveInfosManager.getDrive(primaryKey: providerIdentifiers.domain.rawValue),
+                      let driveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: drive.userId),
+                      let fileId = providerIdentifiers.item.toFileId(),
+                      let file = driveFileManager.getCachedFile(id: fileId),
+                      !file.isTrashed else {
+                    continue
+                }
+
+                entities.append(KDriveFileEntity(file: file, userId: drive.userId, id: identifier))
+            }
+
+            return entities
+        }
+
+        func entities(
+            matching string: String
+        ) async throws -> [KDriveFileEntity] {
+            let searchTerm = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !searchTerm.isEmpty else {
+                return []
+            }
+
+            @InjectService var accountManager: AccountManageable
+            @InjectService var driveInfoManager: DriveInfosManager
+
+            var matches = [(file: File, driveFileManager: DriveFileManager)]()
+
+            for userId in accountManager.accountIds {
+                let drives = driveInfoManager.getDrives(for: userId)
+
+                for drive in drives where !drive.inMaintenance {
+                    guard let driveFileManager = accountManager.getDriveFileManager(for: drive.id, userId: userId) else {
+                        continue
+                    }
+
+                    let results = driveFileManager.database.fetchResults(ofType: File.self) { files in
+                        files
+                            .filter("id > 0 AND name CONTAINS[cd] %@", searchTerm)
+                            .sorted(by: \File.sortedName, ascending: true)
+                    }
+
+                    let files = results.lazy
+                        .filter { !$0.isTrashed }
+                        .prefix(KDriveFileEntity.maximumResultCount)
+                        .map { $0.freeze() }
+
+                    matches.append(contentsOf: files.map {
+                        (file: $0, driveFileManager: driveFileManager)
+                    })
+                }
+            }
+
+            let selectedMatches = matches
+                .sorted { return $0.file.sortedName < $1.file.sortedName }
+                .prefix(KDriveFileEntity.maximumResultCount)
+
+            var entities = [KDriveFileEntity]()
+            entities.reserveCapacity(selectedMatches.count)
+
+            for match in selectedMatches {
+                let entity = await makeEntity(for: match.file, driveFileManager: match.driveFileManager)
+
+                entities.append(entity)
+            }
+
+            return entities
+        }
+
+        private static func providerIdentifiers(
+            for url: URL
+        ) async throws -> (item: NSFileProviderItemIdentifier, domain: NSFileProviderDomainIdentifier) {
+            try await withCheckedThrowingContinuation { continuation in
+                NSFileProviderManager.getIdentifierForUserVisibleFile(at: url) { item, domain, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if let item, let domain {
+                        continuation.resume(returning: (item, domain))
+                    } else {
+                        continuation.resume(throwing: CocoaError(.fileNoSuchFile))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kDriveCore/App Intents/KDriveFileEntity.swift
+++ b/kDriveCore/App Intents/KDriveFileEntity.swift
@@ -62,14 +62,28 @@ struct KDriveFileEntity: FileEntity {
         for file: File,
         driveFileManager: DriveFileManager
     ) async -> KDriveFileEntity {
+        let domains = (try? await NSFileProviderManager.domains()) ?? []
+
+        let manager = domains
+            .first { $0.identifier.rawValue == driveFileManager.drive.objectId }
+            .flatMap { NSFileProviderManager(for: $0) }
+
+        return await makeEntity(
+            for: file,
+            driveFileManager: driveFileManager,
+            fileProviderManager: manager
+        )
+    }
+
+    static func makeEntity(
+        for file: File,
+        driveFileManager: DriveFileManager,
+        fileProviderManager: NSFileProviderManager?
+    ) async -> KDriveFileEntity {
         let userId = driveFileManager.drive.userId
 
-        if let domains = try? await NSFileProviderManager.domains(),
-           let domain = domains.first(where: {
-               $0.identifier.rawValue == driveFileManager.drive.objectId
-           }),
-           let manager = NSFileProviderManager(for: domain),
-           let fileProviderURL = try? await manager.getUserVisibleURL(
+        if let fileProviderManager,
+           let fileProviderURL = try? await fileProviderManager.getUserVisibleURL(
                for: NSFileProviderItemIdentifier(file.id)
            ),
            let entity = try? KDriveFileEntity(
@@ -101,9 +115,7 @@ struct KDriveFileEntity: FileEntity {
     }
 
     struct KDriveEntityQuery: EntityStringQuery {
-        func entities(
-            for identifiers: [KDriveFileEntity.ID]
-        ) async throws -> [KDriveFileEntity] {
+        func entities(for identifiers: [KDriveFileEntity.ID]) async throws -> [KDriveFileEntity] {
             @InjectService var accountManager: AccountManageable
             @InjectService var driveInfosManager: DriveInfosManager
 
@@ -145,9 +157,7 @@ struct KDriveFileEntity: FileEntity {
             return entities
         }
 
-        func entities(
-            matching string: String
-        ) async throws -> [KDriveFileEntity] {
+        func entities(matching string: String) async throws -> [KDriveFileEntity] {
             let searchTerm = string.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !searchTerm.isEmpty else {
                 return []
@@ -187,11 +197,30 @@ struct KDriveFileEntity: FileEntity {
                 .sorted { return $0.file.sortedName < $1.file.sortedName }
                 .prefix(KDriveFileEntity.maximumResultCount)
 
+            let domains = (try? await NSFileProviderManager.domains()) ?? []
+
+            var fileProviderManagers = [String: NSFileProviderManager]()
+
+            for domain in domains {
+                guard let manager = NSFileProviderManager(for: domain) else {
+                    continue
+                }
+
+                fileProviderManagers[domain.identifier.rawValue] = manager
+            }
+
             var entities = [KDriveFileEntity]()
             entities.reserveCapacity(selectedMatches.count)
 
             for match in selectedMatches {
-                let entity = await makeEntity(for: match.file, driveFileManager: match.driveFileManager)
+                let driveObjectId = match.driveFileManager.drive.objectId
+                let fileProviderManager = fileProviderManagers[driveObjectId]
+
+                let entity = await makeEntity(
+                    for: match.file,
+                    driveFileManager: match.driveFileManager,
+                    fileProviderManager: fileProviderManager
+                )
 
                 entities.append(entity)
             }

--- a/kDriveCore/App Intents/KDriveFileIntents.swift
+++ b/kDriveCore/App Intents/KDriveFileIntents.swift
@@ -64,6 +64,10 @@ struct OpenFileIntent: OpenIntent {
 @available(iOS 18.0, *)
 @AppIntent(schema: .files.moveFiles)
 struct MoveFilesIntent {
+    static var authenticationPolicy: IntentAuthenticationPolicy {
+        .requiresLocalDeviceAuthentication
+    }
+
     var entities: [KDriveFileEntity]
 
     @Parameter(supportedContentTypes: [.folder])
@@ -109,6 +113,10 @@ struct MoveFilesIntent {
 @available(iOS 18.0, *)
 @AppIntent(schema: .files.renameFile)
 struct RenameFileIntent {
+    static var authenticationPolicy: IntentAuthenticationPolicy {
+        .requiresLocalDeviceAuthentication
+    }
+
     var target: KDriveFileEntity
     var newName: String
 
@@ -127,6 +135,10 @@ struct RenameFileIntent {
 @available(iOS 18.0, *)
 @AppIntent(schema: .files.deleteFiles)
 struct DeleteFilesIntent: DeleteIntent {
+    static var authenticationPolicy: IntentAuthenticationPolicy {
+        .requiresLocalDeviceAuthentication
+    }
+
     var entities: [KDriveFileEntity]
 
     func perform() async throws -> some IntentResult {
@@ -146,6 +158,10 @@ struct DeleteFilesIntent: DeleteIntent {
 @available(iOS 18.0, *)
 @AppIntent(schema: .files.createFolder)
 struct CreateFolderIntent {
+    static var authenticationPolicy: IntentAuthenticationPolicy {
+        .requiresLocalDeviceAuthentication
+    }
+
     var fileName: String?
 
     @Parameter(supportedContentTypes: [.folder])

--- a/kDriveCore/App Intents/KDriveFileIntents.swift
+++ b/kDriveCore/App Intents/KDriveFileIntents.swift
@@ -89,7 +89,8 @@ struct MoveFilesIntent {
                 throw DriveError.forbidden
             }
 
-            guard source.file.parentId != destination.file.id else {
+            guard source.file.driveId != destination.file.driveId ||
+                source.file.parentId != destination.file.id else {
                 continue
             }
 
@@ -173,7 +174,7 @@ struct CreateFolderIntent {
         let createdFolder = try await resolved.driveFileManager.createDirectory(
             in: resolved.file.proxify(),
             name: folderName,
-            onlyForMe: true
+            onlyForMe: false
         )
 
         let createdEntity = await KDriveFileEntity.makeEntity(

--- a/kDriveCore/App Intents/KDriveFileIntents.swift
+++ b/kDriveCore/App Intents/KDriveFileIntents.swift
@@ -1,0 +1,172 @@
+/*
+ Infomaniak kDrive - iOS App
+ Copyright (C) 2025 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppIntents
+import InfomaniakDI
+import kDriveResources
+
+
+@available(iOS 18.0, *)
+@AppIntent(schema: .files.moveFiles)
+struct MoveFilesIntent {
+    var entities: [KDriveFileEntity]
+
+    @Parameter(supportedContentTypes: [.folder])
+    var destinationFolder: KDriveFileEntity
+
+    func perform() async throws -> some IntentResult {
+        let destination = try destinationFolder.resolveCache()
+
+        guard destination.file.isDirectory else {
+            throw DriveError.fileNotFound
+        }
+
+        guard destination.file.capabilities.canMoveInto else {
+            throw DriveError.forbidden
+        }
+
+        let moveCoordinator = MoveCoordinator()
+
+        for entity in entities {
+            let source = try entity.resolveCache()
+
+            guard source.file.capabilities.canMove else {
+                throw DriveError.forbidden
+            }
+
+            guard source.file.parentId != destination.file.id else {
+                continue
+            }
+
+            _ = try await moveCoordinator.move(
+                file: source.file.proxify(),
+                to: destination.file.proxify(),
+                sourceDriveFileManager: source.driveFileManager,
+                destinationDriveFileManager: destination.driveFileManager
+            )
+        }
+
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+@AppIntent(schema: .files.renameFile)
+struct RenameFileIntent {
+    var target: KDriveFileEntity
+    var newName: String
+
+    func perform() async throws -> some IntentResult {
+        let resolved = try target.resolveCache()
+
+        guard resolved.file.capabilities.canRename else {
+            throw DriveError.forbidden
+        }
+
+        _ = try await resolved.driveFileManager.rename(file: resolved.file.proxify(), newName: newName)
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+@AppIntent(schema: .files.deleteFiles)
+struct DeleteFilesIntent: DeleteIntent {
+    var entities: [KDriveFileEntity]
+
+    func perform() async throws -> some IntentResult {
+        for entity in entities {
+            let resolved = try entity.resolveCache()
+
+            guard resolved.file.capabilities.canDelete else {
+                throw DriveError.forbidden
+            }
+
+            _ = try await resolved.driveFileManager.delete(file: resolved.file.proxify())
+        }
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+@AppIntent(schema: .files.createFolder)
+struct CreateFolderIntent {
+    var fileName: String?
+
+    @Parameter(supportedContentTypes: [.folder])
+    var target: KDriveFileEntity
+
+    func perform() async throws -> some ReturnsValue<KDriveFileEntity> {
+        let folderNameDialog = IntentDialog(
+            stringLiteral: KDriveResourcesStrings.Localizable.hintInputDirName
+        )
+        guard let fileName else {
+            throw $fileName.needsValueError(folderNameDialog)
+        }
+
+        let folderName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !folderName.isEmpty else {
+            throw $fileName.needsValueError(folderNameDialog)
+        }
+
+        let resolved = try target.resolveCache()
+
+        guard resolved.file.isDirectory,
+              resolved.file.capabilities.canCreateDirectory else {
+            throw DriveError.forbidden
+        }
+
+        let createdFolder = try await resolved.driveFileManager.createDirectory(
+            in: resolved.file.proxify(),
+            name: folderName,
+            onlyForMe: true
+        )
+
+        let createdEntity = await KDriveFileEntity.makeEntity(
+            for: createdFolder,
+            driveFileManager: resolved.driveFileManager
+        )
+
+        return .result(value: createdEntity)
+    }
+}
+
+@available(iOS 18.0, *)
+struct ResolvedKDriveFile {
+    let file: File
+    let driveFileManager: DriveFileManager
+}
+
+@available(iOS 18.0, *)
+extension KDriveFileEntity {
+    func resolveCache() throws -> ResolvedKDriveFile {
+        @InjectService var accountManager: AccountManageable
+
+        guard let driveFileManager = accountManager.getDriveFileManager(
+            for: driveId,
+            userId: userId
+        ),
+            let file = driveFileManager.getCachedFile(id: fileId) else {
+            throw DriveError.fileNotFound
+        }
+
+        return ResolvedKDriveFile(
+            file: file,
+            driveFileManager: driveFileManager
+        )
+    }
+}

--- a/kDriveCore/App Intents/KDriveFileIntents.swift
+++ b/kDriveCore/App Intents/KDriveFileIntents.swift
@@ -37,6 +37,10 @@ struct OpenFileIntent: OpenIntent {
             throw DriveError.fileNotFound
         }
 
+        let file = try await driveFileManager.file(
+            ProxyFile(driveId: target.driveId, id: target.fileId)
+        )
+
         if accountManager.currentUserId != target.userId {
             guard let account = accountManager.account(for: target.userId) else {
                 throw DriveError.fileNotFound
@@ -49,10 +53,6 @@ struct OpenFileIntent: OpenIntent {
             accountManager.currentDriveId != target.driveId {
             try await driveFileManager.switchDriveAndReloadUI()
         }
-
-        let file = try await driveFileManager.file(
-            ProxyFile(driveId: target.driveId, id: target.fileId)
-        )
 
         appNavigable.showMainViewController(driveFileManager: driveFileManager, selectedIndex: 1)
         appNavigable.present(file: file, driveFileManager: driveFileManager, office: false)

--- a/kDriveCore/App Intents/KDriveFileIntents.swift
+++ b/kDriveCore/App Intents/KDriveFileIntents.swift
@@ -20,6 +20,46 @@ import AppIntents
 import InfomaniakDI
 import kDriveResources
 
+@available(iOS 18.0, *)
+@AppIntent(schema: .files.openFile)
+struct OpenFileIntent: OpenIntent {
+    var target: KDriveFileEntity
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        @InjectService var accountManager: AccountManageable
+        @InjectService var appNavigable: AppNavigable
+
+        guard let driveFileManager = accountManager.getDriveFileManager(
+            for: target.driveId,
+            userId: target.userId
+        ) else {
+            throw DriveError.fileNotFound
+        }
+
+        if accountManager.currentUserId != target.userId {
+            guard let account = accountManager.account(for: target.userId) else {
+                throw DriveError.fileNotFound
+            }
+
+            accountManager.switchAccount(newAccount: account)
+        }
+
+        if accountManager.currentUserId != target.userId ||
+            accountManager.currentDriveId != target.driveId {
+            try await driveFileManager.switchDriveAndReloadUI()
+        }
+
+        let file = try await driveFileManager.file(
+            ProxyFile(driveId: target.driveId, id: target.fileId)
+        )
+
+        appNavigable.showMainViewController(driveFileManager: driveFileManager, selectedIndex: 1)
+        appNavigable.present(file: file, driveFileManager: driveFileManager, office: false)
+
+        return .result()
+    }
+}
 
 @available(iOS 18.0, *)
 @AppIntent(schema: .files.moveFiles)

--- a/kDriveFileProvider/Info.plist
+++ b/kDriveFileProvider/Info.plist
@@ -28,6 +28,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
+		<key>NSExtensionFileProviderSupportsPickingFolders</key>
+		<true/>
 		<key>NSExtensionFileProviderDocumentGroup</key>
 		<string>group.com.infomaniak.drive</string>
 		<key>NSExtensionFileProviderSupportsEnumeration</key>

--- a/kDriveTestShared/MCKRouter.swift
+++ b/kDriveTestShared/MCKRouter.swift
@@ -43,6 +43,10 @@ public final class MCKRouter: AppNavigable {
         logNoop()
     }
 
+    public func openFile(_ target: kDriveCore.FileNavigationTarget) async {
+        logNoop()
+    }
+
     public func askForReview() async {
         logNoop()
     }

--- a/kDriveTestShared/MCKRouter.swift
+++ b/kDriveTestShared/MCKRouter.swift
@@ -43,10 +43,6 @@ public final class MCKRouter: AppNavigable {
         logNoop()
     }
 
-    public func openFile(_ target: kDriveCore.FileNavigationTarget) async {
-        logNoop()
-    }
-
     public func askForReview() async {
         logNoop()
     }


### PR DESCRIPTION
**Wide-Angle Summary**

PR [#2014](https://github.com/Infomaniak/ios-kDrive/pull/2014) makes kDrive files first-class entities in Apple’s App Intents ecosystem on iOS 18.

In practical terms, it creates a bridge between:

- Apple’s system-level understanding of a “file”
- kDrive’s File Provider integration
- kDrive’s locally cached Realm models
- Existing kDrive operations such as opening, moving, renaming, deleting, and creating folders

This should allow system surfaces that understand Apple’s standard Files intents, such as Shortcuts and other App Intents integrations, to find kDrive files and perform operations on them without reimplementing those operations inside the main UI.

The PR is additive: it introduces 566 lines across 18 files and does not replace an existing workflow.

**What It Adds**

The PR exposes five operations:

- **Open a file**
- **Move one or more files**
- **Rename a file**
- **Delete one or more files**
- **Create a folder**

These use Apple’s predefined Files schemas rather than custom, kDrive-specific intent names:

```swift
@AppIntent(schema: .files.openFile)
@AppIntent(schema: .files.moveFiles)
@AppIntent(schema: .files.renameFile)
@AppIntent(schema: .files.deleteFiles)
@AppIntent(schema: .files.createFolder)
```

That is an important architectural choice: kDrive is presenting itself to the OS as a standard file provider, allowing Apple to understand the meaning and parameters of each operation.

**The Central Abstraction**

The foundation is `KDriveFileEntity` in `kDriveCore/App Intents/KDriveFileEntity.swift:25`.

It is an App Intents `FileEntity` representing either a kDrive file or folder. Alongside its system identifier, it carries enough kDrive-specific information to reconnect the entity to the application:

- User ID
- Drive ID
- File ID
- Internal object UID
- File name
- Creation date
- Modification date

Conceptually, it translates between these two worlds:

```text
Apple FileEntity
      |
      | userId + driveId + fileId
      v
kDrive AccountManager
      |
      v
DriveFileManager
      |
      v
Cached Realm File / kDrive API
```

The entity supports both regular files and folders through `.item` and `.folder` content types.

**How Files Are Identified**

The implementation prefers a real File Provider URL when one is available.

`KDriveFileEntity.makeEntity`:

1. Finds the `NSFileProviderDomain` corresponding to the kDrive.
2. Asks File Provider for the file’s user-visible URL.
3. Creates an Apple `FileEntityIdentifier.file(url:)`.

This gives the system a proper file-backed identity connected to the kDrive File Provider domain.

If File Provider cannot produce a URL, it falls back to a draft identifier:

```text
userId:driveId:fileId
```

That fallback means newly created or not-yet-materialized entities can still be passed between intents even when there is no usable File Provider URL yet.

When an identifier later needs to be resolved, the query reverses this process:

- Draft identifiers are parsed directly into user, drive, and file IDs.
- File URLs are translated back into File Provider item and domain identifiers.
- The domain identifies the kDrive.
- The item identifier identifies the cached file.

This resolution logic is in `KDriveFileEntity.KDriveEntityQuery` at `kDriveCore/App Intents/KDriveFileEntity.swift:117`.

**How System Search Works**

Apple can ask kDrive to find entities matching text, for example while configuring a Shortcut.

The query:

1. Trims and rejects an empty search.
2. Iterates over every locally configured account.
3. Searches every non-maintenance drive belonging to that account.
4. Runs a Realm query for case- and diacritic-insensitive filename matches.
5. Excludes trashed files and internal placeholder IDs.
6. Sorts matches by filename.
7. Returns at most 25 results globally.
8. Converts those matches into File Provider-backed entities where possible.

The latest commit specifically optimizes this path by filtering and limiting in Realm before materializing entities, and by loading File Provider domains once per search rather than once per result.

A significant scope detail is that this is a **local cache search**, not a server-wide kDrive search. Files must be represented in the relevant local Realm database to be discoverable through the intent query.

**How Operations Are Performed**

The intent layer contains very little business logic. It resolves an entity back to a `File` and `DriveFileManager`, checks capabilities, and delegates to existing kDrive services.

The common resolution path is:

```swift
entity.resolveCache()
    -> AccountManager
    -> DriveFileManager
    -> cached File
```

This keeps behavior aligned with operations already used by the application.

### Open

`OpenFileIntent` is slightly different from the mutations because it needs to navigate the application UI.

It:

1. Locates the appropriate `DriveFileManager`.
2. Fetches the requested file.
3. Switches account if the file belongs to another user.
4. Switches drive and reloads the UI if necessary.
5. Shows the main file interface.
6. Presents the selected file using the existing `AppNavigable`/`FilePresenter` flow.

The file is fetched before switching accounts, preventing the account transition from invalidating the context needed to load it.

Relevant code: `kDriveCore/App Intents/KDriveFileIntents.swift:23`.

### Move

The move intent:

- Resolves and validates the destination folder.
- Checks `canMoveInto` on the destination.
- Checks `canMove` on each source.
- Ignores files already inside the selected destination.
- Delegates to the existing `MoveCoordinator`.

Relevant code: `kDriveCore/App Intents/KDriveFileIntents.swift:64`.

### Rename

The rename intent:

- Resolves the target.
- Checks its `canRename` capability.
- Calls `DriveFileManager.rename`.

Relevant code: `kDriveCore/App Intents/KDriveFileIntents.swift:113`.

### Delete

The delete intent:

- Resolves each selected entity.
- Checks its `canDelete` capability.
- Calls the existing deletion API and cache update path.

Relevant code: `kDriveCore/App Intents/KDriveFileIntents.swift:135`.

### Create Folder

The create-folder intent:

- Requests a name if Apple did not supply one.
- Trims and rejects empty names.
- Confirms the destination is a directory.
- Checks `canCreateDirectory`.
- Uses `DriveFileManager.createDirectory`.
- Returns the created folder as another `KDriveFileEntity`, allowing it to feed into subsequent intent steps.

Relevant code: `kDriveCore/App Intents/KDriveFileIntents.swift:158`.

**Security Model**

The mutating operations declare:

```swift
.requiresLocalDeviceAuthentication
```

This applies to move, rename, delete, and create-folder operations. They therefore cannot silently execute while the device is locked and require local device authentication.

Opening a file does not use this explicit mutation policy, because it launches and navigates the application rather than silently changing remote data.

The intents also enforce the capabilities stored on each cached `File`, such as:

- `canMove`
- `canMoveInto`
- `canRename`
- `canDelete`
- `canCreateDirectory`

The server APIs remain the final authority if cached permissions are stale.

**Registration and Packaging**

The actual entities and intents live in `kDriveCore`, alongside the business logic they depend on.

`KDriveCoreIntentsPackage` exposes those definitions:

- `kDriveCore/App Intents/KDriveCoreAppIntentsPackage.swift:21`

The main application then includes that package through:

- `kDrive/App Intents/KDriveExtensionAppIntentsPackage.swift:22`

This separation lets the shared framework own the file behavior while the app target acts as the entry point through which iOS discovers it.

Everything substantive is guarded with `@available(iOS 18.0, *)`, so older supported iOS versions should retain their existing behavior.

**File Provider Change**

The File Provider extension now advertises:

```xml
<key>NSExtensionFileProviderSupportsPickingFolders</key>
<true/>
```

This allows kDrive folders to participate in system folder-selection interfaces, which is necessary for operations such as choosing the destination of a move or selecting where a folder should be created.

**Localization**

The PR adds an `itemLabel` translation in all 13 supported localization files. This is used as the entity type’s display name so Apple’s UI can present a localized label for a kDrive item.

**Overall Architectural Effect**

Before this PR, kDrive files were primarily manipulated through the kDrive UI or the File Provider extension.

After this PR, there is an additional system-facing layer:

```text
Shortcuts / App Intents / Files schemas
                  |
          KDriveFileEntity
                  |
       Account and drive resolution
                  |
      Existing DriveFileManager APIs
                  |
        kDrive API + Realm cache
```

The PR is therefore less about adding new file-management capabilities and more about **making existing kDrive capabilities accessible to iOS through Apple’s standardized file automation model**.

**Current Scope and Caveats**

- It is an iOS 18 feature.
- Search is based on locally cached metadata, not an exhaustive server search.
- Search results are limited to 25.
- Trashed files and drives under maintenance are excluded.
- Multi-file move and delete operations are sequential, not transactional. A later failure could leave earlier items already processed.
- No automated tests were added; Sonar reports 0% coverage on the new code, although its quality gate passed.
- The PR remains open and GitHub indicates that review changes have been requested.